### PR TITLE
feat(web): add icon to language switcher

### DIFF
--- a/service/vspo-schedule/web/src/components/Elements/Control/LanguageSelector.tsx
+++ b/service/vspo-schedule/web/src/components/Elements/Control/LanguageSelector.tsx
@@ -1,4 +1,5 @@
-import { MenuItem, TextField } from "@mui/material";
+import LanguageIcon from "@mui/icons-material/Language";
+import { InputAdornment, MenuItem, TextField } from "@mui/material";
 import { useTranslation } from "next-i18next";
 import { useLocale } from "@/hooks";
 
@@ -25,6 +26,15 @@ export const LanguageSelector = () => {
         onChange={(event) => {
           const selectedLocale = event.target.value;
           setLocale(selectedLocale);
+        }}
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <LanguageIcon />
+              </InputAdornment>
+            ),
+          },
         }}
       >
         {Object.keys(localeLabels).map((loc) => (


### PR DESCRIPTION
Closes #626.

This PR adds a 🌐 icon to the LanguageSelector so that the control is easier to find for users who happen to open the site in a language they cannot read.

https://github.com/user-attachments/assets/303eb054-fa91-496d-a3c3-79d7e826ca06
