### PR TITLE
fix(web): let events on status page be timezone-independent

### DIFF
--- a/service/vspo-schedule/web/src/pages/schedule/[status].tsx
+++ b/service/vspo-schedule/web/src/pages/schedule/[status].tsx
@@ -95,9 +95,9 @@ const HomePage: NextPageWithLayout<LivestreamsProps> = ({
   }, [livestreams, timeZone]);
   const eventsByDate = useMemo(() => {
     return groupBy(events, (event) => {
-      return formatDate(event.startedAt, "yyyy-MM-dd", { timeZone });
+      return formatDate(event.startedAt, "yyyy-MM-dd");
     });
-  }, [events, timeZone]);
+  }, [events]);
 
   if (router.isFallback) {
     return <Loading />;


### PR DESCRIPTION
Realized I hadn't removed the time zone dependency of events on `[status]` pages in #606.
This PR makes these events appear on the page with the expected date.

https://github.com/user-attachments/assets/0fda9ad4-bdc8-4725-8306-5d6462bf8142

