### PR TITLE
Fix Google ad update error

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Google/GoogleAd.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Google/GoogleAd.tsx
@@ -1,4 +1,4 @@
-import { usePathname } from "next/navigation";
+import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 declare global {
@@ -7,7 +7,7 @@ declare global {
   }
 }
 export const GoogleAd: React.FC = () => {
-  const pathname = usePathname();
+  const router = useRouter();
 
   useEffect(() => {
     try {
@@ -16,7 +16,7 @@ export const GoogleAd: React.FC = () => {
     } catch (error) {
       console.error(error);
     }
-  }, [pathname]);
+  }, [router.asPath]);
 
   return (
     <div
@@ -29,7 +29,7 @@ export const GoogleAd: React.FC = () => {
       }}
     >
       <ins
-        key={pathname}
+        key={router.asPath}
         className="adsbygoogle"
         style={{
           display: "flex",


### PR DESCRIPTION
Fixes #241.

**What this PR solves / how to test:**
This change makes it so the ad's `ins` element is rerendered on each route change in sync with the `window.adsbygoogle.push({})` call (following [this guide](https://humanicus.medium.com/fix-google-adsense-loading-issues-with-react-f338cbd61ac4)), which *should* mean we never push more than one ad into the `ins` element and thus eliminating the console error described in #241.

To test:
- Ad is updated on all route changes (though I suspect Google may sometimes show the same ad multiple times)
- The adsbygoogle.push error described in #241 is no longer logged

Unfortunately, I believe we are unable to test this until it is pushed to the live site since the Google ad script is unavailable in Preview.