### PR TITLE
fix(web): move trending clip border from card container to card

### DIFF
--- a/service/vspo-schedule/web/src/components/Templates/ClipList .tsx
+++ b/service/vspo-schedule/web/src/components/Templates/ClipList .tsx
@@ -94,14 +94,7 @@ export const ClipList: React.FC<Props> = ({ clips }) => {
           const clipLabel = getClipLabel(clip);
           return (
             <Grid item xs={12} sm={6} md={4} key={clip.id}>
-              <Box
-                height="100%"
-                display="flex"
-                sx={{
-                  position: "relative",
-                  ...(clipLabel ? { border: "3px solid red" } : {}),
-                }}
-              >
+              <Box sx={{ position: "relative" }}>
                 {clipLabel && (
                   <Chip
                     label={clipLabel.label}
@@ -129,6 +122,7 @@ export const ClipList: React.FC<Props> = ({ clips }) => {
                     flexDirection: "column",
                     width: "100%",
                     position: "relative",
+                    ...(clipLabel ? { border: "3px solid red" } : {}),
                   }}
                 >
                   <CardActionArea onClick={() => openModal(clip)}>


### PR DESCRIPTION
Fixes #196.

**What this PR solves / how to test:**
Trending clips should no longer have a gap at the corners between the card and the red border.

Before:
<img width="372" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/7ee86202-65e1-45e9-b6e6-5136363d58d5">

After:
<img width="450" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/32a4f8cb-61c5-45bc-ab08-164837e93cde">
