### PR TITLE
fix(web): make IconButtons with label display rectangle after click

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
@@ -302,7 +302,13 @@ export const LivestreamDetailsModal: React.FC<LivestreamDetailsModalProps> = ({
           alignItems: "center",
         }}
       >
-        <IconButton onClick={onClose} color="inherit">
+        <IconButton
+          sx={{
+            borderRadius: 0,
+          }}
+          onClick={onClose}
+          color="inherit"
+        >
           <ArrowBackIcon />
           <Typography>戻る</Typography>
         </IconButton>

--- a/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Modal/LivestreamDetailsModal.tsx
@@ -302,16 +302,14 @@ export const LivestreamDetailsModal: React.FC<LivestreamDetailsModalProps> = ({
           alignItems: "center",
         }}
       >
-        <IconButton
-          sx={{
-            borderRadius: 0,
-          }}
+        <Button
+          startIcon={<ArrowBackIcon />}
+          sx={{ height: "100%", borderRadius: 0 }}
           onClick={onClose}
           color="inherit"
         >
-          <ArrowBackIcon />
-          <Typography>戻る</Typography>
-        </IconButton>
+          戻る
+        </Button>
         <Typography
           variant="body1"
           sx={{

--- a/service/vspo-schedule/web/src/components/Layout/Header.tsx
+++ b/service/vspo-schedule/web/src/components/Layout/Header.tsx
@@ -205,10 +205,11 @@ export const Header: React.FC<Props> = ({ title }) => {
             "&:hover": {
               backgroundColor: "transparent", // ホバーエフェクトを無効にする
             },
+            borderRadius: 0,
           }}
         >
           <SettingsIcon />
-          <Typography variant="body1" style={{ marginLeft: "10px" }}>
+          <Typography variant="body1" sx={{ marginLeft: "10px" }}>
             設定
           </Typography>
         </IconButton>

--- a/service/vspo-schedule/web/src/components/Layout/Header.tsx
+++ b/service/vspo-schedule/web/src/components/Layout/Header.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import {
   Alert,
   AppBar,
+  Button,
   IconButton,
   Menu,
   MenuItem,
@@ -47,6 +48,23 @@ const StyledSubtitle = styled(Typography)({
 const StyledAlert = styled(Alert)({
   backgroundColor: "#e5f6fd",
   color: "#014361",
+});
+
+const StyledButton = styled(Button)({
+  display: "flex",
+  justifyContent: "flex-start",
+  paddingLeft: "16px",
+  "&:hover": {
+    backgroundColor: "transparent", // ホバーエフェクトを無効にする
+  },
+  borderRadius: 0,
+  fontSize: "1rem",
+  "& .MuiButton-startIcon": {
+    marginLeft: 0,
+    "& .MuiSvgIcon-root": {
+      fontSize: "24px",
+    },
+  },
 });
 
 const SocialIconLink: React.FC<{
@@ -192,27 +210,16 @@ export const Header: React.FC<Props> = ({ title }) => {
         }}
       >
         <CustomDrawer />
-        <IconButton
+        <StyledButton
           aria-label="settings"
           aria-controls="settings-menu"
           aria-haspopup="true"
           onClick={handleSettingsClick}
           color="inherit"
-          sx={{
-            display: "flex",
-            justifyContent: "flex-start",
-            paddingLeft: "16px",
-            "&:hover": {
-              backgroundColor: "transparent", // ホバーエフェクトを無効にする
-            },
-            borderRadius: 0,
-          }}
+          startIcon={<SettingsIcon />}
         >
-          <SettingsIcon />
-          <Typography variant="body1" sx={{ marginLeft: "10px" }}>
-            設定
-          </Typography>
-        </IconButton>
+          設定
+        </StyledButton>
         <Menu
           id="settings-menu"
           anchorEl={settingsAnchorEl}

--- a/service/vspo-schedule/web/src/pages/events/details/[id].tsx
+++ b/service/vspo-schedule/web/src/pages/events/details/[id].tsx
@@ -77,7 +77,7 @@ const EventPage: NextPageWithLayout<Props> = ({ event }) => {
     <>
       <Toolbar disableGutters>
         <Button startIcon={<ArrowBackIcon />} onClick={() => router.back()}>
-          Back
+          戻る
         </Button>
       </Toolbar>
 


### PR DESCRIPTION
Fixes #165

**What this PR solves / how to test:**
* Fix some buttons do not display as expected
* The reason that caused this issue is because `<IconButton />` has default `borderRadius: 50%`
* Change the radius to `0` to fix the UI display
* Test case: 
  * 戻る Button from LivestreamDetailsModal
  * 設定 Button from Drawer

After fix:

戻る Button:

https://github.com/sugar-cat7/vspo-portal/assets/28031139/fba20e7c-7f14-4086-97aa-b13b0dd9b9a5

設定 Button

https://github.com/sugar-cat7/vspo-portal/assets/28031139/2185e512-9d00-415a-b977-1855e8b49725

**Discussion:**
I think we can also change `<IconButton />` to `<Button />` with `startIcon` prop to display button with label and icons as another solution.
ref: https://mui.com/material-ui/react-button/#buttons-with-icons-and-label

Although we might not need to change the radius if we choose the `<Button />` solution, we still need some customization to meet our UI