### PR TITLE
fix(web): align Discord icon color with other drawer icons

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Icon/Icon.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Icon/Icon.tsx
@@ -86,9 +86,7 @@ export const DrawerIcon: React.FC<DrawerIconProps> = ({ id }) => {
     case "about":
       return <InfoIcon />;
     case "discord":
-      return (
-        <StyledFontAwesomeIcon icon={faDiscord} style={{ height: "20px" }} />
-      );
+      return <FontAwesomeIcon icon={faDiscord} style={{ height: "20px" }} />;
     default:
       return <></>;
   }


### PR DESCRIPTION
Fixes #162.

**What this PR solves / how to test:**
In both light mode and dark mode, the Discord icon should have the same shade as all other list icons in the drawer.

<img width="277" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/2a3a05eb-7441-4164-a132-83885ad39010">

<img width="274" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/a33caa93-846d-4f14-ad85-6ea17bbb8555">
