### PR TITLE
feat(web): list only Twitch members in Twitch clip SearchDialog

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Dialog/SearchDialog.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Dialog/SearchDialog.tsx
@@ -68,6 +68,11 @@ export const SearchDialog: React.FC<Props> = ({
     React.useState<Timeframe | null>(null);
   const [searchKeyword, setSearchKeyword] = React.useState<string>("");
 
+  const selectableMembers =
+    clips.at(0)?.platform === "twitch"
+      ? members.filter((member) => member.twitchChannelId)
+      : members;
+
   const handleClickOpen = () => {
     setIsDialogOpen(true);
   };
@@ -89,7 +94,7 @@ export const SearchDialog: React.FC<Props> = ({
   };
 
   const handleSelectMember = (memberIds: number[]) => {
-    setSearchMemberIds(memberIds.map(Number));
+    setSearchMemberIds(memberIds);
   };
 
   return (
@@ -119,9 +124,9 @@ export const SearchDialog: React.FC<Props> = ({
             <Autocomplete
               multiple
               id="member-select"
-              options={members}
+              options={selectableMembers}
               getOptionLabel={(option) => option.name}
-              value={members.filter((member) =>
+              value={selectableMembers.filter((member) =>
                 searchMemberIds.includes(member.id),
               )}
               onChange={(event, newValue) =>


### PR DESCRIPTION
Closes #248.

**What this PR solves / how to test:**
This change filters the members listed in the SearchDialog so that only members with a Twitch channel are shown when searching Twitch clips.

To test, make sure that members without a Twitch channel (小雀とと, 兎咲ミミ, 夜乃くろむ) are listed in the members dropdown when searching at `/clips` but not at `/twitch-clips`.

Live site's `/twitch-clips`:
<img width="327" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/cac952dd-2417-488d-889e-adc87efa09a6">

This branch's `/twitch-clips`:
<img width="385" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/86da3c85-1352-408f-a162-cd423d14231e">
