### PR TITLE
fix(web): prevent padTop prop from forwarding to DOM

### DIFF
--- a/service/vspo-schedule/web/src/components/Layout/ContentLayout.tsx
+++ b/service/vspo-schedule/web/src/components/Layout/ContentLayout.tsx
@@ -24,17 +24,17 @@ type ContentLayoutProps = {
 
 type StyledContainerProps = Pick<ContentLayoutProps, "padTop">;
 
-const StyledContainer = styled(Container)<StyledContainerProps>(
-  ({ theme, padTop }) => ({
-    padding: theme.spacing(3),
-    paddingTop: padTop ? theme.spacing(4) : 0,
+const StyledContainer = styled(Container, {
+  shouldForwardProp: (prop) => prop !== "padTop",
+})<StyledContainerProps>(({ theme, padTop }) => ({
+  padding: theme.spacing(3),
+  paddingTop: padTop ? theme.spacing(4) : 0,
 
-    [theme.breakpoints.down("sm")]: {
-      padding: theme.spacing(2),
-      paddingTop: padTop ? theme.spacing(3) : 0,
-    },
-  }),
-) as OverridableComponent<ContainerTypeMap<StyledContainerProps>>;
+  [theme.breakpoints.down("sm")]: {
+    padding: theme.spacing(2),
+    paddingTop: padTop ? theme.spacing(3) : 0,
+  },
+})) as OverridableComponent<ContainerTypeMap<StyledContainerProps>>;
 
 export const ContentLayout = ({
   children,


### PR DESCRIPTION
Fixes #239.

**What this PR solves / how to test:**
This fix prevents the ContentLayout's `padTop` prop from being forwarded to the DOM.

The `dev` command should no longer print the error seen in #239.
The log should instead look something like the following:

https://github.com/sugar-cat7/vspo-portal/assets/155891765/0718c5b6-17ea-4c5a-8630-03c21bd93ad7
