### PR TITLE
fix(web): hide date tabs on `/archive`, `/live`, `/upcoming`

### DIFF
--- a/service/vspo-schedule/web/src/pages/schedule/[status].tsx
+++ b/service/vspo-schedule/web/src/pages/schedule/[status].tsx
@@ -313,16 +313,19 @@ export const getServerSideProps: GetServerSideProps<
     };
 
     // Execute the fetches in parallel using Promise.all
+    const useDateTabs = !["archive", "live", "upcoming"].includes(
+      params.status,
+    );
     const [
       uniqueLivestreams,
       events,
       { translations, footerMessage, title, headTitle, t },
-      { todayIndex, tabDates },
+      dateTabsInfo,
     ] = await Promise.all([
       fetchLivestreamsData(),
       fetchEventsData(),
       fetchTranslationsAndMeta(),
-      fetchDateTabsInfo(),
+      useDateTabs ? fetchDateTabsInfo() : undefined,
     ]);
 
     // Livestream description needs to be set after fetching
@@ -343,10 +346,7 @@ export const getServerSideProps: GetServerSideProps<
         lastUpdateTimestamp: getCurrentUTCDate().getTime(),
         liveStatus: params.status,
         locale: locale,
-        dateTabsInfo: {
-          todayIndex,
-          tabDates,
-        },
+        ...(useDateTabs && { dateTabsInfo }),
         footerMessage,
         meta: {
           title,


### PR DESCRIPTION
Fixes #677.

This PR once again hides the date tabs on the `/archive`, `/live`, `/upcoming` pages.

https://github.com/user-attachments/assets/64511f76-cea7-4c17-9ab6-84b08284683f


**Tests**
- Date tabs hidden on `/archive`, `/live`, `/upcoming`
- Date tabs still visible on `/all` and `/[date]`