### PR TITLE
feat(web): detect URLs in video description which are not at start of line

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
@@ -75,6 +75,8 @@ const TypographySmallOnMobile = styled(Typography)(({ theme }) => ({
 }));
 
 const TypographySmallOnMobileDescription = styled(Typography)(({ theme }) => ({
+  whiteSpace: "pre-wrap",
+
   // メディアクエリ: 幅600px以下の場合
   [theme.breakpoints.down("sm")]: {
     fontSize: "0.8rem",
@@ -397,6 +399,7 @@ const InfoTabs: React.FC<{
     isLivestream(videoInfo) &&
     isOnPlatformWithChat(videoInfo) &&
     getLiveStatus(videoInfo) === "live";
+  const urlRegex = /(https?:\/\/\S+)/;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", overflow: "hidden" }}>
@@ -496,28 +499,20 @@ const InfoTabs: React.FC<{
           </Box>
         </Box>
         <TypographySmallOnMobileDescription variant="body1">
-          {videoInfo.description.split("\n").map((text, index) => {
-            const isUrl =
-              text.startsWith("http://") || text.startsWith("https://");
-            if (isUrl) {
-              return (
-                <Link
-                  href={text}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  key={index}
-                >
-                  {text}
-                </Link>
-              );
-            } else {
-              return (
-                <React.Fragment key={index}>
-                  {text}
-                  <br />
-                </React.Fragment>
-              );
+          {videoInfo.description.split(urlRegex).map((text, index) => {
+            if (index % 2 === 0) {
+              return <React.Fragment key={index}>{text}</React.Fragment>;
             }
+            return (
+              <Link
+                href={text}
+                target="_blank"
+                rel="noopener noreferrer"
+                key={index}
+              >
+                {text}
+              </Link>
+            );
           })}
         </TypographySmallOnMobileDescription>
       </TabPanel>


### PR DESCRIPTION
Closes #218.

**What this PR solves / how to test:**
This PR improves URL detection in the LivestreamDetailModal's video description by catching any whitespace-bounded 'word' (substring which does not contain spaces) which starts with `http(s)://`; previously only *lines* which started with `http(s)://` were caught as URLs.
(Also, we used to remove line breaks that came after the URL — this has been fixed to more closely resemble the description seen on YouTube.)

To test, we should check that any word starting with `http(s)://` properly appears as a clickable link.

Current:
<img width="501" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/8c5016c8-ee03-43a9-9af5-08e060802fb9">

New:
<img width="534" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/c8ea2a91-3ebf-473b-b8e5-124ac87f2666">

YouTube description:
<img width="674" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/668a99cf-72b2-4041-a773-caf9a8b3478c">
