### PR TITLE
fix(web): let events month selector use color from CSS vars

### DIFF
--- a/service/vspo-schedule/web/src/pages/events/[yearMonth].tsx
+++ b/service/vspo-schedule/web/src/pages/events/[yearMonth].tsx
@@ -81,7 +81,7 @@ const YearMonthSelector: React.FC<{
       flexDirection: "row",
       alignItems: "center",
       justifyContent: "center",
-      color: theme.palette.text.primary,
+      color: theme.vars.palette.text.primary,
     })}
   >
     <AdjacentYearMonthButton


### PR DESCRIPTION
Fixes #185.

**What this PR solves / how to test:**
The events month selector's `color` styling now uses CSS vars from `theme.vars.palette`. This ensures the color reflects the current theme rather than the color set in SSR (which is light mode by default).

Setting the site to use dark mode and then navigating to `/events/2024-02` via the browser address bar should now display the month selector with white text.

https://github.com/sugar-cat7/vspo-portal/assets/155891765/602b5821-75c2-428f-a2a6-19c062b46041