### PR TITLE
fix: switch fallback true

### DIFF
--- a/service/vspo-schedule/web/src/pages/schedule/[status].tsx
+++ b/service/vspo-schedule/web/src/pages/schedule/[status].tsx
@@ -19,6 +19,8 @@ import { freechatVideoIds } from "@/data/freechat-video-ids";
 import { fetchEvents, fetchLivestreams } from "@/lib/api";
 import { VspoEvent } from "@/types/events";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { Loading } from "@/components/Elements";
 
 type Params = {
   status: string;
@@ -56,6 +58,11 @@ const HomePage: NextPageWithLayout<LivestreamsProps> = ({
   eventsByDate,
   dateTabsInfo,
 }) => {
+  const router = useRouter();
+  if (router.isFallback) {
+    return <Loading />;
+  }
+
   if (!dateTabsInfo) {
     return (
       <LivestreamCards

--- a/service/vspo-schedule/web/src/pages/schedule/[status].tsx
+++ b/service/vspo-schedule/web/src/pages/schedule/[status].tsx
@@ -123,7 +123,7 @@ export const getStaticPaths: GetStaticPaths<Params> = () => {
     const formattedDate = formatWithTimeZone(newDate, "ja", "yyyy-MM-dd");
     datePaths.push({ params: { status: formattedDate } });
   }
-  return { paths: [...statusPaths, ...datePaths], fallback: false };
+  return { paths: [...statusPaths, ...datePaths], fallback: true };
 };
 
 export const getStaticProps: GetStaticProps<LivestreamsProps, Params> = async ({


### PR DESCRIPTION
Fixes #281 

**What this PR solves / how to test:**

Due to inadvertently disabling the regular deployment process running in the background, pages that were supposed to exist became inaccessible.

To address this, the following actions were taken:
- Re-establishing the deploy hook and the regular deployment schedule.
- Setting fallback: true <- This PR

[The impact of this change]
Currently, the API returns more Livestreams than the dates displayed on the tab, allowing some pages to be viewed even on dates not displayed on the tabs. However, this is more of an issue on the API side rather than the frontend. Therefore, in the process of replacing the API, we will make corrections to ensure the Livestreams are returned for the correct dates.