### PR TITLE
fix(bot-dashboard): split wrangler config per env to fix custom domain deploy

### DIFF
--- a/.github/workflows/deploy-bot-dashboard.yaml
+++ b/.github/workflows/deploy-bot-dashboard.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: ${{ github.ref == 'refs/heads/main' && 'bot-dashboard-production' || 'bot-dashboard-development' }}
+    env:
+      WRANGLER_CONFIG: ${{ github.ref == 'refs/heads/main' && 'wrangler.prd.jsonc' || 'wrangler.jsonc' }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up Node.js
@@ -28,23 +30,31 @@ jobs:
         run: pnpm install
       - name: Turbo Build
         run: pnpm turbo build --filter=bot-dashboard...
+      - name: Upload secrets
+        working-directory: service/bot-dashboard
+        run: |
+          node -e "
+            const secrets = {
+              DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
+              DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+              DISCORD_REDIRECT_URI: process.env.DISCORD_REDIRECT_URI,
+              DISCORD_BOT_CLIENT_ID: process.env.DISCORD_BOT_CLIENT_ID,
+            };
+            process.stdout.write(JSON.stringify(secrets));
+          " | pnpm exec wrangler secret bulk --config "$WRANGLER_CONFIG"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DISCORD_CLIENT_ID: ${{ secrets.DISCORD_CLIENT_ID }}
+          DISCORD_CLIENT_SECRET: ${{ secrets.DISCORD_CLIENT_SECRET }}
+          DISCORD_REDIRECT_URI: ${{ secrets.DISCORD_REDIRECT_URI }}
+          DISCORD_BOT_CLIENT_ID: ${{ secrets.DISCORD_BOT_CLIENT_ID }}
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: pnpm
-          wranglerVersion: "4.73.0"
+          wranglerVersion: "4.76.0"
           workingDirectory: service/bot-dashboard
-          command: deploy --env ${{ github.ref == 'refs/heads/main' && 'prd' || 'dev' }}
-          environment: ${{ github.ref == 'refs/heads/main' && 'prd' || 'dev' }}
-          secrets: |
-            DISCORD_CLIENT_ID
-            DISCORD_CLIENT_SECRET
-            DISCORD_REDIRECT_URI
-            DISCORD_BOT_CLIENT_ID
-        env:
-          DISCORD_CLIENT_ID: ${{ secrets.DISCORD_CLIENT_ID }}
-          DISCORD_CLIENT_SECRET: ${{ secrets.DISCORD_CLIENT_SECRET }}
-          DISCORD_REDIRECT_URI: ${{ secrets.DISCORD_REDIRECT_URI }}
-          DISCORD_BOT_CLIENT_ID: ${{ secrets.DISCORD_BOT_CLIENT_ID }}
+          command: deploy --config ${{ env.WRANGLER_CONFIG }}

--- a/service/bot-dashboard/wrangler.prd.jsonc
+++ b/service/bot-dashboard/wrangler.prd.jsonc
@@ -1,23 +1,21 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "dev-bot-dashboard",
+  "name": "prd-bot-dashboard",
   "compatibility_date": "2025-04-01",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true
   },
   "workers_dev": false,
-  "routes": [
-    { "pattern": "dev-discord.vspo-schedule.com", "custom_domain": true }
-  ],
+  "routes": [{ "pattern": "discord.vspo-schedule.com", "custom_domain": true }],
   "services": [
     {
       "binding": "APP_WORKER",
-      "service": "dev-vspo-portal-app",
+      "service": "prd-vspo-portal-app",
       "entrypoint": "ApplicationService"
     }
   ],
-  /** Secrets should be set via `wrangler secret put` */
+  /** Secrets should be set via `wrangler secret put --config wrangler.prd.jsonc` */
   "vars": {
     "DISCORD_CLIENT_ID": "",
     "DISCORD_BOT_CLIENT_ID": ""


### PR DESCRIPTION
## Summary
- `@astrojs/cloudflare` アダプターがビルド時に `dist/server/wrangler.json` をトップレベル設定のみで生成し、`wrangler deploy --env` が無効化される問題を修正
- 環境ごとの独立設定ファイル（`wrangler.jsonc`=dev, `wrangler.prd.jsonc`=prd）に分離し、`--config` フラグで切り替え
- `workers_dev: false` を明示してworkers.devへのフォールバックを防止

## Root cause
1. `astro build` → `dist/server/wrangler.json` にトップレベル設定のみ焼き込み（`env` セクション消失）
2. `.wrangler/deploy/config.json` が生成configにリダイレクト
3. `wrangler deploy --env dev` 実行時、リダイレクト先に `env` が存在せず `--env` が無効化
4. 結果: トップレベルの `name: "bot-dashboard"` でデプロイ、カスタムドメイン未適用、`workers_dev` デフォルト `true` により workers.dev にフォールバック

ローカルでビルド後の `dist/server/wrangler.json` を検証済み:
```
# Before (env-based config)
name: bot-dashboard, services: [], routes: [], workers_dev: undefined

# After (flat config)  
name: dev-bot-dashboard, services: [APP_WORKER], routes: [dev-discord.vspo-schedule.com], workers_dev: false
```

## Test plan
- [ ] develop push で `dev-bot-dashboard` としてデプロイされることを確認
- [ ] `dev-discord.vspo-schedule.com` カスタムドメインが triggers に表示されることを確認
- [ ] `workers.dev` ドメインにデプロイされないことを確認
- [ ] Secrets が正しく設定されることを確認