### PR TITLE
feat(web): use dark mode YouTube and Twitch chat embeds on dark mode

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
@@ -151,12 +151,12 @@ const VideoPlayerOrLink = React.memo(VideoPlayerOrLinkComponent);
 
 const getTwitchChatEmbedUrl = (livestream: Livestream, isDarkMode: boolean) => {
   const chatEmbedUrl = `https://www.twitch.tv/embed/${livestream.twitchName!}/chat?parent=${window.location.hostname}`;
-  return isDarkMode ? chatEmbedUrl + "&darkpopout" : chatEmbedUrl;
+  return isDarkMode ? `${chatEmbedUrl}&darkpopout` : chatEmbedUrl;
 };
 
 const getYouTubeChatEmbedUrl = (livestream: Livestream, isDarkMode: boolean) => {
   const chatEmbedUrl = `https://www.youtube.com/live_chat?v=${livestream.id}&embed_domain=${window.location.hostname}`;
-  return isDarkMode ? chatEmbedUrl + "&dark_theme=1" : chatEmbedUrl;
+  return isDarkMode ? `${chatEmbedUrl}&dark_theme=1` : chatEmbedUrl;
 };
 
 const ChatEmbed: React.FC<{


### PR DESCRIPTION
Implements #163.

When the site is in dark mode, the LivestreamDetailsModal now uses the dark mode variant of YouTube and Twitch's chat embed.

https://github.com/sugar-cat7/vspo-portal/assets/155891765/0266f7f8-4246-44fa-b6fb-384ed5022621