### PR TITLE
Fix dialog tab panel scroll

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
@@ -325,28 +325,30 @@ interface TabPanelProps {
   children: React.ReactNode;
 }
 
-const ScrollableTabPanel = styled("div")({
-  flex: "1",
+const TabPanelScrollContainer = styled("div")(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
+  height: "100%",
   overflowX: "hidden",
   overflowY: "auto",
+  padding: theme.spacing(1),
   scrollbarWidth: "none",
   "&::-webkit-scrollbar": {
     display: "none",
   },
-});
+}));
 
 const TabPanel: React.FC<TabPanelProps> = ({ value, index, children }) => {
   return (
-    <ScrollableTabPanel
+    <div
       role="tabpanel"
       hidden={value !== index}
       id={`livestream tabpanel-${index}`}
       aria-labelledby={`livestream-tab-${index}`}
+      style={{ flex: "1", overflow: "hidden" }}
     >
-      {value === index && <Box p={1} sx={{ flex: 1 }}>{children}</Box>}
-    </ScrollableTabPanel>
+      {value === index && <TabPanelScrollContainer>{children}</TabPanelScrollContainer>}
+    </div>
   );
 };
 


### PR DESCRIPTION
Fixes #129.
This is a follow-up to #148 which was found to be faulty (see #160).

#160 was caused by testing only on `dev` and not with `build && start`; this fix was checked to work when built as well.

https://github.com/sugar-cat7/vspo-portal/assets/155891765/7c3b50a7-5539-471a-8b6e-a59ff2d5b7a4

