### PR TITLE
chore: add generated sitemap-related files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,11 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# sitemaps
+**/public/robots.txt
+**/public/sitemap.xml
+**/public/sitemap-0.xml
+
 **/public/sw.js
 **/public/workbox-*.js
 **/public/worker-*.js


### PR DESCRIPTION
(No associated issue — just a slight QoL improvement for frontend development)

**What this PR solves / how to test:**
This PR adds files that are generated by next-sitemap on `build` to the gitignore file.
No change is expected aside from the gitignore behavior.