### PR TITLE
fix: revalidate window

### DIFF
--- a/service/vspo-schedule/web/src/pages/schedule/[status].tsx
+++ b/service/vspo-schedule/web/src/pages/schedule/[status].tsx
@@ -265,7 +265,7 @@ export const getStaticProps: GetStaticProps<LivestreamsProps, Params> = async ({
     const lastUpdateDate = formatDate(getCurrentUTCDate(), "yyyy/MM/dd HH:mm", {
       localeCode: locale,
     });
-    const revalidateWindow = 30;
+    const revalidateWindow = 60;
 
     const translations = await serverSideTranslations(locale, [
       "common",


### PR DESCRIPTION
I extended the revalidate period to reduce the Data Cache cost for ISR. In exchange, I am adjusting the Cache Control on the API side.