### PR TITLE
fix(web): remove getCurrentUTCDate in gtag script

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Google/GoogleAnalytics.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Google/GoogleAnalytics.tsx
@@ -17,7 +17,7 @@ export const GoogleAnalytics: FC = () => {
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
-          gtag('js', getCurrentUTCDate());
+          gtag('js', new Date());
           gtag('config', '${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}');
         `}
       </Script>


### PR DESCRIPTION
Gets rid of this error when first loading the site:
<img width="412" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/98f7e777-be42-418e-aa0e-8c0a55d120e2">

**What this PR solves / how to test:**
Loading any page via the address bar should no longer show the error in the image above.