### PR TITLE
refactor(web): organize streams using time zone prop available in SSR

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Card/LivestreamCard.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Card/LivestreamCard.tsx
@@ -6,7 +6,6 @@ import { Livestream } from "@/types/streaming";
 import { getLiveStatus, formatDate } from "@/lib/utils";
 import { PlatformIcon } from "../Icon";
 import { useTranslation } from "next-i18next";
-import { useTimeZoneContext } from "@/hooks";
 import { VideoCard } from "./VideoCard";
 
 const ResponsiveTypography = styled(Typography)(({ theme }) => ({
@@ -54,16 +53,21 @@ const FontSizeOnTypography = styled(Typography)(
   }),
 );
 
-type LivestreamCardProps = {
-  livestream: Livestream;
-};
+type LivestreamCardProps =
+  | {
+      livestream: Livestream;
+      isFreechat: false;
+      timeZone: string;
+    }
+  | {
+      livestream: Livestream;
+      isFreechat: true;
+    };
 
-export const LivestreamCard: React.FC<LivestreamCardProps> = ({
-  livestream,
-}) => {
+export const LivestreamCard: React.FC<LivestreamCardProps> = (props) => {
+  const { livestream, isFreechat } = props;
   const { t } = useTranslation("common");
   const theme = useTheme();
-  const { timeZone } = useTimeZoneContext();
   const { title, channelTitle, scheduledStartTime, iconUrl, platform } =
     livestream;
   const livestreamStatus = useMemo(
@@ -100,7 +104,7 @@ export const LivestreamCard: React.FC<LivestreamCardProps> = ({
             alignItems: "center",
           }}
         >
-          {livestreamStatus !== "freechat" && (
+          {!isFreechat && (
             <ResponsiveTypography
               variant="subtitle1"
               color="text.secondary"
@@ -113,7 +117,10 @@ export const LivestreamCard: React.FC<LivestreamCardProps> = ({
                   paddingRight: "3px",
                 }}
               >
-                {formatDate(scheduledStartTime, "HH:mm", { timeZone })}~
+                {formatDate(scheduledStartTime, "HH:mm", {
+                  timeZone: props.timeZone,
+                })}
+                ~
               </Typography>
               <PlatformIcon platform={platform} />
             </ResponsiveTypography>

--- a/service/vspo-schedule/web/src/components/Templates/Livestreams.tsx
+++ b/service/vspo-schedule/web/src/components/Templates/Livestreams.tsx
@@ -16,11 +16,11 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { VspoEvent } from "@/types/events";
 import { members } from "@/data/members";
 import { useTranslation } from "next-i18next";
-import { useTimeZoneContext } from "@/hooks";
 
 type Props = {
   livestreamsByDate: Record<string, Livestream[]>;
   eventsByDate: Record<string, VspoEvent[]>;
+  timeZone: string;
 };
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
@@ -88,8 +88,8 @@ const StyledAvatar = styled(Avatar)(({ theme }) => ({
 export const LivestreamCards: React.FC<Props> = ({
   livestreamsByDate,
   eventsByDate,
+  timeZone,
 }) => {
-  const { timeZone } = useTimeZoneContext();
   const { t } = useTranslation(["streams"]);
   const [expanded, setExpanded] = React.useState<boolean>(true);
   if (Object.keys(livestreamsByDate).length === 0) {
@@ -231,7 +231,11 @@ export const LivestreamCards: React.FC<Props> = ({
                           lg={3}
                           key={livestream.id}
                         >
-                          <LivestreamCard livestream={livestream} />
+                          <LivestreamCard
+                            livestream={livestream}
+                            isFreechat={false}
+                            timeZone={timeZone}
+                          />
                         </Grid>
                       ))}
                     </Grid>

--- a/service/vspo-schedule/web/src/pages/freechat.tsx
+++ b/service/vspo-schedule/web/src/pages/freechat.tsx
@@ -26,7 +26,7 @@ const FreechatPage: NextPageWithLayout<FreechatsProps> = ({ freechats }) => {
     <Grid container spacing={3}>
       {freechats.map((freechat) => (
         <Grid item xs={6} md={3} key={freechat.id}>
-          <LivestreamCard livestream={freechat} />
+          <LivestreamCard livestream={freechat} isFreechat={true} />
         </Grid>
       ))}
     </Grid>

--- a/service/vspo-schedule/web/src/pages/schedule/[status].tsx
+++ b/service/vspo-schedule/web/src/pages/schedule/[status].tsx
@@ -103,6 +103,7 @@ const HomePage: NextPageWithLayout<LivestreamsProps> = ({
       <LivestreamCards
         livestreamsByDate={livestreamsByDate}
         eventsByDate={eventsByDate}
+        timeZone={timeZone}
       />
     );
   }
@@ -144,6 +145,7 @@ const HomePage: NextPageWithLayout<LivestreamsProps> = ({
       <LivestreamCards
         livestreamsByDate={livestreamsByDate}
         eventsByDate={eventsByDate}
+        timeZone={timeZone}
       />
     </TabContext>
   );


### PR DESCRIPTION
Closes #543.

#### Changes
- The main content of `/schedule` pages (i.e. livestream cards, time range labels) now rely on the client time zone detected by the server during SSR rather than always falling back to Asia/Tokyo.

#### Tests
When opening any `/schedule` page with any time zone:
- The livestream cards should be in the correct positions on first paint, meaning there should no longer be any visible shuffling around on non-Asia/Tokyo time zones.
- The time range labels should show the correct time range on first paint, with no updating of values.
- The start time shown on each card should show the correct time on first paint, with no updating of values.

Before:

https://github.com/user-attachments/assets/6de5ad47-1958-42c5-8b5b-8c2b6112b9c6

After:

https://github.com/user-attachments/assets/4eec8a3f-c09c-4342-a947-98fa69a30135
