### PR TITLE
fix(web): Add padding for the <LivestreamCard /> to let date tabs cov…

### DIFF
--- a/service/vspo-schedule/web/src/pages/schedule/[status].tsx
+++ b/service/vspo-schedule/web/src/pages/schedule/[status].tsx
@@ -44,6 +44,7 @@ const TabBox = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "center",
   position: "sticky",
+  margin: "0 -2px",
 
   [theme.breakpoints.down("sm")]: {
     top: "56px",


### PR DESCRIPTION
Fixes #213 

**What this PR solves / how to test:**
* Livestream card's border would exceed date tabs since they are sharing the same container without padding
* Add padding for livestream cards to solve this issue
* Test:
  * Different width devices to check border does not exceed while scrolling
  * Check both left and right side of date tabs
