### PR TITLE
Hide chat on Twitch VOD

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Card/LivestreamCard.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Card/LivestreamCard.tsx
@@ -12,7 +12,7 @@ import { Box } from "@mui/system";
 import { Livestream } from "@/types/streaming";
 import {
   getLivestreamUrl,
-  isStatusLive,
+  getLiveStatus,
   formatWithTimeZone,
 } from "@/lib/utils";
 import { PlatformIcon } from "../Icon";
@@ -167,7 +167,7 @@ export const LivestreamCard: React.FC<LivestreamCardProps> = ({
     twitchPastVideoId: twitchPastVideoId,
   });
   const livestreamStatus = useMemo(
-    () => isStatusLive(livestream),
+    () => getLiveStatus(livestream),
     [livestream]
   );
   return (

--- a/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
@@ -18,7 +18,7 @@ import { Clip, Livestream, Platform } from "@/types/streaming";
 import {
   formatWithTimeZone,
   getLivestreamUrl,
-  isStatusLive,
+  getLiveStatus,
 } from "@/lib/utils";
 import { Loading, PlatformIcon } from "..";
 import CloseIcon from "@mui/icons-material/Close";
@@ -391,7 +391,7 @@ const InfoTabs: React.FC<{
   );
   const showChatTab = isLivestream(videoInfo) &&
     isOnPlatformWithChat(videoInfo) &&
-    isStatusLive(videoInfo) === "live";
+    getLiveStatus(videoInfo) === "live";
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", overflow: "hidden" }}>
@@ -425,10 +425,10 @@ const InfoTabs: React.FC<{
             </TypographySmallOnMobile>
             {isLivestream(videoInfo) && (
               <>
-                {isStatusLive(videoInfo) === "live" && (
+                {getLiveStatus(videoInfo) === "live" && (
                   <LiveLabel>Live</LiveLabel>
                 )}
-                {isStatusLive(videoInfo) === "upcoming" && (
+                {getLiveStatus(videoInfo) === "upcoming" && (
                   <LiveLabel isUpcoming>配信予定</LiveLabel>
                 )}
               </>

--- a/service/vspo-schedule/web/src/lib/api.ts
+++ b/service/vspo-schedule/web/src/lib/api.ts
@@ -6,7 +6,7 @@ import { mockClips, mockTwitchClips } from "@/data/clips";
 import { mockLiveStreams } from "@/data/livestreams";
 import {
   convertThumbnailQualityInObjects,
-  isStatusLive,
+  getLiveStatus,
   shuffleClips,
 } from "./utils";
 import { API_ROOT, BASE_URL, ENVIRONMENT } from "./Const";
@@ -147,7 +147,7 @@ export const fetchVspoRelatedVideo = async (
 ): Promise<RelatedProps> => {
   const pastLivestreams = await fetchVspoLivestreams({ limit: 50 });
   const liveStreams = pastLivestreams.filter(
-    (livestream) => isStatusLive(livestream) === "live"
+    (livestream) => getLiveStatus(livestream) === "live"
   );
 
   const pastClips = await fetchVspoClips();

--- a/service/vspo-schedule/web/src/pages/schedule/[status].tsx
+++ b/service/vspo-schedule/web/src/pages/schedule/[status].tsx
@@ -7,7 +7,7 @@ import {
   formatWithTimeZone,
   getOneWeekRange,
   groupBy,
-  isStatusLive,
+  getLiveStatus,
   isValidDate,
   removeDuplicateTitles,
 } from "@/lib/utils";
@@ -162,7 +162,7 @@ export const getStaticProps: GetStaticProps<LivestreamsProps> = async ({
         scheduledStartTime >= oneWeekAgo &&
         scheduledStartTime <= oneWeekLater &&
         !freeChatVideoIds.includes(livestream.id) &&
-        params?.status === isStatusLive(livestream)
+        params?.status === getLiveStatus(livestream)
       );
     }
   });

--- a/service/vspo-schedule/web/src/types/streaming.ts
+++ b/service/vspo-schedule/web/src/types/streaming.ts
@@ -42,6 +42,12 @@ export type SearchListResponse = {
   items: SearchResult[];
 };
 
+export enum LiveStatus {
+  Archive = "archive",
+  Live = "live",
+  Upcoming = "upcoming",
+}
+
 export enum Platform {
   YouTube = "youtube",
   Twitch = "twitch",


### PR DESCRIPTION
Fixes #133.

In the LivestreamDetailsModal, the chat tab is now unavailable on non-live Twitch streams. (The chat panel behavior should now be identical between Twitch and YouTube streams.)

https://github.com/sugar-cat7/vspo-portal/assets/155891765/c388130d-7e56-41e7-830c-806a68d57909

I have also renamed the `isStatusLive` util to `getLiveStatus` since the `is-` prefix suggested a boolean return type, when in fact this function returns one of several strings (namely, the live status of the livestream).