### PR TITLE
feat(multiview): replace greedy overlap resolution with VPSC algorithm

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -115,12 +115,14 @@ unmounted
 vercel
 vitejs
 vitest
+vpsc
 vspo
 vspo-lab
 vtuber
 vtubers
 wada
 wcag
+webcola
 workerd
 wrangler
 youtu

--- a/docs/web-frontend/multiview.md
+++ b/docs/web-frontend/multiview.md
@@ -51,7 +51,7 @@ Shortcuts are disabled when focus is in an input field, textarea, or contentEdit
 - `react-grid-layout` (120 columns, rowHeight=10px for fine resize control)
 - `allowOverlap={true}`, `compactType={null}` for free-form placement
 - Drag swap detection at 50% overlap (RAF-throttled)
-- Post-drop/resize overlap resolution: integer-grid algorithm checks all pairs, pushes apart on the axis with minimum overlap (up to 20 passes)
+- Post-drop/resize overlap resolution: VPSC-based algorithm (webcola) solves all separation constraints simultaneously with minimum displacement, followed by greedy fixup for edge cases and integer rounding
 - `resolveOverlaps` is called on ALL paths that modify layout: drag stop, resize stop, stream add/remove, and saved layout restore
 - All 8 resize handles (n, s, e, w, ne, nw, se, sw) — visible on grid item hover
 - Auto-fills viewport height; grid container uses `position: sticky` below the AppBar

--- a/docs/web-frontend/multiview.md
+++ b/docs/web-frontend/multiview.md
@@ -14,7 +14,7 @@ features/multiview/
 │   └── useConfigurationLoader.ts # URL config loading
 ├── utils/
 │   ├── stateManager.ts           # localStorage + URL sharing + custom presets + resolveStream/toStreamSnapshot
-│   ├── gridSwap.ts               # Overlap resolution (integer grid) + drag swap
+│   ├── gridSwap.ts               # VPSC overlap resolution (webcola) + drag swap
 │   ├── urlParser.ts              # Platform URL parsing
 │   ├── platformUtils.ts          # Per-platform embed URL generation (YouTube, Twitch, Twitcasting)
 │   ├── configLoader.ts           # External config loading
@@ -51,11 +51,41 @@ Shortcuts are disabled when focus is in an input field, textarea, or contentEdit
 - `react-grid-layout` (120 columns, rowHeight=10px for fine resize control)
 - `allowOverlap={true}`, `compactType={null}` for free-form placement
 - Drag swap detection at 50% overlap (RAF-throttled)
-- Post-drop/resize overlap resolution: VPSC-based algorithm (webcola) solves all separation constraints simultaneously with minimum displacement, followed by greedy fixup for edge cases and integer rounding
 - `resolveOverlaps` is called on ALL paths that modify layout: drag stop, resize stop, stream add/remove, and saved layout restore
 - All 8 resize handles (n, s, e, w, ne, nw, se, sw) — visible on grid item hover
 - Auto-fills viewport height; grid container uses `position: sticky` below the AppBar
 - Visual guide lines: 12-column vertical + row-aligned horizontal (CSS background-image)
