### PR TITLE
fix(web): fix position of drawer divider between nav items and site settings

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Drawer/Drawer.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Drawer/Drawer.tsx
@@ -213,13 +213,14 @@ export const CustomDrawer: React.FC<DrawerProps> = ({
 
       <Stack direction="column" justifyContent="space-between" flex="1">
         <DrawerNavigation sections={drawerNavigationSections} />
-        <Divider />
         <Box
           sx={{
             display: "flex",
             flexDirection: "column",
             gap: "16px",
             padding: "20px 12px",
+            borderTop: 1,
+            borderColor: "divider",
           }}
         >
           <LanguageSelector />


### PR DESCRIPTION
Just a minor styling fix so the divider between the nav items and site settings is no longer floating in the middle of nowhere.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5467bef5-a760-41af-8353-188225361bb7">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1ac2bf37-92d8-47a8-9d7c-a397a6670920">
