### PR TITLE
fix(bot-dashboard): use Discord user locale instead of browser Accept-Language

### DIFF
--- a/service/bot-dashboard/src/env.d.ts
+++ b/service/bot-dashboard/src/env.d.ts
@@ -24,6 +24,7 @@ declare namespace App {
     refreshToken: string;
     expiresAt: number;
     oauth_state: string;
+    locale: import("~/i18n/dict").Locale;
   }
   interface Locals {
     user: SessionData["user"] | null;

--- a/service/bot-dashboard/src/features/auth/repository/discord-api.ts
+++ b/service/bot-dashboard/src/features/auth/repository/discord-api.ts
@@ -23,6 +23,7 @@ const DiscordApiUserSchema = z.object({
   username: z.string(),
   global_name: z.string().nullable().optional(),
   avatar: z.string().nullable(),
+  locale: z.string().optional(),
 });
 
 type DiscordApiUser = z.infer<typeof DiscordApiUserSchema>;
@@ -121,6 +122,7 @@ const DiscordApiRepository = {
         username: "dev-user",
         global_name: "Dev User",
         avatar: null,
+        locale: "ja",
       });
     }
 

--- a/service/bot-dashboard/src/features/auth/usecase/login.test.ts
+++ b/service/bot-dashboard/src/features/auth/usecase/login.test.ts
@@ -60,6 +60,7 @@ describe("LoginUsecase", () => {
       username: "testuser",
       global_name: "Test User",
       avatar: "abc123",
+      locale: "ja",
     };
 
     it("returns LoginResult on success", async () => {

--- a/service/bot-dashboard/src/features/auth/usecase/login.ts
+++ b/service/bot-dashboard/src/features/auth/usecase/login.ts
@@ -22,6 +22,7 @@ const LoginResultSchema = z.object({
   accessToken: z.string(),
   refreshToken: z.string(),
   expiresAt: z.number(),
+  locale: z.string().optional(),
 });
 
 type LoginResult = z.infer<typeof LoginResultSchema>;
@@ -82,6 +83,7 @@ const handleCallback = async (
     accessToken: tokenResult.val.access_token,
     refreshToken: tokenResult.val.refresh_token,
     expiresAt: Date.now() + tokenResult.val.expires_in * 1000,
+    locale: userResult.val.locale,
   });
 };
 

--- a/service/bot-dashboard/src/middleware.ts
+++ b/service/bot-dashboard/src/middleware.ts
@@ -9,7 +9,8 @@ const MOCK_USER = {
 } as const;
 
 export const onRequest = defineMiddleware(async (context, next) => {
-  context.locals.locale = context.preferredLocale === "en" ? "en" : "ja";
+  const sessionLocale = await context.session?.get("locale");
+  context.locals.locale = sessionLocale ?? "ja";
 
   const devMockAuth = (env as unknown as Record<string, unknown>).DEV_MOCK_AUTH;
   if (devMockAuth === "true" && import.meta.env.DEV) {

--- a/service/bot-dashboard/src/pages/auth/callback.ts
+++ b/service/bot-dashboard/src/pages/auth/callback.ts
@@ -32,7 +32,7 @@ export const GET: APIRoute = async (context) => {
     return context.redirect("/?error=auth_failed");
   }
 
-  const { user, accessToken, refreshToken, expiresAt } = result.val;
+  const { user, accessToken, refreshToken, expiresAt, locale } = result.val;
   context.session?.set("user", {
     id: user.id,
     username: user.username,
@@ -42,6 +42,7 @@ export const GET: APIRoute = async (context) => {
   context.session?.set("accessToken", accessToken);
   context.session?.set("refreshToken", refreshToken);
   context.session?.set("expiresAt", expiresAt);
+  context.session?.set("locale", locale?.startsWith("en") ? "en" : "ja");
 
   return context.redirect("/dashboard");
 };


### PR DESCRIPTION
## Summary

- Discord APIの `/users/@me` レスポンスから `locale` フィールドを取得し、セッションに保存するように変更
- ミドルウェアのlocale判定をブラウザの `Accept-Language`（`preferredLocale`）からセッション保存のDiscordユーザーlocaleに変更
- 未ログインユーザーはデフォルト `"ja"`、ログインユーザーはDiscordの言語設定に従う（`en-*` → `"en"`, それ以外 → `"ja"`）