+
+### Overlap Resolution (`resolveOverlaps`)
+
+2段階のハイブリッドアルゴリズムで重なりを解消する。
+
+**Phase 1: VPSC (webcola)**
+
+[VPSC (Variable Placement with Separation Constraints)](https://doi.org/10.1007/11618058_15) は、二次計画法ベースの制約ソルバー。全アイテムの分離制約を同時に解き、元位置からの二乗変位 `Σ(xᵢ − dᵢ)²` を最小化する。[webcola](https://github.com/tgdwyer/WebCola) の実装を使用。
+
+1. **X-pass**: 各アイテムの中心 X 座標を `Variable` として生成。`generateXConstraints` が Y 方向に重なるペアに対し X 分離制約を sweep-line で生成。境界制約（`x ≥ 0`, `x + w ≤ 120`）を weight=10⁸ の固定変数で追加。`Solver.solve()` で最適解を算出
+2. **Y-pass**: 更新後の X 位置を前提に `generateYConstraints` が X 方向に重なるペアに対し Y 分離制約を生成。境界制約（`y ≥ 0`、下限のみ — グリッドは垂直スクロール可能）を追加して解く
+3. **整数化**: VPSC の実数解を `Math.round()` で整数グリッドに丸め、境界にクランプ
+
+**Phase 2: Greedy Fixup**
+
+webcola の sweep-line 制約生成は、同一中心のアイテムや整数丸めで残る重なりを見逃すケースがある。残存する重なりを貪欲法で解消する:
+
+1. 全ペアから最大重なり面積のペアを探索（`getOverlapArea` を使用）
+2. 重なりなし → 終了
+3. X 重なり ≤ Y 重なり → X 方向に押し出し（境界で塞がれたら Y にフォールバック）
+4. それ以外 → Y 方向に押し出し
+5. 最大 `n² × 2` 回まで繰り返し（n ≤ 12 なので実質的に瞬時）
+
+```
+resolveOverlaps(layout)
+  ├── solveWithVpsc(items)      ← Phase 1: 大域最適（O(n² log n)）
+  │   ├── X-pass + boundary constraints → Solver.solve()
+  │   └── Y-pass + boundary constraints → Solver.solve()
+  └── greedyFixup(items)        ← Phase 2: 残存重なり修正（通常 0-2 回）
+      └── worst-pair → tryPushX / pushY
+```
 
 ## Chat
 
@@ -122,6 +152,8 @@ Hides header/footer/nav for distraction-free viewing. Exit via Escape or `I` key
 ## References
 
 - [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout) — Grid layout library
+- [webcola](https://github.com/tgdwyer/WebCola) — VPSC solver for overlap resolution
+- [Dwyer, Marriott & Stuckey, "Fast Node Overlap Removal" (GD 2005)](https://doi.org/10.1007/11618058_15) — VPSC algorithm paper
 - [YouTube IFrame Player API](https://developers.google.com/youtube/iframe_api_reference) — postMessage-based control
 - [Twitch Embed](https://dev.twitch.tv/docs/embed/) — iframe embed spec
 - [YouTube oEmbed](https://oembed.com/) — Metadata API for URL-added streams

--- a/docs/web-frontend/multiview.md
+++ b/docs/web-frontend/multiview.md
@@ -50,41 +50,78 @@ Shortcuts are disabled when focus is in an input field, textarea, or contentEdit
 
 - `react-grid-layout` (120 columns, rowHeight=10px for fine resize control)
 - `allowOverlap={true}`, `compactType={null}` for free-form placement
-- Drag swap detection at 50% overlap (RAF-throttled)
-- `resolveOverlaps` is called on ALL paths that modify layout: drag stop, resize stop, stream add/remove, and saved layout restore
+- Drag swap: real-time position swap during drag (50% overlap threshold, RAF-throttled via `computeSwapDuringDrag`)
+- Post-drop: `resolveOverlaps` on ALL paths that modify layout: drag stop, resize stop, stream add/remove, and saved layout restore
 - All 8 resize handles (n, s, e, w, ne, nw, se, sw) — visible on grid item hover
 - Auto-fills viewport height; grid container uses `position: sticky` below the AppBar
 - Visual guide lines: 12-column vertical + row-aligned horizontal (CSS background-image)
 
+### Drag-Time Swap (`computeSwapDuringDrag`)
+
+ドラッグ中に RAF スロットルで呼び出され、アイテムの位置をリアルタイムに入れ替える。
+
+1. ドラッグ中のアイテムと最も重なりが大きいアイテムを検出
+2. 重なり面積がドラッグアイテム面積の **50%** 以上 → ターゲットをドラッグ元の位置にスワップ
+3. 同一ターゲットへの連続スワップを `lastSwappedId` で抑制（チャタリング防止）
+4. スワップ後の二次衝突は `resolveOverlaps` で即解消
+5. `startTransition` でレイアウト更新し、ドラッグの応答性を維持
+
 ### Overlap Resolution (`resolveOverlaps`)
 
-2段階のハイブリッドアルゴリズムで重なりを解消する。
+#### 数学的背景
 
-**Phase 1: VPSC (webcola)**
+[VPSC (Variable Placement with Separation Constraints)](https://doi.org/10.1007/11618058_15) は以下の制約付き二次計画問題を解く:
 
-[VPSC (Variable Placement with Separation Constraints)](https://doi.org/10.1007/11618058_15) は、二次計画法ベースの制約ソルバー。全アイテムの分離制約を同時に解き、元位置からの二乗変位 `Σ(xᵢ − dᵢ)²` を最小化する。[webcola](https://github.com/tgdwyer/WebCola) の実装を使用。
+```
+minimize   Σᵢ wᵢ(xᵢ − dᵢ)²
+subject to xₗ + gₗᵣ ≤ xᵣ   ∀(l, r) ∈ C
+```
 
-1. **X-pass**: 各アイテムの中心 X 座標を `Variable` として生成。`generateXConstraints` が Y 方向に重なるペアに対し X 分離制約を sweep-line で生成。境界制約（`x ≥ 0`, `x + w ≤ 120`）を weight=10⁸ の固定変数で追加。`Solver.solve()` で最適解を算出
-2. **Y-pass**: 更新後の X 位置を前提に `generateYConstraints` が X 方向に重なるペアに対し Y 分離制約を生成。境界制約（`y ≥ 0`、下限のみ — グリッドは垂直スクロール可能）を追加して解く
-3. **整数化**: VPSC の実数解を `Math.round()` で整数グリッドに丸め、境界にクランプ
+- **xᵢ**: アイテム i の中心座標（求解対象）
+- **dᵢ**: アイテム i の元の中心座標（desired position）
+- **wᵢ**: 重み（通常 1、境界変数は 10⁸）
+- **gₗᵣ**: ペア (l, r) 間の最小距離 = `(wₗ + wᵣ) / 2`（半幅の和）
+- **C**: 分離制約の集合
 
-**Phase 2: Greedy Fixup**
+目的関数は元位置からの **二乗変位の重み付き和** を最小化するため、全アイテムが協調的に最小量だけ移動する。これが貪欲法（1ペアずつ逐次処理）と本質的に異なる点で、カスケード問題（A-B を直すと B-C が壊れる）が発生しない。
 
-webcola の sweep-line 制約生成は、同一中心のアイテムや整数丸めで残る重なりを見逃すケースがある。残存する重なりを貪欲法で解消する:
+VPSC ソルバーはブロックマージ/分割アルゴリズムで O(n log n) で解く（[Dwyer et al., GD 2005](https://doi.org/10.1007/11618058_15)）。
 
-1. 全ペアから最大重なり面積のペアを探索（`getOverlapArea` を使用）
-2. 重なりなし → 終了
-3. X 重なり ≤ Y 重なり → X 方向に押し出し（境界で塞がれたら Y にフォールバック）
-4. それ以外 → Y 方向に押し出し
-5. 最大 `n² × 2` 回まで繰り返し（n ≤ 12 なので実質的に瞬時）
+#### 2D への拡張
+
+2D の矩形重なり除去は X 軸と Y 軸を逐次解く（[Dwyer et al., "Fast Node Overlap Removal"](https://doi.org/10.1007/11618058_15)）:
+
+1. **X-pass**: Y 方向に重なるペアに対し X 分離制約を生成して VPSC で解く
+2. **Y-pass**: 更新後の X 位置で X 方向に重なるペアに対し Y 分離制約を生成して解く
+
+各パスの制約生成は [webcola](https://github.com/tgdwyer/WebCola) の sweep-line アルゴリズム（`generateXConstraints` / `generateYConstraints`）を基本とし、scan-line が見逃すペア（同一中心、X overlap > Y overlap）に対する O(n²) 補完パス（`supplementConstraints`）を追加。
+
+#### 境界制約
+
+グリッド境界 `[0, 120]` × `[0, ∞)` は、重み 10⁸ の固定変数として VPSC に組み込む:
+
+```
+x_left_bound = 0   (w = 10⁸)     // 動かない壁
+x_right_bound = 120 (w = 10⁸)
+
+制約: x_left_bound + wᵢ/2 ≤ xᵢ    (左端からはみ出さない)
+      xᵢ + wᵢ/2 ≤ x_right_bound   (右端からはみ出さない)
+```
+
+重みが 10⁸ 対 1 なので、ソルバーは境界をほぼ動かさず、アイテム側を移動させる。
+
+#### 整数化と Rounding Fixup
+
+VPSC の解は実数。`Math.round()` で整数グリッドに丸めた後、1px の重なりが生じうる。O(n²) の軽量パス（`roundingFixup`）で残存重なりを X 押し出し → Y 押し出しで解消。
+
+#### 処理フロー
 
 ```
 resolveOverlaps(layout)
-  ├── solveWithVpsc(items)      ← Phase 1: 大域最適（O(n² log n)）
-  │   ├── X-pass + boundary constraints → Solver.solve()
-  │   └── Y-pass + boundary constraints → Solver.solve()
-  └── greedyFixup(items)        ← Phase 2: 残存重なり修正（通常 0-2 回）
-      └── worst-pair → tryPushX / pushY
+  ├── solveWithVpsc(items)                        ← O(n²) 制約生成 + O(n log n) VPSC
+  │   ├── X-pass: generateXConstraints + supplementConstraints + boundary → Solver.solve()
+  │   └── Y-pass: generateYConstraints + supplementConstraints + boundary → Solver.solve()
+  └── roundingFixup(items)                        ← O(n²) 整数丸め補正（通常 0-1 回）
 ```
 
 ## Chat
@@ -134,7 +171,8 @@ Hides header/footer/nav for distraction-free viewing. Exit via Escape or `I` key
 
 ## Performance
 
-- `startTransition` for drag swap layout updates (React 19)
+- `startTransition` for drag swap layout updates (keeps drag responsive)
+- Drag-time swap throttled via `requestAnimationFrame` (one swap computation per frame)
 - `loading="lazy"` on iframes
 - `will-change: transform` only during active drag
 - Debounced localStorage writes (500ms)

--- a/service/vspo-schedule/v2/web/package.json
+++ b/service/vspo-schedule/v2/web/package.json
@@ -48,6 +48,7 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",
+    "webcola": "^3.4.0",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/service/vspo-schedule/v2/web/pnpm-lock.yaml
+++ b/service/vspo-schedule/v2/web/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       remark-html:
         specifier: ^16.0.1
         version: 16.0.1
+      webcola:
+        specifier: ^3.4.0
+        version: 3.4.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -3335,6 +3338,24 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-dispatch@1.0.6:
+    resolution: {integrity: sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==}
+
+  d3-drag@1.2.5:
+    resolution: {integrity: sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-selection@1.4.2:
+    resolution: {integrity: sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-timer@1.0.10:
+    resolution: {integrity: sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -6119,6 +6140,9 @@ packages:
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
+
+  webcola@3.4.0:
+    resolution: {integrity: sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -10209,6 +10233,23 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-dispatch@1.0.6: {}
+
+  d3-drag@1.2.5:
+    dependencies:
+      d3-dispatch: 1.0.6
+      d3-selection: 1.4.2
+
+  d3-path@1.0.9: {}
+
+  d3-selection@1.4.2: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-timer@1.0.10: {}
+
   data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -13525,6 +13566,13 @@ snapshots:
       graceful-fs: 4.2.11
 
   web-streams-polyfill@4.0.0-beta.3: {}
+
+  webcola@3.4.0:
+    dependencies:
+      d3-dispatch: 1.0.6
+      d3-drag: 1.2.5
+      d3-shape: 1.3.7
+      d3-timer: 1.0.10
 
   webidl-conversions@3.0.1: {}
 

--- a/service/vspo-schedule/v2/web/src/features/multiview/components/presenters/MultiviewGridPresenter.tsx
+++ b/service/vspo-schedule/v2/web/src/features/multiview/components/presenters/MultiviewGridPresenter.tsx
@@ -13,7 +13,7 @@ import GridLayout from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 import { MultiviewLayout } from "../../hooks/useMultiviewLayout";
-import { resolveOverlaps } from "../../utils/gridSwap";
+import { GRID_COLS, resolveOverlaps } from "../../utils/gridSwap";
 import { scaledBorderRadius } from "../../utils/theme";
 import { ChatCell, VideoPlayer } from "../containers";
 
@@ -26,9 +26,6 @@ const GRID_ITEM_STYLE: React.CSSProperties = {
   height: "100%",
   width: "100%",
 };
-
-// Grid cell size for 12 columns — used for background grid lines
-const GRID_COLS = 120;
 
 const GridContainer = styled(Paper)(({ theme }) => ({
   minHeight: "auto",

--- a/service/vspo-schedule/v2/web/src/features/multiview/components/presenters/MultiviewGridPresenter.tsx
+++ b/service/vspo-schedule/v2/web/src/features/multiview/components/presenters/MultiviewGridPresenter.tsx
@@ -13,7 +13,11 @@ import GridLayout from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 import { MultiviewLayout } from "../../hooks/useMultiviewLayout";
-import { GRID_COLS, resolveOverlaps } from "../../utils/gridSwap";
+import {
+  GRID_COLS,
+  computeSwapDuringDrag,
+  resolveOverlaps,
+} from "../../utils/gridSwap";
 import { scaledBorderRadius } from "../../utils/theme";
 import { ChatCell, VideoPlayer } from "../containers";
 
@@ -314,6 +318,10 @@ export const MultiviewGridPresenter: React.FC<MultiviewGridPresenterProps> = ({
   // Drag state
   const isDraggingRef = useRef(false);
   const isResizingRef = useRef(false);
+  const dragOriginRef = useRef<{ x: number; y: number } | null>(null);
+  const draggedIdRef = useRef<string | null>(null);
+  const lastSwappedIdRef = useRef<string | null>(null);
+  const dragRafRef = useRef(0);
 
 
   // Internal layout state — only reset when layout button is pressed
@@ -511,22 +519,57 @@ export const MultiviewGridPresenter: React.FC<MultiviewGridPresenterProps> = ({
     }
   }, [internalLayout, onGridPositionsChange]);
 
-  const handleDragStart = () => {
+  const handleDragStart = (
+    _rglLayout: GridLayout.Layout[],
+    oldItem: GridLayout.Layout,
+  ) => {
     isDraggingRef.current = true;
+    draggedIdRef.current = oldItem.i;
+    dragOriginRef.current = { x: oldItem.x, y: oldItem.y };
+    lastSwappedIdRef.current = null;
     containerRef.current?.classList.add("is-dragging");
   };
 
-  const handleDrag = () => {};
+  const handleDrag = (
+    rglLayout: GridLayout.Layout[],
+    _oldItem: GridLayout.Layout,
+    _newItem: GridLayout.Layout,
+  ) => {
+    if (!draggedIdRef.current || !dragOriginRef.current) return;
+
+    cancelAnimationFrame(dragRafRef.current);
+    dragRafRef.current = requestAnimationFrame(() => {
+      const merged = mergeLayoutSizes(rglLayout, internalLayout);
+      const { layout: swapped, swappedId } = computeSwapDuringDrag(
+        merged,
+        draggedIdRef.current!,
+        dragOriginRef.current!,
+        lastSwappedIdRef.current,
+      );
+
+      if (swappedId && swappedId !== lastSwappedIdRef.current) {
+        lastSwappedIdRef.current = swappedId;
+        dragOriginRef.current = {
+          x: rglLayout.find((item) => item.i === draggedIdRef.current)?.x ?? dragOriginRef.current!.x,
+          y: rglLayout.find((item) => item.i === draggedIdRef.current)?.y ?? dragOriginRef.current!.y,
+        };
+        React.startTransition(() => setInternalLayout(swapped));
+      }
+    });
+  };
 
   const handleDragStop = (
     rglLayout: GridLayout.Layout[],
     _oldItem: GridLayout.Layout,
     _newItem: GridLayout.Layout,
   ) => {
+    cancelAnimationFrame(dragRafRef.current);
     containerRef.current?.classList.remove("is-dragging");
-    // Use RGL's layout as the single source of truth, then resolve overlaps synchronously
     setInternalLayout(resolveOverlaps(mergeLayoutSizes(rglLayout, internalLayout)));
     isDraggingRef.current = false;
+    draggedIdRef.current = null;
+    dragOriginRef.current = null;
+    lastSwappedIdRef.current = null;
   };
 
   const handleResizeStart = () => {

--- a/service/vspo-schedule/v2/web/src/features/multiview/components/presenters/MultiviewGridPresenter.tsx
+++ b/service/vspo-schedule/v2/web/src/features/multiview/components/presenters/MultiviewGridPresenter.tsx
@@ -323,9 +323,11 @@ export const MultiviewGridPresenter: React.FC<MultiviewGridPresenterProps> = ({
   const lastSwappedIdRef = useRef<string | null>(null);
   const dragRafRef = useRef(0);
 
-
   // Internal layout state — only reset when layout button is pressed
   const [internalLayout, setInternalLayout] = useState<GridLayout.Layout[]>([]);
+  // Ref mirror for accessing latest layout inside RAF callbacks without stale closures
+  const internalLayoutRef = useRef(internalLayout);
+  internalLayoutRef.current = internalLayout;
   // Track layout type to detect layout button presses
   const prevLayoutTypeRef = useRef(layout.type);
 
@@ -372,6 +374,7 @@ export const MultiviewGridPresenter: React.FC<MultiviewGridPresenterProps> = ({
     return () => {
       window.removeEventListener("resize", handleResize);
       cancelAnimationFrame(rafId);
+      cancelAnimationFrame(dragRafRef.current);
       clearTimeout(timeoutId);
       clearTimeout(timeoutId2);
       observer.disconnect();
@@ -539,7 +542,7 @@ export const MultiviewGridPresenter: React.FC<MultiviewGridPresenterProps> = ({
 
     cancelAnimationFrame(dragRafRef.current);
     dragRafRef.current = requestAnimationFrame(() => {
-      const merged = mergeLayoutSizes(rglLayout, internalLayout);
+      const merged = mergeLayoutSizes(rglLayout, internalLayoutRef.current);
       const { layout: swapped, swappedId } = computeSwapDuringDrag(
         merged,
         draggedIdRef.current!,
@@ -548,11 +551,12 @@ export const MultiviewGridPresenter: React.FC<MultiviewGridPresenterProps> = ({
       );
 
       if (swappedId && swappedId !== lastSwappedIdRef.current) {
+        // Update origin to the swapped target's pre-swap position (now free)
+        const target = merged.find((item) => item.i === swappedId);
+        if (target) {
+          dragOriginRef.current = { x: target.x, y: target.y };
+        }
         lastSwappedIdRef.current = swappedId;
-        dragOriginRef.current = {
-          x: rglLayout.find((item) => item.i === draggedIdRef.current)?.x ?? dragOriginRef.current!.x,
-          y: rglLayout.find((item) => item.i === draggedIdRef.current)?.y ?? dragOriginRef.current!.y,
-        };
         React.startTransition(() => setInternalLayout(swapped));
       }
     });
@@ -565,7 +569,7 @@ export const MultiviewGridPresenter: React.FC<MultiviewGridPresenterProps> = ({
   ) => {
     cancelAnimationFrame(dragRafRef.current);
     containerRef.current?.classList.remove("is-dragging");
-    setInternalLayout(resolveOverlaps(mergeLayoutSizes(rglLayout, internalLayout)));
+    setInternalLayout(resolveOverlaps(mergeLayoutSizes(rglLayout, internalLayoutRef.current)));
     isDraggingRef.current = false;
     draggedIdRef.current = null;
     dragOriginRef.current = null;

--- a/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.test.ts
+++ b/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.test.ts
@@ -142,6 +142,38 @@ describe("resolveOverlaps", () => {
     assertWithinBounds(result);
   });
 
+  it("swaps positions when boundary blocks push (small item at edge, large inside)", () => {
+    // Large item at right edge overlapping with small item — can't push right,
+    // so swap puts the small item at the edge and large item in the open space
+    const layout = [
+      makeItem({ i: "small", x: 80, y: 0, w: 20, h: 20 }),
+      makeItem({ i: "large", x: 70, y: 0, w: 50, h: 20 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    assertWithinBounds(result);
+  });
+
+  it("resolves overlap when both items are at left boundary", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 40, h: 20 }),
+      makeItem({ i: "b", x: 0, y: 0, w: 30, h: 20 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    assertWithinBounds(result);
+  });
+
+  it("resolves overlap when items span nearly the full grid width", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 70, h: 20 }),
+      makeItem({ i: "b", x: 50, y: 0, w: 70, h: 20 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    // At least one item may be pushed to Y since total width > GRID_COLS
+  });
+
   it("handles 12 items all stacked at (0,0)", () => {
     const layout = Array.from({ length: 12 }, (_, i) =>
       makeItem({ i: `item-${i}`, x: 0, y: 0, w: 10, h: 10 }),

--- a/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.test.ts
+++ b/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.test.ts
@@ -217,7 +217,7 @@ describe("resolveOverlaps", () => {
     const result = resolveOverlaps(layout);
     const elapsed = performance.now() - start;
     assertNoOverlaps(result);
-    expect(elapsed).toBeLessThan(100); // should be well under 10ms
+    expect(elapsed).toBeLessThan(100); // generous for CI; typically <10ms locally
   });
 });
 

--- a/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.test.ts
+++ b/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+import type GridLayout from "react-grid-layout";
+import {
+  GRID_COLS,
+  resolveOverlaps,
+  computeSwapDuringDrag,
+  getOverlapArea,
+} from "./gridSwap";
+
+/** Helper to create a minimal layout item. */
+const makeItem = (
+  overrides: Partial<GridLayout.Layout> & { i: string; x: number; y: number; w: number; h: number },
+): GridLayout.Layout => overrides as GridLayout.Layout;
+
+/** Check that no pair of items overlaps. */
+const assertNoOverlaps = (items: GridLayout.Layout[]) => {
+  for (let i = 0; i < items.length; i++) {
+    for (let j = i + 1; j < items.length; j++) {
+      expect(
+        getOverlapArea(items[i], items[j]),
+        `Items "${items[i].i}" and "${items[j].i}" overlap`,
+      ).toBe(0);
+    }
+  }
+};
+
+/** Check all items are within grid boundaries. */
+const assertWithinBounds = (items: GridLayout.Layout[]) => {
+  for (const item of items) {
+    expect(item.x, `"${item.i}" x=${item.x} < 0`).toBeGreaterThanOrEqual(0);
+    expect(item.y, `"${item.i}" y=${item.y} < 0`).toBeGreaterThanOrEqual(0);
+    expect(
+      item.x + item.w,
+      `"${item.i}" right edge ${item.x + item.w} > ${GRID_COLS}`,
+    ).toBeLessThanOrEqual(GRID_COLS);
+  }
+};
+
+describe("resolveOverlaps", () => {
+  it("returns empty array for empty input", () => {
+    expect(resolveOverlaps([])).toEqual([]);
+  });
+
+  it("returns single item unchanged", () => {
+    const layout = [makeItem({ i: "a", x: 10, y: 5, w: 20, h: 10 })];
+    const result = resolveOverlaps(layout);
+    expect(result).toEqual(layout);
+  });
+
+  it("returns non-overlapping items unchanged", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 30, h: 10 }),
+      makeItem({ i: "b", x: 30, y: 0, w: 30, h: 10 }),
+      makeItem({ i: "c", x: 60, y: 0, w: 30, h: 10 }),
+    ];
+    const result = resolveOverlaps(layout);
+    // Positions should not change
+    for (let i = 0; i < layout.length; i++) {
+      expect(result[i].x).toBe(layout[i].x);
+      expect(result[i].y).toBe(layout[i].y);
+    }
+    assertNoOverlaps(result);
+  });
+
+  it("resolves two items overlapping horizontally", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 30, h: 10 }),
+      makeItem({ i: "b", x: 20, y: 0, w: 30, h: 10 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    assertWithinBounds(result);
+  });
+
+  it("resolves two items overlapping vertically", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 30, h: 10 }),
+      makeItem({ i: "b", x: 0, y: 5, w: 30, h: 10 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    assertWithinBounds(result);
+  });
+
+  it("resolves fully overlapping items (same position and size)", () => {
+    const layout = [
+      makeItem({ i: "a", x: 10, y: 10, w: 20, h: 10 }),
+      makeItem({ i: "b", x: 10, y: 10, w: 20, h: 10 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    assertWithinBounds(result);
+  });
+
+  it("resolves cascade scenario (A-B-C chain)", () => {
+    // A, B, C overlap in a chain — pushing A-B apart should not cause B-C to overlap
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 30, h: 20 }),
+      makeItem({ i: "b", x: 20, y: 0, w: 30, h: 20 }),
+      makeItem({ i: "c", x: 40, y: 0, w: 30, h: 20 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    assertWithinBounds(result);
+  });
+
+  it("minimizes displacement from original positions", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 20, h: 10 }),
+      makeItem({ i: "b", x: 15, y: 0, w: 20, h: 10 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+
+    // Total displacement should be small (VPSC minimizes squared displacement)
+    const totalDisplacement = result.reduce(
+      (sum, item, i) =>
+        sum + Math.abs(item.x - layout[i].x) + Math.abs(item.y - layout[i].y),
+      0,
+    );
+    // The minimum to resolve 5-unit horizontal overlap is ~5 total shift
+    expect(totalDisplacement).toBeLessThan(30);
+  });
+
+  it("respects left boundary (x >= 0)", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 30, h: 10 }),
+      makeItem({ i: "b", x: 10, y: 0, w: 30, h: 10 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    assertWithinBounds(result);
+  });
+
+  it("respects right boundary (x + w <= GRID_COLS)", () => {
+    const layout = [
+      makeItem({ i: "a", x: 90, y: 0, w: 30, h: 10 }),
+      makeItem({ i: "b", x: 100, y: 0, w: 30, h: 10 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    assertWithinBounds(result);
+  });
+
+  it("handles 12 items all stacked at (0,0)", () => {
+    const layout = Array.from({ length: 12 }, (_, i) =>
+      makeItem({ i: `item-${i}`, x: 0, y: 0, w: 10, h: 10 }),
+    );
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    assertWithinBounds(result);
+    expect(result).toHaveLength(12);
+  });
+
+  it("handles items with different sizes", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 60, h: 30 }),
+      makeItem({ i: "b", x: 30, y: 10, w: 20, h: 10 }),
+      makeItem({ i: "c", x: 50, y: 20, w: 40, h: 20 }),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    assertWithinBounds(result);
+  });
+
+  it("preserves extra layout properties (minW, minH, static)", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 30, h: 10, minW: 5, minH: 3, static: true } as GridLayout.Layout),
+      makeItem({ i: "b", x: 20, y: 0, w: 30, h: 10, minW: 2, minH: 2 } as GridLayout.Layout),
+    ];
+    const result = resolveOverlaps(layout);
+    assertNoOverlaps(result);
+    const a = result.find((item) => item.i === "a")!;
+    const b = result.find((item) => item.i === "b")!;
+    expect(a.minW).toBe(5);
+    expect(a.minH).toBe(3);
+    expect(a.static).toBe(true);
+    expect(b.minW).toBe(2);
+    expect(b.minH).toBe(2);
+  });
+
+  it("is idempotent (running twice produces same result)", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 40, h: 20 }),
+      makeItem({ i: "b", x: 20, y: 10, w: 40, h: 20 }),
+      makeItem({ i: "c", x: 60, y: 0, w: 40, h: 20 }),
+    ];
+    const first = resolveOverlaps(layout);
+    const second = resolveOverlaps(first);
+    expect(second).toEqual(first);
+  });
+
+  it("positions are always integers", () => {
+    const layout = [
+      makeItem({ i: "a", x: 0, y: 0, w: 25, h: 15 }),
+      makeItem({ i: "b", x: 10, y: 5, w: 25, h: 15 }),
+      makeItem({ i: "c", x: 20, y: 10, w: 25, h: 15 }),
+    ];
+    const result = resolveOverlaps(layout);
+    for (const item of result) {
+      expect(Number.isInteger(item.x), `x=${item.x} is not integer`).toBe(true);
+      expect(Number.isInteger(item.y), `y=${item.y} is not integer`).toBe(true);
+    }
+  });
+
+  it("completes in reasonable time for 12 items", () => {
+    const layout = Array.from({ length: 12 }, (_, i) =>
+      makeItem({
+        i: `item-${i}`,
+        x: (i % 4) * 25 + 5,
+        y: Math.floor(i / 4) * 15 + 3,
+        w: 30,
+        h: 20,
+      }),
+    );
+    const start = performance.now();
+    const result = resolveOverlaps(layout);
+    const elapsed = performance.now() - start;
+    assertNoOverlaps(result);
+    expect(elapsed).toBeLessThan(100); // should be well under 10ms
+  });
+});
+
+describe("getOverlapArea", () => {
+  it("returns 0 for non-overlapping items", () => {
+    const a = makeItem({ i: "a", x: 0, y: 0, w: 10, h: 10 });
+    const b = makeItem({ i: "b", x: 20, y: 0, w: 10, h: 10 });
+    expect(getOverlapArea(a, b)).toBe(0);
+  });
+
+  it("returns 0 for touching items (no overlap)", () => {
+    const a = makeItem({ i: "a", x: 0, y: 0, w: 10, h: 10 });
+    const b = makeItem({ i: "b", x: 10, y: 0, w: 10, h: 10 });
+    expect(getOverlapArea(a, b)).toBe(0);
+  });
+
+  it("calculates partial overlap correctly", () => {
+    const a = makeItem({ i: "a", x: 0, y: 0, w: 20, h: 10 });
+    const b = makeItem({ i: "b", x: 10, y: 5, w: 20, h: 10 });
+    // Overlap: x=[10,20], y=[5,10] => 10 * 5 = 50
+    expect(getOverlapArea(a, b)).toBe(50);
+  });
+
+  it("handles full containment", () => {
+    const a = makeItem({ i: "a", x: 0, y: 0, w: 40, h: 40 });
+    const b = makeItem({ i: "b", x: 10, y: 10, w: 10, h: 10 });
+    expect(getOverlapArea(a, b)).toBe(100); // 10 * 10
+  });
+});
+
+describe("computeSwapDuringDrag", () => {
+  it("returns original layout if dragged item not found", () => {
+    const layout = [makeItem({ i: "a", x: 0, y: 0, w: 30, h: 10 })];
+    const result = computeSwapDuringDrag(layout, "nonexistent", { x: 0, y: 0 }, null);
+    expect(result.layout).toBe(layout);
+    expect(result.swappedId).toBeNull();
+  });
+
+  it("returns original layout if overlap < 50% of dragged area", () => {
+    const layout = [
+      makeItem({ i: "dragged", x: 0, y: 0, w: 20, h: 10 }),
+      makeItem({ i: "target", x: 19, y: 0, w: 20, h: 10 }),
+    ];
+    // Overlap = 1 * 10 = 10, dragged area = 200, 10 < 100 (50%)
+    const result = computeSwapDuringDrag(layout, "dragged", { x: 0, y: 0 }, null);
+    expect(result.swappedId).toBeNull();
+  });
+
+  it("swaps target to drag origin when overlap >= 50%", () => {
+    const layout = [
+      makeItem({ i: "dragged", x: 5, y: 0, w: 20, h: 10 }),
+      makeItem({ i: "target", x: 10, y: 0, w: 20, h: 10 }),
+    ];
+    // Overlap = 15 * 10 = 150, dragged area = 200, 150 >= 100
+    const result = computeSwapDuringDrag(layout, "dragged", { x: 0, y: 0 }, null);
+    expect(result.swappedId).toBe("target");
+    const target = result.layout.find((item) => item.i === "target")!;
+    expect(target.x).toBe(0);
+    expect(target.y).toBe(0);
+  });
+
+  it("skips swap if target is same as lastSwappedId", () => {
+    const layout = [
+      makeItem({ i: "dragged", x: 5, y: 0, w: 20, h: 10 }),
+      makeItem({ i: "target", x: 10, y: 0, w: 20, h: 10 }),
+    ];
+    const result = computeSwapDuringDrag(layout, "dragged", { x: 0, y: 0 }, "target");
+    expect(result.swappedId).toBe("target");
+    // Layout should be unchanged (no swap)
+    expect(result.layout).toBe(layout);
+  });
+
+  it("resolves secondary collisions after swap", () => {
+    const layout = [
+      makeItem({ i: "dragged", x: 60, y: 0, w: 30, h: 20 }),
+      makeItem({ i: "target", x: 70, y: 0, w: 30, h: 20 }),
+      makeItem({ i: "bystander", x: 0, y: 0, w: 30, h: 20 }),
+    ];
+    const result = computeSwapDuringDrag(layout, "dragged", { x: 0, y: 0 }, null);
+    expect(result.swappedId).toBe("target");
+
+    // After swap, target moves to (0,0) which may collide with bystander
+    // resolveOverlaps should fix that
+    const nonDragged = result.layout.filter((item) => item.i !== "dragged");
+    assertNoOverlaps(nonDragged);
+  });
+});

--- a/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.ts
+++ b/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.ts
@@ -120,9 +120,15 @@ const greedyFixup = (items: GridLayout.Layout[]): void => {
     const overlapX = Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x);
     const overlapY = Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y);
 
+    // 1. Try pushing apart along the shorter overlap axis
     if (overlapX <= overlapY && tryPushX(items, worstI, worstJ)) {
       continue;
     }
+    // 2. If X-push blocked by boundary, try swapping positions
+    if (trySwap(items, worstI, worstJ)) {
+      continue;
+    }
+    // 3. Last resort: push apart along Y (always succeeds)
     pushY(items, worstI, worstJ);
   }
 };
@@ -154,6 +160,42 @@ const tryPushX = (
     return true;
   }
   return false;
+};
+
+/**
+ * Try swapping two items' positions to resolve overlap.
+ * Useful when one item is stuck at a boundary — trading places puts
+ * the smaller item at the edge and the larger item in the open space.
+ * Returns false if swapping doesn't resolve the overlap or violates bounds.
+ */
+const trySwap = (
+  items: GridLayout.Layout[],
+  i: number,
+  j: number,
+): boolean => {
+  const a = items[i];
+  const b = items[j];
+
+  const newAx = b.x;
+  const newAy = b.y;
+  const newBx = a.x;
+  const newBy = a.y;
+
+  // Check bounds after swap
+  if (newAx < 0 || newAx + a.w > GRID_COLS) return false;
+  if (newBx < 0 || newBx + b.w > GRID_COLS) return false;
+  if (newAy < 0 || newBy < 0) return false;
+
+  // Check if swap actually resolves the overlap between these two items
+  const oxAfter =
+    Math.min(newAx + a.w, newBx + b.w) - Math.max(newAx, newBx);
+  const oyAfter =
+    Math.min(newAy + a.h, newBy + b.h) - Math.max(newAy, newBy);
+  if (oxAfter > 0 && oyAfter > 0) return false;
+
+  items[i] = { ...a, x: newAx, y: newAy };
+  items[j] = { ...b, x: newBx, y: newBy };
+  return true;
 };
 
 /** Push two items apart along Y (always succeeds — grid scrolls vertically). */

--- a/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.ts
+++ b/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.ts
@@ -1,18 +1,30 @@
 import GridLayout from "react-grid-layout";
+import {
+  Constraint,
+  Rectangle,
+  Solver,
+  Variable,
+  generateXConstraints,
+  generateYConstraints,
+} from "webcola";
+
+/** Number of grid columns for the desktop multiview layout. */
+export const GRID_COLS = 120;
+
+/** Weight for VPSC boundary variables — high enough to pin boundaries in place. */
+const BOUNDARY_WEIGHT = 1e8;
 
 /**
- * Resolve all overlaps among items on an integer grid.
+ * Resolve all overlaps among items on an integer grid using VPSC (webcola).
  *
- * Algorithm:
- * 1. Find the pair with the largest overlap area
- * 2. Push them apart along the axis with the smaller overlap (minimum movement)
- * 3. **Restart the full pairwise search from the beginning** (pushing may create new overlaps)
- * 4. Repeat until no overlaps remain (max n*(n-1)/2 * 10 iterations)
+ * Uses webcola's VPSC solver with boundary constraints for the bulk of the work,
+ * then applies a greedy fixup for edge cases that webcola's scan-line misses
+ * (e.g., items with identical centers on the scan axis).
  *
- * Each push resolves exactly one pair's overlap, so convergence is guaranteed in finite steps.
- *
+ * @precondition layout items have positive w and h
+ * @postcondition No pairwise overlaps; x in [0, GRID_COLS-w], y >= 0
  * @param layout - Current layout (integer grid coordinates)
- * @returns Layout with no overlaps
+ * @returns Layout with no overlaps, positions adjusted minimally from originals
  */
 export const resolveOverlaps = (
   layout: GridLayout.Layout[],
@@ -20,22 +32,73 @@ export const resolveOverlaps = (
   if (layout.length <= 1) return layout;
 
   const items = layout.map((item) => ({ ...item }));
-  const maxIterations = items.length * items.length * 10;
+  solveWithVpsc(items);
+  greedyFixup(items);
+  return items;
+};
 
-  for (let iter = 0; iter < maxIterations; iter++) {
-    // Find the overlapping pair with the largest overlap area
+/**
+ * VPSC-based overlap removal with boundary constraints.
+ * Mutates items' x/y in place.
+ */
+const solveWithVpsc = (items: GridLayout.Layout[]): void => {
+  const rects = items.map(
+    (item) =>
+      new Rectangle(item.x, item.x + item.w, item.y, item.y + item.h),
+  );
+
+  const xVars = rects.map((r) => new Variable(r.cx()));
+  const xCs = generateXConstraints(rects, xVars);
+  const leftBound = new Variable(0, BOUNDARY_WEIGHT);
+  const rightBound = new Variable(GRID_COLS, BOUNDARY_WEIGHT);
+  for (let i = 0; i < rects.length; i++) {
+    const halfW = rects[i].width() / 2;
+    xCs.push(new Constraint(leftBound, xVars[i], halfW));
+    xCs.push(new Constraint(xVars[i], rightBound, halfW));
+  }
+  new Solver([...xVars, leftBound, rightBound], xCs).solve();
+  xVars.forEach((v, i) => rects[i].setXCentre(v.position()));
+
+  const yVars = rects.map((r) => new Variable(r.cy()));
+  const yCs = generateYConstraints(rects, yVars);
+  const topBound = new Variable(0, BOUNDARY_WEIGHT);
+  for (let i = 0; i < rects.length; i++) {
+    const halfH = rects[i].height() / 2;
+    yCs.push(new Constraint(topBound, yVars[i], halfH));
+  }
+  new Solver([...yVars, topBound], yCs).solve();
+  yVars.forEach((v, i) => rects[i].setYCentre(v.position()));
+
+  for (let i = 0; i < items.length; i++) {
+    const r = rects[i];
+    items[i] = {
+      ...items[i],
+      x: Math.max(0, Math.min(GRID_COLS - items[i].w, Math.round(r.x))),
+      y: Math.max(0, Math.round(r.y)),
+    };
+  }
+};
+
+/**
+ * Greedy fixup for remaining overlaps after VPSC.
+ *
+ * Handles edge cases that webcola's scan-line algorithm misses (items with
+ * identical centers, rounding artifacts). Pushes apart along the shorter
+ * overlap axis, respecting grid boundaries.
+ *
+ * Mutates items' x/y in place.
+ */
+const greedyFixup = (items: GridLayout.Layout[]): void => {
+  const maxIter = items.length * items.length * 2;
+
+  for (let iter = 0; iter < maxIter; iter++) {
     let worstI = -1;
     let worstJ = -1;
     let worstArea = 0;
 
     for (let i = 0; i < items.length; i++) {
       for (let j = i + 1; j < items.length; j++) {
-        const a = items[i];
-        const b = items[j];
-        const ox = Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x);
-        const oy = Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y);
-        if (ox <= 0 || oy <= 0) continue;
-        const area = ox * oy;
+        const area = getOverlapArea(items[i], items[j]);
         if (area > worstArea) {
           worstArea = area;
           worstI = i;
@@ -44,7 +107,6 @@ export const resolveOverlaps = (
       }
     }
 
-    // No overlaps found — done
     if (worstI < 0) break;
 
     const a = items[worstI];
@@ -52,31 +114,51 @@ export const resolveOverlaps = (
     const overlapX = Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x);
     const overlapY = Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y);
 
-    // Push apart on the axis with smaller overlap (minimum movement)
-    if (overlapX <= overlapY) {
-      const aCx = a.x + a.w / 2;
-      const bCx = b.x + b.w / 2;
-      if (aCx <= bCx) {
-        items[worstJ] = { ...b, x: a.x + a.w };
-      } else {
-        items[worstI] = { ...a, x: b.x + b.w };
-      }
-    } else {
-      const aCy = a.y + a.h / 2;
-      const bCy = b.y + b.h / 2;
-      if (aCy <= bCy) {
-        items[worstJ] = { ...b, y: a.y + a.h };
-      } else {
-        items[worstI] = { ...a, y: b.y + b.h };
-      }
+    if (overlapX <= overlapY && tryPushX(items, worstI, worstJ)) {
+      continue;
     }
+    pushY(items, worstI, worstJ);
   }
+};
 
-  return items.map((item) => ({
-    ...item,
-    x: Math.max(0, item.x),
-    y: Math.max(0, item.y),
-  }));
+/**
+ * Try to push two overlapping items apart along X.
+ * Returns false if blocked by grid boundaries on both sides.
+ */
+const tryPushX = (
+  items: GridLayout.Layout[],
+  i: number,
+  j: number,
+): boolean => {
+  const a = items[i];
+  const b = items[j];
+  const aIsLeft = a.x + a.w / 2 <= b.x + b.w / 2;
+  const [leftIdx, rightIdx] = aIsLeft ? [i, j] : [j, i];
+  const left = items[leftIdx];
+  const right = items[rightIdx];
+
+  const targetX = left.x + left.w;
+  if (targetX + right.w <= GRID_COLS) {
+    items[rightIdx] = { ...right, x: targetX };
+    return true;
+  }
+  const targetLeftX = right.x - left.w;
+  if (targetLeftX >= 0) {
+    items[leftIdx] = { ...left, x: targetLeftX };
+    return true;
+  }
+  return false;
+};
+
+/** Push two items apart along Y (always succeeds — grid scrolls vertically). */
+const pushY = (items: GridLayout.Layout[], i: number, j: number): void => {
+  const a = items[i];
+  const b = items[j];
+  if (a.y + a.h / 2 <= b.y + b.h / 2) {
+    items[j] = { ...b, y: a.y + a.h };
+  } else {
+    items[i] = { ...a, y: b.y + b.h };
+  }
 };
 
 /**

--- a/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.ts
+++ b/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.ts
@@ -29,7 +29,13 @@ const BOUNDARY_WEIGHT = 1e8;
 export const resolveOverlaps = (
   layout: GridLayout.Layout[],
 ): GridLayout.Layout[] => {
-  if (layout.length <= 1) return layout;
+  if (layout.length <= 1) {
+    return layout.map((item) => ({
+      ...item,
+      x: Math.max(0, Math.min(GRID_COLS - item.w, item.x)),
+      y: Math.max(0, item.y),
+    }));
+  }
 
   const items = layout.map((item) => ({ ...item }));
   solveWithVpsc(items);

--- a/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.ts
+++ b/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.ts
@@ -17,9 +17,10 @@ const BOUNDARY_WEIGHT = 1e8;
 /**
  * Resolve all overlaps among items on an integer grid using VPSC (webcola).
  *
- * Uses webcola's VPSC solver with boundary constraints for the bulk of the work,
- * then applies a greedy fixup for edge cases that webcola's scan-line misses
- * (e.g., items with identical centers on the scan axis).
+ * Two-phase approach:
+ * 1. VPSC (webcola) — scan-line constraint generation + supplemental O(n²) pass
+ *    for pairs the scan-line misses, solved with boundary constraints
+ * 2. Lightweight fixup — resolves residual overlaps from integer rounding
  *
  * @precondition layout items have positive w and h
  * @postcondition No pairwise overlaps; x in [0, GRID_COLS-w], y >= 0
@@ -39,25 +40,33 @@ export const resolveOverlaps = (
 
   const items = layout.map((item) => ({ ...item }));
   solveWithVpsc(items);
-  greedyFixup(items);
+  roundingFixup(items);
   return items;
 };
 
 /**
  * VPSC-based overlap removal with boundary constraints.
+ *
+ * Uses webcola's scan-line constraint generation as the base, then supplements
+ * with an O(n²) pass to add constraints for any overlapping pairs that the
+ * scan-line missed (e.g. items with identical centers or where X overlap > Y overlap).
+ *
  * Mutates items' x/y in place.
  */
 const solveWithVpsc = (items: GridLayout.Layout[]): void => {
+  const n = items.length;
   const rects = items.map(
     (item) =>
       new Rectangle(item.x, item.x + item.w, item.y, item.y + item.h),
   );
 
+  // --- X-pass ---
   const xVars = rects.map((r) => new Variable(r.cx()));
   const xCs = generateXConstraints(rects, xVars);
+  supplementConstraints(rects, xVars, xCs, "x");
   const leftBound = new Variable(0, BOUNDARY_WEIGHT);
   const rightBound = new Variable(GRID_COLS, BOUNDARY_WEIGHT);
-  for (let i = 0; i < rects.length; i++) {
+  for (let i = 0; i < n; i++) {
     const halfW = rects[i].width() / 2;
     xCs.push(new Constraint(leftBound, xVars[i], halfW));
     xCs.push(new Constraint(xVars[i], rightBound, halfW));
@@ -65,17 +74,20 @@ const solveWithVpsc = (items: GridLayout.Layout[]): void => {
   new Solver([...xVars, leftBound, rightBound], xCs).solve();
   xVars.forEach((v, i) => rects[i].setXCentre(v.position()));
 
+  // --- Y-pass (uses updated X positions) ---
   const yVars = rects.map((r) => new Variable(r.cy()));
   const yCs = generateYConstraints(rects, yVars);
+  supplementConstraints(rects, yVars, yCs, "y");
   const topBound = new Variable(0, BOUNDARY_WEIGHT);
-  for (let i = 0; i < rects.length; i++) {
+  for (let i = 0; i < n; i++) {
     const halfH = rects[i].height() / 2;
     yCs.push(new Constraint(topBound, yVars[i], halfH));
   }
   new Solver([...yVars, topBound], yCs).solve();
   yVars.forEach((v, i) => rects[i].setYCentre(v.position()));
 
-  for (let i = 0; i < items.length; i++) {
+  // --- Write back ---
+  for (let i = 0; i < n; i++) {
     const r = rects[i];
     items[i] = {
       ...items[i],
@@ -86,126 +98,119 @@ const solveWithVpsc = (items: GridLayout.Layout[]): void => {
 };
 
 /**
- * Greedy fixup for remaining overlaps after VPSC.
+ * Add separation constraints for overlapping pairs not already covered.
  *
- * Handles edge cases that webcola's scan-line algorithm misses (items with
- * identical centers, rounding artifacts). Pushes apart along the shorter
- * overlap axis, respecting grid boundaries.
+ * webcola's scan-line can miss pairs where:
+ * - Items share the same center on the scan axis
+ * - X overlap > Y overlap (skipped by X-pass, but Y-pass scan-line may also miss)
+ *
+ * This performs an O(n²) check and adds constraints only for uncovered pairs.
+ */
+const supplementConstraints = (
+  rects: Rectangle[],
+  vars: Variable[],
+  existing: Constraint[],
+  axis: "x" | "y",
+): void => {
+  const n = rects.length;
+
+  // Build a set of pairs already constrained (in either direction)
+  const covered = new Set<string>();
+  for (const c of existing) {
+    const li = vars.indexOf(c.left);
+    const ri = vars.indexOf(c.right);
+    if (li >= 0 && ri >= 0) {
+      covered.add(`${Math.min(li, ri)},${Math.max(li, ri)}`);
+    }
+  }
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      if (covered.has(`${i},${j}`)) continue;
+
+      const a = rects[i];
+      const b = rects[j];
+      const ox = Math.min(a.X, b.X) - Math.max(a.x, b.x);
+      const oy = Math.min(a.Y, b.Y) - Math.max(a.y, b.y);
+      if (ox <= 0 || oy <= 0) continue;
+
+      // For X-pass: only add if X separation is preferred (ox <= oy)
+      // For Y-pass: add for any remaining overlap (X-pass already ran)
+      if (axis === "x" && ox > oy) continue;
+
+      const size =
+        axis === "x"
+          ? (a.width() + b.width()) / 2
+          : (a.height() + b.height()) / 2;
+      const aCenter = axis === "x" ? a.cx() : a.cy();
+      const bCenter = axis === "x" ? b.cx() : b.cy();
+
+      if (aCenter <= bCenter) {
+        existing.push(new Constraint(vars[i], vars[j], size + 1e-6));
+      } else {
+        existing.push(new Constraint(vars[j], vars[i], size + 1e-6));
+      }
+    }
+  }
+};
+
+/**
+ * Lightweight fixup for integer rounding artifacts.
+ *
+ * After VPSC + rounding, at most 1-2 pairs may overlap by 1 unit.
+ * Resolves by pushing/swapping, bounded to O(n²) iterations.
  *
  * Mutates items' x/y in place.
  */
-const greedyFixup = (items: GridLayout.Layout[]): void => {
-  const maxIter = items.length * items.length * 2;
+const roundingFixup = (items: GridLayout.Layout[]): void => {
+  const maxIter = items.length * 2;
 
   for (let iter = 0; iter < maxIter; iter++) {
-    let worstI = -1;
-    let worstJ = -1;
-    let worstArea = 0;
+    let found = false;
 
-    for (let i = 0; i < items.length; i++) {
-      for (let j = i + 1; j < items.length; j++) {
-        const area = getOverlapArea(items[i], items[j]);
-        if (area > worstArea) {
-          worstArea = area;
-          worstI = i;
-          worstJ = j;
+    for (let i = 0; i < items.length && !found; i++) {
+      for (let j = i + 1; j < items.length && !found; j++) {
+        if (getOverlapArea(items[i], items[j]) === 0) continue;
+        found = true;
+
+        const a = items[i];
+        const b = items[j];
+        const overlapX =
+          Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x);
+        const overlapY =
+          Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y);
+
+        if (overlapX <= overlapY) {
+          // Push apart in X
+          const aIsLeft = a.x + a.w / 2 <= b.x + b.w / 2;
+          const [li, ri] = aIsLeft ? [i, j] : [j, i];
+          const left = items[li];
+          const right = items[ri];
+          const targetX = left.x + left.w;
+          if (targetX + right.w <= GRID_COLS) {
+            items[ri] = { ...right, x: targetX };
+          } else if (right.x - left.w >= 0) {
+            items[li] = { ...left, x: right.x - left.w };
+          } else {
+            // X blocked — push Y
+            if (a.y <= b.y) {
+              items[j] = { ...b, y: a.y + a.h };
+            } else {
+              items[i] = { ...a, y: b.y + b.h };
+            }
+          }
+        } else {
+          // Push apart in Y
+          if (a.y + a.h / 2 <= b.y + b.h / 2) {
+            items[j] = { ...b, y: a.y + a.h };
+          } else {
+            items[i] = { ...a, y: b.y + b.h };
+          }
         }
       }
     }
 
-    if (worstI < 0) break;
-
-    const a = items[worstI];
-    const b = items[worstJ];
-    const overlapX = Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x);
-    const overlapY = Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y);
-
-    // 1. Try pushing apart along the shorter overlap axis
-    if (overlapX <= overlapY && tryPushX(items, worstI, worstJ)) {
-      continue;
-    }
-    // 2. If X-push blocked by boundary, try swapping positions
-    if (trySwap(items, worstI, worstJ)) {
-      continue;
-    }
-    // 3. Last resort: push apart along Y (always succeeds)
-    pushY(items, worstI, worstJ);
-  }
-};
-
-/**
- * Try to push two overlapping items apart along X.
- * Returns false if blocked by grid boundaries on both sides.
- */
-const tryPushX = (
-  items: GridLayout.Layout[],
-  i: number,
-  j: number,
-): boolean => {
-  const a = items[i];
-  const b = items[j];
-  const aIsLeft = a.x + a.w / 2 <= b.x + b.w / 2;
-  const [leftIdx, rightIdx] = aIsLeft ? [i, j] : [j, i];
-  const left = items[leftIdx];
-  const right = items[rightIdx];
-
-  const targetX = left.x + left.w;
-  if (targetX + right.w <= GRID_COLS) {
-    items[rightIdx] = { ...right, x: targetX };
-    return true;
-  }
-  const targetLeftX = right.x - left.w;
-  if (targetLeftX >= 0) {
-    items[leftIdx] = { ...left, x: targetLeftX };
-    return true;
-  }
-  return false;
-};
-
-/**
- * Try swapping two items' positions to resolve overlap.
- * Useful when one item is stuck at a boundary — trading places puts
- * the smaller item at the edge and the larger item in the open space.
- * Returns false if swapping doesn't resolve the overlap or violates bounds.
- */
-const trySwap = (
-  items: GridLayout.Layout[],
-  i: number,
-  j: number,
-): boolean => {
-  const a = items[i];
-  const b = items[j];
-
-  const newAx = b.x;
-  const newAy = b.y;
-  const newBx = a.x;
-  const newBy = a.y;
-
-  // Check bounds after swap
-  if (newAx < 0 || newAx + a.w > GRID_COLS) return false;
-  if (newBx < 0 || newBx + b.w > GRID_COLS) return false;
-  if (newAy < 0 || newBy < 0) return false;
-
-  // Check if swap actually resolves the overlap between these two items
-  const oxAfter =
-    Math.min(newAx + a.w, newBx + b.w) - Math.max(newAx, newBx);
-  const oyAfter =
-    Math.min(newAy + a.h, newBy + b.h) - Math.max(newAy, newBy);
-  if (oxAfter > 0 && oyAfter > 0) return false;
-
-  items[i] = { ...a, x: newAx, y: newAy };
-  items[j] = { ...b, x: newBx, y: newBy };
-  return true;
-};
-
-/** Push two items apart along Y (always succeeds — grid scrolls vertically). */
-const pushY = (items: GridLayout.Layout[], i: number, j: number): void => {
-  const a = items[i];
-  const b = items[j];
-  if (a.y + a.h / 2 <= b.y + b.h / 2) {
-    items[j] = { ...b, y: a.y + a.h };
-  } else {
-    items[i] = { ...a, y: b.y + b.h };
+    if (!found) break;
   }
 };
 

--- a/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.ts
+++ b/service/vspo-schedule/v2/web/src/features/multiview/utils/gridSwap.ts
@@ -114,12 +114,14 @@ const supplementConstraints = (
 ): void => {
   const n = rects.length;
 
-  // Build a set of pairs already constrained (in either direction)
+  const varIndex = new Map<Variable, number>();
+  for (let i = 0; i < vars.length; i++) varIndex.set(vars[i], i);
+
   const covered = new Set<string>();
   for (const c of existing) {
-    const li = vars.indexOf(c.left);
-    const ri = vars.indexOf(c.right);
-    if (li >= 0 && ri >= 0) {
+    const li = varIndex.get(c.left);
+    const ri = varIndex.get(c.right);
+    if (li !== undefined && ri !== undefined) {
       covered.add(`${Math.min(li, ri)},${Math.max(li, ri)}`);
     }
   }

--- a/service/vspo-schedule/v2/web/src/features/multiview/utils/index.ts
+++ b/service/vspo-schedule/v2/web/src/features/multiview/utils/index.ts
@@ -1,3 +1,3 @@
-// Re-export theme utilities
+// Re-export multiview utilities
 export { scaledBorderRadius } from "./theme";
 export { GRID_COLS, getOverlapArea, computeSwapDuringDrag, resolveOverlaps } from "./gridSwap";

--- a/service/vspo-schedule/v2/web/src/features/multiview/utils/index.ts
+++ b/service/vspo-schedule/v2/web/src/features/multiview/utils/index.ts
@@ -1,3 +1,3 @@
 // Re-export theme utilities
 export { scaledBorderRadius } from "./theme";
-export { getOverlapArea, computeSwapDuringDrag, resolveOverlaps } from "./gridSwap";
+export { GRID_COLS, getOverlapArea, computeSwapDuringDrag, resolveOverlaps } from "./gridSwap";


### PR DESCRIPTION
## Summary
- multiview グリッドの `resolveOverlaps` を webcola の VPSC ソルバーに置き換え。全分離制約を同時に解くことで、貪欲法のカスケード問題（A-B を直すと B-C が重なる）を解消
- グリッド境界制約（x ∈ [0, 120], y ≥ 0）を VPSC の変数として組み込み、アイテムがグリッド外に押し出されることを防止
- webcola のスキャンラインが見逃すエッジケース（同一中心のアイテム等）に対する greedy fixup を後段に配置するハイブリッド構成
- `GRID_COLS` 定数を `gridSwap.ts` に一元化し、`MultiviewGridPresenter.tsx` のローカル定義を削除
- `gridSwap.test.ts` を新規追加（25テスト: resolveOverlaps, computeSwapDuringDrag, getOverlapArea）

## Test plan
- [x] `vitest run` — 全140テスト合格
- [ ] マルチビューページでストリーム追加/削除時の配置確認
- [ ] ドラッグ停止後に重なりが解消されることを確認
- [ ] リサイズ停止後に重なりが解消されることを確認
- [ ] カスタムレイアウト復元時の重なり解消確認
- [ ] 12アイテム配置時にグリッド境界内に収まることを確認