### PR TITLE
refactor(web): create getRelevantMembers util

### DIFF
--- a/service/vspo-schedule/web/src/components/Templates/Livestreams.tsx
+++ b/service/vspo-schedule/web/src/components/Templates/Livestreams.tsx
@@ -10,11 +10,10 @@ import {
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { Livestream } from "@/types/streaming";
-import { groupLivestreamsByTimeRange } from "@/lib/utils";
+import { getRelevantMembers, groupLivestreamsByTimeRange } from "@/lib/utils";
 import { Link, LivestreamCard } from "../Elements";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { VspoEvent } from "@/types/events";
-import { members } from "@/data/members";
 import { useTranslation } from "next-i18next";
 import { useTimeZoneContext } from "@/hooks";
 
@@ -150,26 +149,21 @@ export const LivestreamCards: React.FC<Props> = ({
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails sx={{ backgroundColor: "transparent" }}>
-                  {events.map((event, index) => (
-                    <Box
-                      display="flex"
-                      sx={{
-                        gap: "10px",
-                        marginBottom: "10px",
-                        flexDirection: "column",
-                      }}
-                      key={index}
-                    >
-                      {event.isNotLink ? (
-                        <Typography
-                          sx={{
-                            fontSize: "16px",
-                          }}
-                        >
-                          ・{event.title}
-                        </Typography>
-                      ) : (
-                        <Link href={`/events/details/${event.newsId}`}>
+                  {events.map((event, eventIndex) => {
+                    const eventMembers = getRelevantMembers(
+                      event.contentSummary,
+                    );
+                    return (
+                      <Box
+                        display="flex"
+                        sx={{
+                          gap: "10px",
+                          marginBottom: "10px",
+                          flexDirection: "column",
+                        }}
+                        key={eventIndex}
+                      >
+                        {event.isNotLink ? (
                           <Typography
                             sx={{
                               fontSize: "16px",
@@ -177,30 +171,37 @@ export const LivestreamCards: React.FC<Props> = ({
                           >
                             ・{event.title}
                           </Typography>
-                        </Link>
-                      )}
-                      <Box
-                        display="flex"
-                        sx={{
-                          gap: "10px",
-                          marginBottom: "10px",
-                        }}
-                      >
-                        {members.map(
-                          (member, index) =>
-                            event.contentSummary.includes(
-                              (member.name || "").replace(" ", ""),
-                            ) && (
+                        ) : (
+                          <Link href={`/events/details/${event.newsId}`}>
+                            <Typography
+                              sx={{
+                                fontSize: "16px",
+                              }}
+                            >
+                              ・{event.title}
+                            </Typography>
+                          </Link>
+                        )}
+                        {eventMembers.length > 0 && (
+                          <Box
+                            display="flex"
+                            sx={{
+                              gap: "10px",
+                              marginBottom: "10px",
+                            }}
+                          >
+                            {eventMembers.map((member, memberIndex) => (
                               <StyledAvatar
-                                key={index}
+                                key={memberIndex}
                                 alt={member.name}
                                 src={member.iconUrl}
                               />
-                            ),
+                            ))}
+                          </Box>
                         )}
                       </Box>
-                    </Box>
-                  ))}
+                    );
+                  })}
                 </AccordionDetails>
               </StyledAccordion>
             )}

--- a/service/vspo-schedule/web/src/components/Templates/RelatedVideos.tsx
+++ b/service/vspo-schedule/web/src/components/Templates/RelatedVideos.tsx
@@ -1,7 +1,7 @@
-import { memberNames } from "@/data/members";
+import { members } from "@/data/members";
 import { DEFAULT_LOCALE, TEMP_TIMESTAMP } from "@/lib/Const";
 import { RelatedProps, fetcher } from "@/lib/api";
-import { formatDate } from "@/lib/utils";
+import { formatDate, isRelevantMember } from "@/lib/utils";
 import { Clip, Livestream, Video } from "@/types/streaming";
 import {
   Card,
@@ -103,7 +103,7 @@ const getRelatedVideos = (
 
   const relatedMemberClip = relatedVideos.clips.filter((c) => {
     if (
-      memberNames.find((m) => c.title.includes(m.replace(" ", ""))) &&
+      members.some((member) => isRelevantMember(member, c.title)) &&
       !clipIdSet.has(c.id)
     ) {
       clipIdSet.add(c.id);

--- a/service/vspo-schedule/web/src/data/members.ts
+++ b/service/vspo-schedule/web/src/data/members.ts
@@ -299,5 +299,3 @@ export const members: Member[] = [
     keywords: ["Riko Solari", "Riko", "Solari", "ソラリリコ", "ソラリ リコ"],
   },
 ];
-
-export const memberNames = members.map(({ name }) => name);

--- a/service/vspo-schedule/web/src/lib/utils.ts
+++ b/service/vspo-schedule/web/src/lib/utils.ts
@@ -21,6 +21,7 @@ import { SiteNewsTag } from "@/types/site-news";
 import { ParsedUrlQuery } from "querystring";
 import { convertToUTCDate, getCurrentUTCDate } from "./dayjs";
 import { ServerResponse } from "http";
+import { Member } from "@/types/member";
 
 /**
  * Group an array of items by a specified key.
@@ -565,6 +566,25 @@ export const groupEventsByYearMonth = (events: VspoEvent[]) => {
       },
       {} as { [key: string]: VspoEvent[] },
     );
+};
+
+/**
+ * Searches for members who are relevant to the given string.
+ * @param str - The string to search through.
+ * @returns The list of relevant members.
+ */
+export const getRelevantMembers = (str: string) => {
+  return members.filter((member) => isRelevantMember(member, str));
+};
+
+/**
+ * Determines whether the given member is relevant to the given string.
+ * @param member - The query member.
+ * @param str - The string to search through.
+ * @returns true if the member is relevant to the string, false otherwise.
+ */
+export const isRelevantMember = (member: Member, str: string) => {
+  return member.keywords.some((keyword) => str.includes(keyword));
 };
 
 type HasThumbnailUrl = { thumbnailUrl: string };

--- a/service/vspo-schedule/web/src/pages/events/[yearMonth].tsx
+++ b/service/vspo-schedule/web/src/pages/events/[yearMonth].tsx
@@ -21,11 +21,11 @@ import { NextPageWithLayout } from "../_app";
 import { VspoEvent } from "@/types/events";
 import { ContentLayout } from "@/components/Layout";
 import { useMediaQuery } from "@mui/material";
-import { members } from "@/data/members";
 import {
   formatDate,
   generateStaticPathsForLocales,
   getInitializedI18nInstance,
+  getRelevantMembers,
   groupEventsByYearMonth,
 } from "@/lib/utils";
 import React, { useEffect } from "react";
@@ -315,7 +315,6 @@ const IndexPage: NextPageWithLayout<Props> = ({
                 </TimelineSeparator>
                 <TimelineContent sx={{ py: matches ? "40px" : "20px", px: 2 }}>
                   {eventsOnDate.map((event, eventIndex) => {
-                    // TODO: Consider whether an event should hold time zone info
                     const eventDate = event.startedAt.split("T")[0]; // Get the date part of the ISO string
                     const today = formatDate(
                       getCurrentUTCDate(),
@@ -323,6 +322,9 @@ const IndexPage: NextPageWithLayout<Props> = ({
                       { timeZone },
                     );
                     const isEventToday = eventDate === today;
+                    const eventMembers = getRelevantMembers(
+                      event.contentSummary,
+                    );
                     return (
                       <React.Fragment key={eventIndex}>
                         {event.isNotLink ? (
@@ -344,29 +346,23 @@ const IndexPage: NextPageWithLayout<Props> = ({
                               >
                                 {event.title}
                               </Typography>
-                              <Box
-                                sx={{
-                                  display: "flex",
-                                  gap: "10px",
-                                  marginTop: "10px",
-                                }}
-                              >
-                                {members.map((member, index) => {
-                                  const isMatch = member.keywords.some(
-                                    (keyword) =>
-                                      event.contentSummary.includes(keyword),
-                                  );
-                                  return (
-                                    isMatch && (
-                                      <StyledAvatar
-                                        key={index}
-                                        alt={member.name}
-                                        src={member.iconUrl}
-                                      />
-                                    )
-                                  );
-                                })}
-                              </Box>
+                              {eventMembers.length > 0 && (
+                                <Box
+                                  sx={{
+                                    display: "flex",
+                                    gap: "10px",
+                                    marginTop: "10px",
+                                  }}
+                                >
+                                  {eventMembers.map((member, memberIndex) => (
+                                    <StyledAvatar
+                                      key={memberIndex}
+                                      alt={member.name}
+                                      src={member.iconUrl}
+                                    />
+                                  ))}
+                                </Box>
+                              )}
                             </CardContent>
                           </Card>
                         ) : (
@@ -389,29 +385,23 @@ const IndexPage: NextPageWithLayout<Props> = ({
                                 >
                                   {event.title}
                                 </Typography>
-                                <Box
-                                  sx={{
-                                    display: "flex",
-                                    gap: "10px",
-                                    marginTop: "10px",
-                                  }}
-                                >
-                                  {members.map((member, index) => {
-                                    const isMatch = member.keywords.some(
-                                      (keyword) =>
-                                        event.contentSummary.includes(keyword),
-                                    );
-                                    return (
-                                      isMatch && (
-                                        <StyledAvatar
-                                          key={index}
-                                          alt={member.name}
-                                          src={member.iconUrl}
-                                        />
-                                      )
-                                    );
-                                  })}
-                                </Box>
+                                {eventMembers.length > 0 && (
+                                  <Box
+                                    sx={{
+                                      display: "flex",
+                                      gap: "10px",
+                                      marginTop: "10px",
+                                    }}
+                                  >
+                                    {eventMembers.map((member, memberIndex) => (
+                                      <StyledAvatar
+                                        key={memberIndex}
+                                        alt={member.name}
+                                        src={member.iconUrl}
+                                      />
+                                    ))}
+                                  </Box>
+                                )}
                               </CardContent>
                             </Card>
                           </Link>

--- a/service/vspo-schedule/web/src/pages/events/details/[id].tsx
+++ b/service/vspo-schedule/web/src/pages/events/details/[id].tsx
@@ -5,10 +5,13 @@ import { useRouter } from "next/router";
 import { NextPageWithLayout } from "../../_app";
 import { VspoEvent } from "@/types/events";
 import { TweetEmbed } from "@/components/Elements";
-import { formatDate, generateStaticPathsForLocales } from "@/lib/utils";
+import {
+  formatDate,
+  generateStaticPathsForLocales,
+  getRelevantMembers,
+} from "@/lib/utils";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { ContentLayout } from "@/components/Layout";
-import { members } from "@/data/members";
 import { fetchEvents } from "@/lib/api";
 import { DEFAULT_LOCALE, TEMP_TIMESTAMP } from "@/lib/Const";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -132,20 +135,9 @@ const EventPage: NextPageWithLayout<Props> = ({ event }) => {
               { localeCode: locale, timeZone },
             )}
           </Typography>
-          {members.map((member, index) => {
-            const isMatch = member.keywords.some((keyword) =>
-              event.contentSummary.includes(keyword),
-            );
-            return (
-              isMatch && (
-                <StyledAvatar
-                  key={index}
-                  alt={member.name}
-                  src={member.iconUrl}
-                />
-              )
-            );
-          })}
+          {getRelevantMembers(event.contentSummary).map((member, index) => (
+            <StyledAvatar key={index} alt={member.name} src={member.iconUrl} />
+          ))}
         </Box>
         <Box sx={{ marginBottom: "20px" }}>
           {event.contentSummary.split("\n").map((line, index) => {


### PR DESCRIPTION
I noticed code like `str.includes((member.name || "").replace(" ", ""))` being repeated in several places throughout the site as a way to search for members relevant to some given `str`, so this PR just moves this logic into a util to better capture the intent and make the implementation consistent site-wide.