### PR TITLE
Feature: Apply full-height iframe in LivestreamDetailsModal

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
@@ -81,10 +81,13 @@ const TypographySmallOnMobileDescription = styled(Typography)(({ theme }) => ({
   },
 }));
 
-const ResponsiveIframeWrapper = styled("div")({
+const ResponsiveIframeWrapper = styled("div")(({ theme }) => ({
   overflow: "hidden",
-  aspectRatio: "16/9",
-});
+
+  [theme.breakpoints.down("md")]: {
+    aspectRatio: "16/9",
+  },
+}));
 
 const ResponsiveChatIframeWrapper = styled("div")({
   overflow: "hidden",


### PR DESCRIPTION
**Related Issue:**
* #198 

**What this PR solves / how to test:**
* Remove `aspect-ratio` css property from `<ResponsiveIframeWrapper />` but keep it in `md` size width devices
* The reason is in some devices if we don't give `min-height` the video will be very short
* EX: iPad Air after removing `aspect-ratio`

<img width="457" alt="Screenshot 2024-02-21 at 14 10 05" src="https://github.com/sugar-cat7/vspo-portal/assets/28031139/9eb278c6-2e04-4bdb-b99e-e864dbde887b">

* If keep `aspect-ratio`:
<img width="460" alt="Screenshot 2024-02-21 at 14 27 16" src="https://github.com/sugar-cat7/vspo-portal/assets/28031139/1ab7ea44-71aa-4cc6-b0d9-1e8d3d741853">

* Therefore I decided to keep `aspect-ratio` in `md` size devices to match the **Grid** UI

BTW I could only test **Youtube** video since videos like **Twitch** and ** TwitCasting** are not available in local environment