### PR TITLE
fix(web): revert video description links to using MUI Link

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Modal/VideoModal.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Modal/VideoModal.tsx
@@ -8,6 +8,7 @@ import {
   Avatar,
   Button,
   IconButton,
+  Link as MuiLink,
   Tab,
   Tabs,
   BottomNavigation,
@@ -270,14 +271,14 @@ const InfoTabs: React.FC<{ video: Video }> = ({ video }) => {
               return <React.Fragment key={index}>{text}</React.Fragment>;
             }
             return (
-              <Link
+              <MuiLink
                 href={text}
                 target="_blank"
                 rel="noopener noreferrer"
                 key={index}
               >
                 {text}
-              </Link>
+              </MuiLink>
             );
           })}
         </TypographySmallOnMobileDescription>


### PR DESCRIPTION
Fixes #607.

This PR makes links in the video description use the MUI Link component rather than the custom Link component, since the latter prepends Spodule's base URL and locale to the desired target URL.
(This should revert to the same behavior as prior to #534.)

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/9ef87b8d-b9b5-4f5d-83dc-3ae80f494263">
