### PR TITLE
fix(bot-dashboard): resolve Cloudflare Workers deploy failures

### DIFF
--- a/.github/workflows/deploy-bot-dashboard.yaml
+++ b/.github/workflows/deploy-bot-dashboard.yaml
@@ -34,7 +34,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: pnpm
-          wranglerVersion: "4.6.0"
+          wranglerVersion: "4.73.0"
           workingDirectory: service/bot-dashboard
           command: deploy --env ${{ github.ref == 'refs/heads/main' && 'prd' || 'dev' }}
           environment: ${{ github.ref == 'refs/heads/main' && 'prd' || 'dev' }}

--- a/service/bot-dashboard/astro.config.ts
+++ b/service/bot-dashboard/astro.config.ts
@@ -8,9 +8,7 @@ export default defineConfig({
     defaultLocale: "ja",
     locales: ["ja", "en"],
   },
-  adapter: cloudflare({
-    sessionKVBindingName: "SESSION",
-  }),
+  adapter: cloudflare(),
   vite: {
     plugins: [tailwindcss()],
   },


### PR DESCRIPTION
## Summary
- Update `wranglerVersion` from `4.6.0` to `4.73.0` in deploy workflow to match pnpm catalog and satisfy `@astrojs/cloudflare` peer dependency (`^4.61.1`)
- Remove `sessionKVBindingName: "SESSION"` from `astro.config.ts` since KV namespaces have not been created yet, causing `kv_namespaces[0]` missing `id` error in generated `dist/server/wrangler.json`

## Test plan
- [ ] Confirm deploy workflow succeeds on develop branch
- [ ] Verify bot-dashboard is accessible at dev-discord.vspo-schedule.com after deploy