### PR TITLE
fix(web): move padding from theme toggle button's parent element to i…

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Button/ThemeToggleButton.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Button/ThemeToggleButton.tsx
@@ -76,9 +76,9 @@ export const ThemeToggleButton: React.FC = () => {
   return (
     <FormGroup>
       <FormControlLabel
-        style={{
+        sx={{
           marginRight: 0,
-          padding: '6px 24px',
+          padding: "6px 24px",
         }}
         control={
           <MaterialUISwitch

--- a/service/vspo-schedule/web/src/components/Elements/Button/ThemeToggleButton.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Button/ThemeToggleButton.tsx
@@ -76,6 +76,10 @@ export const ThemeToggleButton: React.FC = () => {
   return (
     <FormGroup>
       <FormControlLabel
+        style={{
+          marginRight: 0,
+          padding: '6px 24px',
+        }}
         control={
           <MaterialUISwitch
             checked={mode === "dark"}

--- a/service/vspo-schedule/web/src/components/Layout/Header.tsx
+++ b/service/vspo-schedule/web/src/components/Layout/Header.tsx
@@ -220,6 +220,7 @@ export const Header: React.FC<Props> = ({ title }) => {
               display: "flex",
               justifyContent: "flex-start",
               alignItems: "center",
+              padding: 0,
             }}
           >
             <ThemeToggleButton />

--- a/service/vspo-schedule/web/src/components/Layout/Header.tsx
+++ b/service/vspo-schedule/web/src/components/Layout/Header.tsx
@@ -216,7 +216,7 @@ export const Header: React.FC<Props> = ({ title }) => {
         >
           <MenuItem
             // onClick={handleSettingsClose}
-            style={{
+            sx={{
               display: "flex",
               justifyContent: "flex-start",
               alignItems: "center",


### PR DESCRIPTION
Fixes #164 

**What this PR solves / how to test:**
* The confusing area is caused by the **padding** from `<MenuItem>` and `<FormControlLabel>` default **margin-right**
* Move the padding to `<FormControlLabel>` to remain the original UI and remove the confusing area
* How to test: Click the edge area of the theme toggle button and check whether the toggle event trigger

https://github.com/sugar-cat7/vspo-portal/assets/28031139/e3511201-0bf1-4a0b-8e9e-16b458f69395

