### PR TITLE
fix(web): let site news dates be timezone-independent

### DIFF
--- a/service/vspo-schedule/web/src/pages/site-news/[id].tsx
+++ b/service/vspo-schedule/web/src/pages/site-news/[id].tsx
@@ -15,7 +15,6 @@ import { DEFAULT_LOCALE } from "@/lib/Const";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
-import { useTimeZoneContext } from "@/hooks";
 
 type Params = {
   id: string;
@@ -32,11 +31,9 @@ const SiteNewsItemPage: NextPageWithLayout<Props> = ({ siteNewsItem }) => {
   const router = useRouter();
   const locale = router.locale ?? DEFAULT_LOCALE;
   const { t } = useTranslation("site-news");
-  const { timeZone } = useTimeZoneContext();
 
   const formattedDate = formatDate(siteNewsItem.updated, "PPP", {
     localeCode: locale,
-    timeZone,
   });
 
   return (

--- a/service/vspo-schedule/web/src/pages/site-news/index.tsx
+++ b/service/vspo-schedule/web/src/pages/site-news/index.tsx
@@ -25,7 +25,6 @@ import { DEFAULT_LOCALE } from "@/lib/Const";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
-import { useTimeZoneContext } from "@/hooks";
 
 type Props = {
   meta: {
@@ -58,7 +57,6 @@ const SiteNewsPage: NextPageWithLayout<Props> = () => {
   const router = useRouter();
   const locale = router.locale ?? DEFAULT_LOCALE;
   const { t } = useTranslation("site-news");
-  const { timeZone } = useTimeZoneContext();
 
   return (
     <>
@@ -125,7 +123,6 @@ const SiteNewsPage: NextPageWithLayout<Props> = () => {
                 >
                   {formatDate(siteNewsItem.updated, "PPP", {
                     localeCode: locale,
-                    timeZone,
                   })}
                 </TableCell>
                 <TableCell sx={{ fontSize: "16px", padding: "24px" }}>


### PR DESCRIPTION
Fixes #542.

This PR makes it so the site news dates (in the table at `/site-news` and in the heading for each news item at `/site-news/[id]`) are no longer dependent on user time zone.

https://github.com/user-attachments/assets/9a499406-99c1-428b-a5f2-c36c44e7334b