### PR TITLE
fix(web): align schedule page heading date format with date tabs

### DIFF
--- a/service/vspo-schedule/web/src/components/Templates/Livestreams.tsx
+++ b/service/vspo-schedule/web/src/components/Templates/Livestreams.tsx
@@ -10,7 +10,11 @@ import {
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { Livestream } from "@/types/streaming";
-import { getRelevantMembers, groupLivestreamsByTimeRange } from "@/lib/utils";
+import {
+  formatDate,
+  getRelevantMembers,
+  groupLivestreamsByTimeRange,
+} from "@/lib/utils";
 import { Link, LivestreamCard } from "../Elements";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { VspoEvent } from "@/types/events";
@@ -20,6 +24,7 @@ type Props = {
   livestreamsByDate: Record<string, Livestream[]>;
   eventsByDate: Record<string, VspoEvent[]>;
   timeZone: string;
+  locale: string;
 };
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
@@ -88,6 +93,7 @@ export const LivestreamCards: React.FC<Props> = ({
   livestreamsByDate,
   eventsByDate,
   timeZone,
+  locale,
 }) => {
   const { t } = useTranslation(["streams"]);
   const [expanded, setExpanded] = React.useState<boolean>(true);
@@ -116,8 +122,9 @@ export const LivestreamCards: React.FC<Props> = ({
           events = eventsByDate[date];
         }
 
-        const formattedDate =
-          livestreamsByDate[date].at(0)?.formattedDateString;
+        const formattedDate = formatDate(date, "MM/dd (E)", {
+          localeCode: locale,
+        });
 
         return (
           <Box

--- a/service/vspo-schedule/web/src/pages/schedule/[status].tsx
+++ b/service/vspo-schedule/web/src/pages/schedule/[status].tsx
@@ -77,6 +77,7 @@ const HomePage: NextPageWithLayout<LivestreamsProps> = ({
   events,
   dateTabsInfo,
   timeZone,
+  locale,
 }) => {
   const router = useRouter();
   const { t } = useTranslation("streams");
@@ -104,6 +105,7 @@ const HomePage: NextPageWithLayout<LivestreamsProps> = ({
         livestreamsByDate={livestreamsByDate}
         eventsByDate={eventsByDate}
         timeZone={timeZone}
+        locale={locale}
       />
     );
   }
@@ -146,6 +148,7 @@ const HomePage: NextPageWithLayout<LivestreamsProps> = ({
         livestreamsByDate={livestreamsByDate}
         eventsByDate={eventsByDate}
         timeZone={timeZone}
+        locale={locale}
       />
     </TabContext>
   );


### PR DESCRIPTION
Fixes #490.

The date heading on schedule pages should now always have the same `MM/dd (E)` date format as the date tabs, event dates, etc.

https://github.com/user-attachments/assets/c1a2eca2-e5ab-49fd-bd28-b3fc6941db4c
