### PR TITLE
fix(web): show news titles instead of descriptions on news index page

### DIFF
--- a/service/vspo-schedule/web/src/pages/site-news/index.tsx
+++ b/service/vspo-schedule/web/src/pages/site-news/index.tsx
@@ -114,7 +114,7 @@ const SiteNewsPage: NextPageWithLayout<Props> = () => {
                 <TableCell sx={{ fontSize: "16px", padding: "24px" }}>
                   <Link href={`/site-news/${siteNewsItem.id}`} passHref>
                     <Box sx={{ textDecoration: "none", color: "inherit" }}>
-                      {siteNewsItem.content}
+                      {siteNewsItem.title}
                     </Box>
                   </Link>
                 </TableCell>


### PR DESCRIPTION
Fixes #253.

**What this PR solves / how to test:**
The table at `/site-news` should now show the title of each site news item rather than the description.
E.g. the top item should say '配信情報を通知するDiscord Botを公開しました。' rather than '今後は切り抜きやイベント情報の通知機能も追加予定です。'.

<img width="898" alt="image" src="https://github.com/sugar-cat7/vspo-portal/assets/155891765/e0a0b4de-bf55-4dd9-b665-829eceeeae85">
