### PR TITLE
fix(web): let event dates be timezone-independent

### DIFF
--- a/service/vspo-schedule/web/src/pages/events/[yearMonth].tsx
+++ b/service/vspo-schedule/web/src/pages/events/[yearMonth].tsx
@@ -301,10 +301,7 @@ const IndexPage: NextPageWithLayout<Props> = ({
                       width: matches ? "130px" : "100px",
                     }}
                   >
-                    {formatDate(date, "MM/dd (E)", {
-                      localeCode: locale,
-                      timeZone,
-                    })}
+                    {formatDate(date, "MM/dd (E)", { localeCode: locale })}
                   </Typography>
                 </TimelineOppositeContent>
                 <TimelineSeparator>
@@ -315,13 +312,12 @@ const IndexPage: NextPageWithLayout<Props> = ({
                 </TimelineSeparator>
                 <TimelineContent sx={{ py: matches ? "40px" : "20px", px: 2 }}>
                   {eventsOnDate.map((event, eventIndex) => {
-                    const eventDate = event.startedAt.split("T")[0]; // Get the date part of the ISO string
                     const today = formatDate(
                       getCurrentUTCDate(),
                       "yyyy-MM-dd",
                       { timeZone },
                     );
-                    const isEventToday = eventDate === today;
+                    const isEventToday = date === today;
                     const eventMembers = getRelevantMembers(
                       event.contentSummary,
                     );

--- a/service/vspo-schedule/web/src/pages/events/details/[id].tsx
+++ b/service/vspo-schedule/web/src/pages/events/details/[id].tsx
@@ -17,7 +17,6 @@ import { DEFAULT_LOCALE, TEMP_TIMESTAMP } from "@/lib/Const";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { convertToUTCDate } from "@/lib/dayjs";
-import { useTimeZoneContext } from "@/hooks";
 
 type Params = {
   id: string;
@@ -103,7 +102,6 @@ const EventPage: NextPageWithLayout<Props> = ({ event }) => {
   const router = useRouter();
   const { t } = useTranslation(["common"]);
   const locale = router.locale ?? DEFAULT_LOCALE;
-  const { timeZone } = useTimeZoneContext();
 
   if (!event) {
     return null;
@@ -132,7 +130,7 @@ const EventPage: NextPageWithLayout<Props> = ({ event }) => {
             {formatDate(
               convertToUTCDate(event.startedAt.split("T")[0] || TEMP_TIMESTAMP),
               "MM/dd (E)",
-              { localeCode: locale, timeZone },
+              { localeCode: locale },
             )}
           </Typography>
           {getRelevantMembers(event.contentSummary).map((member, index) => (


### PR DESCRIPTION
Fixes half of #542.

This PR makes it so the displayed event dates are no longer dependent on user time zone.
E.g. if an event has date `2024-11-11T00:00:00Z`, the event is listed as being on `2024-11-11` in all time zones.

https://github.com/user-attachments/assets/9f214e31-3a10-42c2-bee1-b7b176d4f5c6

Regarding the rest of #542, I am unsure if we should apply the same change as above to site news items since, on second thought, I feel site news items do carry time information.
E.g. if the Discord bot was released on `2023-09-05T00:00:00Z`, from the perspective of a user in Los Angeles, it might make more sense to say that the bot was released on `2023-09-04`.
@sugar-cat7 Please let me know which you would prefer.