### PR TITLE
fix(web): hide start time for freechats and clips

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Modal/VideoModal.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Modal/VideoModal.tsx
@@ -185,25 +185,27 @@ const InfoTabs: React.FC<{ video: Video }> = ({ video }) => {
           <TypographySmallOnMobile variant="h5">
             {video.title}
           </TypographySmallOnMobile>
-          <Box
-            display="flex"
-            justifyContent="flex-start"
-            sx={{ marginTop: "10px" }}
-          >
-            <TypographySmallOnMobile sx={{ marginRight: "10px" }}>
-              {formattedStartTime}
-            </TypographySmallOnMobile>
-            {(liveStatus === "live" || liveStatus === "upcoming") && (
-              <HighlightedVideoChip
-                highlightColor={
-                  theme.vars.palette.customColors.videoHighlight[liveStatus]
-                }
-                bold
-              >
-                {t(`liveStatus.${liveStatus}`)}
-              </HighlightedVideoChip>
-            )}
-          </Box>
+          {liveStatus !== undefined && liveStatus !== "freechat" && (
+            <Box
+              display="flex"
+              justifyContent="flex-start"
+              sx={{ marginTop: "10px" }}
+            >
+              <TypographySmallOnMobile sx={{ marginRight: "10px" }}>
+                {formattedStartTime}
+              </TypographySmallOnMobile>
+              {(liveStatus === "live" || liveStatus === "upcoming") && (
+                <HighlightedVideoChip
+                  highlightColor={
+                    theme.vars.palette.customColors.videoHighlight[liveStatus]
+                  }
+                  bold
+                >
+                  {t(`liveStatus.${liveStatus}`)}
+                </HighlightedVideoChip>
+              )}
+            </Box>
+          )}
         </Box>
         <Box>
           <Box display="flex" alignItems="center" mt={2} mb={2}>


### PR DESCRIPTION
Fixes #544.

The video modal no longer shows the start time for freechats and clips.

<img width="256" alt="image" src="https://github.com/user-attachments/assets/62b932b8-cd43-4ec8-9bf9-233c3c73c552">
<img width="256" alt="image" src="https://github.com/user-attachments/assets/be5bd149-41e6-4967-bd18-4dea7ced3fc2">
<img width="256" alt="image" src="https://github.com/user-attachments/assets/3af18a39-45cd-42b7-b2c5-70e129909577">
