### PR TITLE
fix(bot-dashboard): fix Cloudflare Workers deploy

### DIFF
--- a/.github/workflows/deploy-bot-dashboard.yaml
+++ b/.github/workflows/deploy-bot-dashboard.yaml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: ${{ github.ref == 'refs/heads/main' && 'bot-dashboard-production' || 'bot-dashboard-development' }}
-    env:
-      WRANGLER_CONFIG: ${{ github.ref == 'refs/heads/main' && 'wrangler.prd.jsonc' || 'wrangler.jsonc' }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up Node.js
@@ -28,6 +26,10 @@ jobs:
           run_install: false
       - name: Install dependencies
         run: pnpm install
+      - name: Use production wrangler config
+        if: github.ref == 'refs/heads/main'
+        working-directory: service/bot-dashboard
+        run: cp wrangler.prd.jsonc wrangler.jsonc
       - name: Turbo Build
         run: pnpm turbo build --filter=bot-dashboard...
       - name: Upload secrets
@@ -41,7 +43,7 @@ jobs:
               DISCORD_BOT_CLIENT_ID: process.env.DISCORD_BOT_CLIENT_ID,
             };
             process.stdout.write(JSON.stringify(secrets));
-          " | pnpm exec wrangler secret bulk --config "$WRANGLER_CONFIG"
+          " | pnpm exec wrangler secret bulk
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -57,4 +59,4 @@ jobs:
           packageManager: pnpm
           wranglerVersion: "4.76.0"
           workingDirectory: service/bot-dashboard
-          command: deploy --config ${{ env.WRANGLER_CONFIG }}
+          command: deploy

--- a/service/bot-dashboard/wrangler.jsonc
+++ b/service/bot-dashboard/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "dev-bot-dashboard",
+  "main": "@astrojs/cloudflare/entrypoints/server",
   "compatibility_date": "2025-04-01",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {

--- a/service/bot-dashboard/wrangler.prd.jsonc
+++ b/service/bot-dashboard/wrangler.prd.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "prd-bot-dashboard",
+  "main": "@astrojs/cloudflare/entrypoints/server",
   "compatibility_date": "2025-04-01",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {


### PR DESCRIPTION
## Summary

- Astro v6 + `@astrojs/cloudflare` v13 generates a redirected wrangler config at `dist/server/wrangler.json` during build
- `wrangler deploy` auto-discovers this redirect when no `--config` flag is passed, but **bypasses it** when `--config` is explicitly specified, causing `Missing entry-point to Worker script` errors
- Add `"main": "@astrojs/cloudflare/entrypoints/server"` to both wrangler configs (Astro v6 recommended setting)
- Remove `--config` flag from `wrangler deploy` and `wrangler secret bulk` commands
- Add CI step to copy `wrangler.prd.jsonc` → `wrangler.jsonc` for production deploys (main branch only)

## Test plan

- [x] Verified `wrangler deploy --dry-run` succeeds locally (without `--config`)
- [ ] Verify develop branch deploy succeeds in CI
- [ ] Verify main branch deploy succeeds in CI

Closes: https://github.com/vspo-lab/vspo-portal/actions/runs/23355885135/job/67946446200