### PR TITLE
fix(web): hide side nav scrollbar

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
@@ -336,10 +336,7 @@ const TabPanelScrollContainer = styled("div")(({ theme }) => ({
   overflowX: "hidden",
   overflowY: "auto",
   padding: theme.spacing(1),
-  scrollbarWidth: "none",
-  "&::-webkit-scrollbar": {
-    display: "none",
-  },
+  ...theme.mixins.scrollbar,
 }));
 
 const TabPanel: React.FC<TabPanelProps> = ({ value, index, children }) => {

--- a/service/vspo-schedule/web/src/context/Theme.tsx
+++ b/service/vspo-schedule/web/src/context/Theme.tsx
@@ -12,14 +12,23 @@ type ThemeProviderProps = {
 };
 
 const theme = extendTheme({
+  mixins: {
+    scrollbar: {
+      scrollbarWidth: "none",
+      "&::-webkit-scrollbar": {
+        display: "none",
+      },
+    },
+  },
   components: {
     MuiCssBaseline: {
+      styleOverrides: ({ mixins }) => ({
+        body: mixins.scrollbar,
+      }),
+    },
+    MuiDrawer: {
       styleOverrides: {
-        body: {
-          "&::-webkit-scrollbar": {
-            display: "none",
-          },
-        },
+        paper: ({ theme }) => theme.mixins.scrollbar,
       },
     },
   },

--- a/service/vspo-schedule/web/src/styles/globals.css
+++ b/service/vspo-schedule/web/src/styles/globals.css
@@ -11,10 +11,6 @@ body {
   height: 100%;
 }
 
-body {
-  /* overflow-y: scroll !important; */
-}
-
 a {
   color: inherit;
   text-decoration: none;

--- a/service/vspo-schedule/web/src/types/mui-styles.d.ts
+++ b/service/vspo-schedule/web/src/types/mui-styles.d.ts
@@ -1,0 +1,7 @@
+import { CSSProperties } from "@mui/material/styles/createMixins";
+
+declare module "@mui/material/styles" {
+  interface Mixins {
+    scrollbar: CSSProperties;
+  }
+}


### PR DESCRIPTION
Fixes #175.

The scrollbar should now never be visible in the side nev, keeping consistent with the design of all the other scrollable elements on the site.
Also, the site-wide scrollbar styling now lives in a single mixin which components can access via the `theme` object.

https://github.com/sugar-cat7/vspo-portal/assets/155891765/d0d12e98-deb1-4b71-8d39-719b2a9f3b3d