### PR TITLE
fix(web): apply app-wide FontAwesome styles

### DIFF
--- a/service/vspo-schedule/web/src/pages/_app.tsx
+++ b/service/vspo-schedule/web/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import "@fortawesome/fontawesome-svg-core/styles.css";
 import "@/styles/globals.css";
 import "@/styles/normalize.css";
 import type { AppProps } from "next/app";
@@ -6,6 +7,9 @@ import { ReactElement, ReactNode } from "react";
 import { NextPage } from "next";
 import { ThemeModeProvider } from "@/context/Theme";
 import { GoogleAnalytics } from "@/components/Elements";
+import { config } from "@fortawesome/fontawesome-svg-core";
+
+config.autoAddCss = false;
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement, pageProps: P) => ReactNode;


### PR DESCRIPTION
Fixes #226.

**What this PR solves / how to test:**
FontAwesome icons seem to be displayed properly on all pages once importing the FA styles following [their documention](https://fontawesome.com/docs/web/use-with/react/use-with#next-js).
Regardless of which page,
- the social icons in the header should now be 20px in size, and
- the Twitch icon in the side nav should now be visible.

https://github.com/sugar-cat7/vspo-portal/assets/155891765/7ec333be-c2e4-4768-a5f5-f3dc62bf012d

