### PR TITLE
feat(web): use system theme until user toggles site theme

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Button/ThemeToggleButton.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Button/ThemeToggleButton.tsx
@@ -2,6 +2,7 @@ import FormGroup from "@mui/material/FormGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
 import { styled, useColorScheme } from "@mui/material/styles";
+import { useTranslation } from "next-i18next";
 
 const MaterialUISwitch = styled(Switch)(({ theme }) => ({
   width: 62,
@@ -64,7 +65,8 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
 }));
 
 export const ThemeToggleButton: React.FC = () => {
-  const { mode, setMode } = useColorScheme();
+  const { mode, systemMode, setMode } = useColorScheme();
+  const { t } = useTranslation("common");
 
   const handleModeChange = (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -72,7 +74,7 @@ export const ThemeToggleButton: React.FC = () => {
   ) => {
     setMode(checked ? "dark" : "light");
   };
-  const label = `Theme: ${mode ?? "light"}`;
+  const label = `${t("drawer.site-theme")}: ${systemMode ?? mode ?? "light"}`;
   return (
     <FormGroup>
       <FormControlLabel
@@ -82,7 +84,7 @@ export const ThemeToggleButton: React.FC = () => {
         }}
         control={
           <MaterialUISwitch
-            checked={mode === "dark"}
+            checked={systemMode === "dark" || mode === "dark"}
             onChange={handleModeChange}
           />
         }

--- a/service/vspo-schedule/web/src/context/Theme.tsx
+++ b/service/vspo-schedule/web/src/context/Theme.tsx
@@ -39,7 +39,7 @@ export const ThemeModeProvider: React.FC<ThemeProviderProps> = ({
   children,
 }) => {
   return (
-    <CssVarsProvider theme={theme}>
+    <CssVarsProvider theme={theme} defaultMode="system">
       <CssBaseline />
       {children}
     </CssVarsProvider>

--- a/service/vspo-schedule/web/src/pages/_document.tsx
+++ b/service/vspo-schedule/web/src/pages/_document.tsx
@@ -37,7 +37,7 @@ class MyDocument extends Document {
           <meta name="theme-color" content="#fff" />
         </Head>
         <body>
-          {getInitColorSchemeScript()}
+          {getInitColorSchemeScript({ defaultMode: "system" })}
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
Closes #134.

**What this PR solves / how to test:**
This PR makes it so the site is displayed in the user's preferred color scheme (as set in `prefers-color-scheme`) until the user interacts with the theme toggle button to explicitly set the site theme.

Note that this is slightly different from the behavior described in #134, but I feel this is less awkward than fixing the color scheme to the one used by the user on their first visit.

https://github.com/user-attachments/assets/5c63ae3e-192f-4ea4-9838-0f84ec6f6878
