### PR TITLE
refactor(web): always treat freechat as single word

### DIFF
--- a/service/vspo-schedule/web/src/data/freechat-video-ids.ts
+++ b/service/vspo-schedule/web/src/data/freechat-video-ids.ts
@@ -1,4 +1,4 @@
-export const freeChatVideoIds = [
+export const freechatVideoIds = [
   "tFFq_vUblrs",
   "Rfuu2gkj18w",
   "bx1-cTN0Zas",

--- a/service/vspo-schedule/web/src/data/mocks/freechats.ts
+++ b/service/vspo-schedule/web/src/data/mocks/freechats.ts
@@ -1,6 +1,6 @@
 import { Livestream } from "@/types/streaming";
 
-export const mockFreeChats: Livestream[] = [
+export const mockFreechats: Livestream[] = [
   {
     id: "7-rmkxy7SSg",
     title: "Free chat",

--- a/service/vspo-schedule/web/src/lib/api.ts
+++ b/service/vspo-schedule/web/src/lib/api.ts
@@ -3,7 +3,7 @@ import { VspoEvent } from "@/types/events";
 import { Clip, Livestream } from "@/types/streaming";
 import { mockClips, mockTwitchClips } from "@/data/mocks/clips";
 import { mockEvents } from "@/data/mocks/events";
-import { mockFreeChats } from "@/data/mocks/freechats";
+import { mockFreechats } from "@/data/mocks/freechats";
 import { mockLivestreams } from "@/data/mocks/livestreams";
 import {
   convertThumbnailQualityInObjects,
@@ -72,7 +72,7 @@ export const fetchLivestreams = async ({
   }
 };
 
-export const fetchFreeChats = async (): Promise<Livestream[]> => {
+export const fetchFreechats = async (): Promise<Livestream[]> => {
   try {
     if (ENVIRONMENT === "production") {
       const response = await axios.get<Livestream[]>(
@@ -85,7 +85,7 @@ export const fetchFreeChats = async (): Promise<Livestream[]> => {
       );
       return convertThumbnailQualityInObjects(response.data);
     } else {
-      return convertThumbnailQualityInObjects(mockFreeChats);
+      return convertThumbnailQualityInObjects(mockFreechats);
     }
   } catch (error) {
     console.error("Failed to fetch freechats:", error);

--- a/service/vspo-schedule/web/src/lib/utils.ts
+++ b/service/vspo-schedule/web/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { freeChatVideoIds } from "@/data/freechat-video-ids";
+import { freechatVideoIds } from "@/data/freechat-video-ids";
 import { members } from "@/data/members";
 import { VspoEvent } from "@/types/events";
 import {
@@ -383,7 +383,7 @@ export const formatWithTimeZone = (
 export const getLiveStatus = (
   livestream: Livestream,
 ): LiveStatus | "freechat" => {
-  if (freeChatVideoIds.includes(livestream.id)) {
+  if (freechatVideoIds.includes(livestream.id)) {
     return "freechat";
   }
 

--- a/service/vspo-schedule/web/src/pages/freechat.tsx
+++ b/service/vspo-schedule/web/src/pages/freechat.tsx
@@ -7,48 +7,48 @@ import { NextPageWithLayout } from "./_app";
 import { Livestream } from "@/types/streaming";
 import { Grid } from "@mui/material";
 import { members } from "@/data/members";
-import { fetchFreeChats } from "@/lib/api";
+import { fetchFreechats } from "@/lib/api";
 
-type FreeChatsProps = {
-  freeChats: Livestream[];
+type FreechatsProps = {
+  freechats: Livestream[];
   lastUpdateDate: string;
 };
 
-const FreeChatPage: NextPageWithLayout<FreeChatsProps> = ({ freeChats }) => {
+const FreechatPage: NextPageWithLayout<FreechatsProps> = ({ freechats }) => {
   return (
     <Grid container spacing={3}>
-      {freeChats.map((freeChat) => (
-        <Grid item xs={6} md={3} key={freeChat.id}>
-          <LivestreamCard livestream={freeChat} />
+      {freechats.map((freechat) => (
+        <Grid item xs={6} md={3} key={freechat.id}>
+          <LivestreamCard livestream={freechat} />
         </Grid>
       ))}
     </Grid>
   );
 };
 
-export const getStaticProps: GetStaticProps<FreeChatsProps> = async () => {
-  const freeChats = await fetchFreeChats();
+export const getStaticProps: GetStaticProps<FreechatsProps> = async () => {
+  const freechats = await fetchFreechats();
 
   // Create a mapping of channelId to id for members
   const memberIdMap = new Map(
     members.map((member) => [member.channelId, member.id]),
   );
 
-  // Sort the freeChats array based on the memberIdMap
-  freeChats.sort((a, b) => {
+  // Sort the freechats array based on the memberIdMap
+  freechats.sort((a, b) => {
     const aMemberId = memberIdMap.get(a.channelId) || 0;
     const bMemberId = memberIdMap.get(b.channelId) || 0;
     return aMemberId - bMemberId;
   });
   return {
     props: {
-      freeChats: freeChats,
+      freechats: freechats,
       lastUpdateDate: formatWithTimeZone(new Date(), "ja", "yyyy/MM/dd HH:mm"),
     },
   };
 };
 
-FreeChatPage.getLayout = (page, pageProps) => {
+FreechatPage.getLayout = (page, pageProps) => {
   return (
     <ContentLayout
       title="ぶいすぽっ!フリーチャット"
@@ -63,4 +63,4 @@ FreeChatPage.getLayout = (page, pageProps) => {
   );
 };
 
-export default FreeChatPage;
+export default FreechatPage;

--- a/service/vspo-schedule/web/src/pages/schedule/[status].tsx
+++ b/service/vspo-schedule/web/src/pages/schedule/[status].tsx
@@ -15,7 +15,7 @@ import { TabContext } from "@mui/lab";
 import { ContentLayout } from "@/components/Layout/ContentLayout";
 import { NextPageWithLayout } from "../_app";
 import { LivestreamCards } from "@/components/Templates";
-import { freeChatVideoIds } from "@/data/freechat-video-ids";
+import { freechatVideoIds } from "@/data/freechat-video-ids";
 import { fetchEvents, fetchLivestreams } from "@/lib/api";
 import { VspoEvent } from "@/types/events";
 import Link from "next/link";
@@ -138,7 +138,7 @@ export const getStaticProps: GetStaticProps<LivestreamsProps, Params> = async ({
   const events = await fetchEvents();
 
   const uniqueLivestreams = removeDuplicateTitles(pastLivestreams).filter(
-    (livestream) => !freeChatVideoIds.includes(livestream.id),
+    (livestream) => !freechatVideoIds.includes(livestream.id),
   );
 
   const { oneWeekAgo, oneWeekLater } = getOneWeekRange();
@@ -169,7 +169,7 @@ export const getStaticProps: GetStaticProps<LivestreamsProps, Params> = async ({
       return (
         scheduledStartTime >= oneWeekAgo &&
         scheduledStartTime <= oneWeekLater &&
-        !freeChatVideoIds.includes(livestream.id) &&
+        !freechatVideoIds.includes(livestream.id) &&
         params.status === getLiveStatus(livestream)
       );
     }


### PR DESCRIPTION
Closes #206.

**What this PR solves / how to test:**
This PR standardizes the name 'freechat'/'free chat' so we always use the single-word variant 'freechat'.
No functionality should be affected.

#206 also notes standardizing 'livestream'/'live stream' to 'livestream', but it looks like all instances of 'live stream' actually refer to livestreams that are live, so I believe it makes sense for us to keep these variables named 'live stream'.