### PR TITLE
fix(web): remove non-canonical schedule pages from sitemap

### DIFF
--- a/service/vspo-schedule/web/next-sitemap.config.js
+++ b/service/vspo-schedule/web/next-sitemap.config.js
@@ -1,9 +1,21 @@
 // next-sitemap.js
+/** @type import("next-sitemap").IConfig */
 module.exports = {
   siteUrl: "https://www.vspo-schedule.com",
   generateRobotsTxt: true,
   exclude: ["/api/*"],
   robotsTxtOptions: {
     additionalSitemaps: ["https://www.vspo-schedule.com/sitemap.xml"],
+  },
+  transform: (config, path) => {
+    if (path.startsWith("/schedule") && path !== "/schedule/all") {
+      return null;
+    }
+    return {
+      loc: path,
+      lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+      changefreq: config.changefreq,
+      priority: config.priority,
+    };
   },
 };


### PR DESCRIPTION
Follow-up to #221.

**What this PR solves / how to test:**
This PR configures `next-sitemap` to exclude from the sitemap all pages under `/schedule` except for `/schedule/all`, since that is the canonical page for all those pages.

Everything in the generated sitemap should look identical other than the removal of the aforementioned pages.
<img width="1293" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/0fe3aa9d-e5bd-4091-a3cd-5bf04764a2f4">

Note that this solution requires manual syncing between the pages and the config file, but for now I cannot think of a simpler solution than this.