### PR TITLE
docs: sync docs with implementation and fix wrangler version

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get deployed URL
         id: get-url
-        run: echo "url=https://dev-bot-dashboard-storybook.$(echo ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} | head -c 8).workers.dev" >> "$GITHUB_OUTPUT"
+        run: echo "url=https://storybook-bot.vspo-schedule.com" >> "$GITHUB_OUTPUT"
 
   deploy-vspo-schedule-storybook:
     name: Build & Deploy vspo-schedule Storybook

--- a/.github/workflows/deploy-web-workers.yaml
+++ b/.github/workflows/deploy-web-workers.yaml
@@ -28,7 +28,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: pnpm
-          wranglerVersion: "4.6.0"
+          wranglerVersion: "4.76.0"
           workingDirectory: service/vspo-schedule/v2/web/config/wrangler/${{ github.ref == 'refs/heads/main' && 'prd' || 'dev' }}
           command: deploy
           preCommands: |

--- a/docs/design/design-patterns.md
+++ b/docs/design/design-patterns.md
@@ -74,10 +74,8 @@ Core: passive recognition, proximity display, screen reader support.
 
 | Pattern | Component | When |
 |---------|-----------|------|
-| Modal dialog | Dialog | Small-medium forms |
-| Full-page | FloatArea | Large information |
-| Drawer | Drawer | Maintain context |
-| Step-based | StepFormDialog | Multi-step operations |
+| Modal dialog | MUI `Dialog` | Small-medium forms (e.g., `DateSearchDialog`) |
+| Drawer | MUI `Drawer` | Side panels, navigation, maintaining context |
 
 **Avoid disabling submit buttons** -- let users press the button, then show error feedback.
 

--- a/docs/design/design-tokens.md
+++ b/docs/design/design-tokens.md
@@ -1,90 +1,67 @@
 # Design Tokens
 
-## Token Architecture
+## Token Architecture (vspo-schedule)
 
-3-layer structure: `Base Palette -> Semantic Tokens -> Component Tokens`
+The main application (`service/vspo-schedule/v2/web`) uses MUI's `createTheme` with the `cssVariables` option. Colors, shadows, and shape values are defined in the MUI theme object and accessed via `theme.*` or MUI's `sx` prop -- there is no separate CSS custom-property layer or OKLch color format.
 
-1. **Base Palette** (`--palette-*`): Raw color values in [OKLch format](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch) -- `oklch(L C H / A)`
-2. **Semantic Tokens** (`--token-*`): Intent-based aliases
-3. **Component Tokens** (`--color-*`): Final values consumed by MUI/Emotion
+### Theme Definition
 
-## Color Tokens
+Source: `service/vspo-schedule/v2/web/src/context/Theme.tsx`
 
-### Base Palette
-
-```css
-/* Neutral */
---palette-ink-900: oklch(...);     /* Dark text */
---palette-ink-800: oklch(...);     /* Soft text */
---palette-ink-500: oklch(...);     /* Muted text */
---palette-cream-50: oklch(...);    /* Background */
---palette-white: oklch(1 0 0);
-
-/* Accent & Status */
---palette-accent-100: oklch(...);
---palette-info-100: oklch(...);
---palette-warning-100: oklch(...);
---palette-success-100: oklch(...);
---palette-line: oklch(... / 0.3);
+```tsx
+const theme = createTheme({
+  cssVariables: { colorSchemeSelector: "class" },
+  colorSchemes: {
+    light: { palette: { customColors: { vspoPurple: "#7266cf", /* ... */ } } },
+    dark:  { palette: { customColors: { vspoPurple: "#7266cf", /* ... */ } } },
+  },
+  // mixins, component overrides, etc.
+});
 ```
 
-### Semantic -> Component mapping
+Key points:
 
-```css
-/* Semantic                          Component */
---token-canvas: var(--palette-cream-50);    --color-background: var(--token-canvas);
---token-surface: var(--palette-white);      --color-card: var(--token-surface);
---token-text: var(--palette-ink-900);       --color-foreground: var(--token-text);
---token-text-soft: var(--palette-ink-800);  --color-foreground-soft: var(--token-text-soft);
---token-text-muted: var(--palette-ink-500); --color-muted-foreground: var(--token-text-muted);
---token-accent: var(--palette-accent-100);  --color-accent: var(--token-accent);
---token-border: var(--palette-line);        --color-border: var(--token-border);
---token-info: var(--palette-info-100);      --color-info: var(--token-info);
---token-warning: var(--palette-warning-100);--color-warning: var(--token-warning);
---token-success: var(--palette-success-100);--color-success: var(--token-success);
-```
+- Light/dark mode is toggled via a CSS class selector (`colorSchemeSelector: "class"`).
+- Custom brand colors are placed under `palette.customColors`.
+- Component-level overrides (e.g., `MuiDrawer` scrollbar) live in `theme.components`.
 
-## Other Tokens
+### Color Tokens
 
-| Category | Tokens |
-|----------|--------|
-| **Radius** | `--radius-sm` (8px), `--radius-md` (14px), `--radius-lg` (20px), `--radius-xl` (24px), `--radius-2xl` (32px) |
-| **Shadow** | `--shadow-card`, `--shadow-action`, `--shadow-hero`, `--shadow-focus` |
-| **Motion** | `--duration-fast` (150ms), `--duration-md` (300ms), `--ease-standard` (cubic-bezier(0.2,0.7,0.2,1)) |
-| **Typography** | `--font-body` (body text), `--font-display` (headings) |
+Colors are provided by MUI's default palette plus the `customColors` extension:
+
+| Token path | Value | Purpose |
+|---|---|---|
+| `palette.customColors.vspoPurple` | `#7266cf` | Brand accent |
+| `palette.customColors.darkBlue` | `rgb(45, 75, 112)` | Secondary accent |
+| `palette.customColors.gray` | `#353535` | Neutral |
+| `palette.customColors.darkGray` | `#212121` | Dark neutral |
+| `palette.customColors.videoHighlight.live` | `red` | Live stream indicator |
+| `palette.customColors.videoHighlight.upcoming` | `rgb(45, 75, 112)` | Upcoming stream indicator |
+
+All other colors (background, text, divider, etc.) come from MUI's built-in light/dark palettes.
 
 ## Usage
 
 ```tsx
-// MUI sx prop (using theme.vars for light/dark mode compatibility)
+// MUI sx prop
 <Box sx={{ bgcolor: "background.default", color: "text.primary" }} />
 
 // Emotion styled() with theme access
 const Card = styled("div")(({ theme }) => ({
   backgroundColor: theme.vars.palette.background.paper,
   border: `1px solid ${theme.vars.palette.divider}`,
-  borderRadius: theme.shape.borderRadius * 2.5, // ~20px
+  borderRadius: theme.shape.borderRadius * 2.5,
   boxShadow: theme.shadows[1],
 }));
 ```
 
-## Naming Convention
-
-```text
---{layer}-{category}-{variant}
---palette-ink-900      (Base)
---token-text-soft      (Semantic)
---color-foreground     (Component)
-```
-
 ## Adding New Tokens
 
-1. Add value to `--palette-*`
-2. Create semantic alias `--token-*`
-3. Expose as `--color-*` if needed
-4. Document here
+1. Add the value to the MUI theme object in `Theme.tsx` (under `palette`, `shape`, `mixins`, etc.)
+2. For custom brand values, add under `palette.customColors`
+3. Document here
 
-**Prohibited**: hardcoded values, overriding existing tokens, raw color values in components.
+**Prohibited**: hardcoded color values in components -- always reference `theme.*` or MUI palette paths.
 
 ## References
 
@@ -104,7 +81,7 @@ The bot-dashboard (`service/bot-dashboard/src/app.css`) uses a simplified 2-laye
 1. **Semantic variables (`--sem-*`):** Light/dark mode values defined in `:root` and `.dark` CSS blocks
 2. **Utility binding (`--color-*`):** Tailwind CSS 4 `@theme inline` maps utility class names to `var(--sem-*)` references
 
-This differs from the 3-layer pattern (palette → semantic → component) described above. The simplification is intentional: the bot-dashboard has a smaller design surface and Tailwind CSS 4's `@theme inline` directive requires this indirection pattern.
+This differs from the MUI theme approach used in vspo-schedule. The bot-dashboard has a smaller design surface and uses Tailwind CSS 4's `@theme inline` directive, which requires this indirection pattern.
 
 ### Example
 

--- a/docs/infra/cloudflare-workers.md
+++ b/docs/infra/cloudflare-workers.md
@@ -74,7 +74,7 @@ Defined in `.github/workflows/deploy-web-workers.yaml`.
 
 1. Checkout code
 2. Setup pnpm (via composite action `.github/actions/setup-pnpm`)
-3. Deploy via `cloudflare/wrangler-action@v3.14.1` (Wrangler CLI v4.6.0)
+3. Deploy via `cloudflare/wrangler-action@v3.14.1` (Wrangler CLI v4.76.0)
    - `workingDirectory` is set to the env-specific wrangler config dir (`config/wrangler/{env}`)
    - `preCommands` copies config files to the web root so the build can find sources
 

--- a/docs/testing/integration-testing.md
+++ b/docs/testing/integration-testing.md
@@ -31,8 +31,12 @@
 
 ## Execution Commands
 
-- All: `pnpm test:integration`
-- Web: `pnpm --filter vspo-schedule-v2-web test:integration`
+There are no root-level test scripts. Tests are run per-package using the service-level scripts (`test`, `test:run`, `test:coverage`).
+
+- Watch mode: `pnpm --filter vspo-schedule-v2-web test`
+- Single run: `pnpm --filter vspo-schedule-v2-web test:run`
+- Coverage: `pnpm --filter vspo-schedule-v2-web test:coverage`
+- Bot dashboard: `pnpm --filter bot-dashboard test:run`
 
 ## References (Primary Sources)
 

--- a/docs/web-frontend/accessibility.md
+++ b/docs/web-frontend/accessibility.md
@@ -8,7 +8,7 @@ For the full specification, see [W3C WCAG 2.2](https://www.w3.org/TR/WCAG22/).
 
 ## Table of Contents
 
-1. [React Aria](#react-aria)
+1. [Accessibility Foundation](#accessibility-foundation)
 2. [Current State Analysis](#current-state-analysis)
 3. [Implementation Guidelines](#implementation-guidelines)
 4. [Component-Specific Requirements](#component-specific-requirements)
@@ -16,321 +16,25 @@ For the full specification, see [W3C WCAG 2.2](https://www.w3.org/TR/WCAG22/).
 
 ---
 
-**Note on code examples**: React Aria examples below use utility class names (e.g., `text-sm`, `rounded-full`) for brevity. In this project, implement equivalent styles using MUI `sx` prop or Emotion `styled()` per [Styling Guide](./styling.md).
+## Accessibility Foundation
 
-## React Aria
+This project relies on **MUI (Material UI) components** for its accessibility foundation. MUI components provide built-in ARIA attributes, keyboard interaction, and focus management out of the box.
 
-This project uses **React Aria** for accessibility support.
+### MUI Built-in Accessibility
 
-### What is React Aria
+MUI components used in this project include accessibility features by default:
 
-[React Aria](https://react-spectrum.adobe.com/react-aria/) is an accessible UI component library developed by Adobe. It provides over 50 components and hooks with built-in:
+- **`Button`**: Keyboard-focusable, `Enter`/`Space` activation, focus-visible styles
+- **`Tabs`**: Arrow key navigation, `role="tablist"` / `role="tab"`, `aria-selected`
+- **`Dialog` / `Modal`**: Focus trapping, `Escape` to close, `role="dialog"`, `aria-modal`
+- **`TextField`**: Label association via `InputLabel`, `aria-describedby` for helper/error text
+- **`Select`**: Keyboard navigation, `role="combobox"`, `aria-expanded`
+- **`IconButton`**: Supports `aria-label` for icon-only buttons
+- **`Tooltip`**: `aria-describedby` linking, keyboard-accessible
 
-- **Accessibility**: WCAG-compliant ARIA attributes, focus management, keyboard interaction
-- **Internationalization**: RTL, date/number formatting, translation support
-- **Adaptive interactions**: Mouse, touch, keyboard, screen reader support
-- **Style freedom**: Compatible with any styling solution (this project uses MUI + Emotion)
+### Styling with `sx` Prop
 
-### Installation
-
-```bash
-pnpm add react-aria-components
-```
-
-### Components to Use
-
-| Component | Usage | Replaces |
-|-----------|-------|----------|
-| `Button` | Buttons | Custom Button |
-| `TextField` | Text input | Custom Input |
-| `Select` | Select box | Custom Select |
-| `Modal` / `Dialog` | Modals | InterruptReasonModal, SurveyModal |
-| `Form` | Forms | HTML forms |
-| `RadioGroup` | Radio button groups | Custom implementation |
-| `Checkbox` | Checkboxes | Custom implementation |
-| `ProgressBar` | Progress display | Custom implementation |
-
-### Implementation Examples
-
-#### Button
-
-```tsx
-import { Button } from "react-aria-components";
-
-export function PrimaryButton({ children, ...props }: ButtonProps) {
-  return (
-    <Button
-      className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center
-                 rounded-full bg-primary px-6 py-3 font-semibold text-white
-                 transition duration-fast ease-standard
-                 hover:bg-primary/90
-                 focus-visible:outline-none focus-visible:ring-2
-                 focus-visible:ring-ring focus-visible:ring-offset-2
-                 disabled:opacity-60 disabled:cursor-not-allowed"
-      {...props}
-    >
-      {children}
-    </Button>
-  );
-}
-```
-
-#### TextField (Input)
-
-```tsx
-import { TextField, Label, Input, FieldError, Text } from "react-aria-components";
-
-type TextFieldProps = {
-  label: string;
-  description?: string;
-  errorMessage?: string;
-  isRequired?: boolean;
-};
-
-export function FormTextField({ label, description, errorMessage, isRequired, ...props }: TextFieldProps) {
-  return (
-    <TextField isRequired={isRequired} {...props}>
-      <Label className="font-medium text-sm">
-        {label}
-        {isRequired && <span className="text-error ml-1">*</span>}
-      </Label>
-      <Input
-        className="mt-1 w-full rounded-2xl border bg-card px-4 py-3 text-sm
-                   transition duration-fast ease-standard
-                   focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
-                   invalid:border-error"
-      />
-      {description && (
-        <Text slot="description" className="mt-1 text-muted text-sm">
-          {description}
-        </Text>
-      )}
-      <FieldError className="mt-1 text-error text-sm" />
-    </TextField>
-  );
-}
-```
-
-#### Select
-
-```tsx
-import {
-  Select,
-  Label,
-  Button,
-  SelectValue,
-  Popover,
-  ListBox,
-  ListBoxItem,
-} from "react-aria-components";
-import { ChevronDown } from "lucide-react";
-
-type SelectOption = { id: string; name: string };
-
-type FormSelectProps = {
-  label: string;
-  items: SelectOption[];
-  placeholder?: string;
-};
-
-export function FormSelect({ label, items, placeholder, ...props }: FormSelectProps) {
-  return (
-    <Select {...props}>
-      <Label className="font-medium text-sm">{label}</Label>
-      <Button className="mt-1 flex w-full items-center justify-between rounded-2xl
-                         border bg-card px-4 py-3 text-sm
-                         focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
-        <SelectValue className="truncate">
-          {({ selectedText }) => selectedText || placeholder}
-        </SelectValue>
-        <ChevronDown className="h-4 w-4 text-muted" />
-      </Button>
-      <Popover className="w-[--trigger-width] rounded-xl border bg-card shadow-lg">
-        <ListBox items={items} className="max-h-60 overflow-auto p-1">
-          {(item) => (
-            <ListBoxItem
-              className="cursor-pointer rounded-lg px-3 py-2 text-sm
-                         hover:bg-muted/10
-                         focus:bg-muted/10 focus:outline-none
-                         selected:bg-primary/10 selected:text-primary"
-            >
-              {item.name}
-            </ListBoxItem>
-          )}
-        </ListBox>
-      </Popover>
-    </Select>
-  );
-}
-```
-
-#### Modal / Dialog
-
-```tsx
-import {
-  DialogTrigger,
-  Modal,
-  Dialog,
-  Heading,
-  Button,
-} from "react-aria-components";
-
-type ConfirmDialogProps = {
-  title: string;
-  children: React.ReactNode;
-  triggerLabel: string;
-  confirmLabel?: string;
-  cancelLabel?: string;
-  onConfirm: () => void;
-};
-
-export function ConfirmDialog({
-  title,
-  children,
-  triggerLabel,
-  confirmLabel = "Confirm",
-  cancelLabel = "Cancel",
-  onConfirm,
-}: ConfirmDialogProps) {
-  return (
-    <DialogTrigger>
-      <Button className="...">{triggerLabel}</Button>
-      <Modal
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-        isDismissable
-      >
-        <Dialog className="mx-4 w-full max-w-lg rounded-2xl bg-card p-6 shadow-xl
-                          focus:outline-none">
-          <Heading slot="title" className="font-bold text-lg">
-            {title}
-          </Heading>
-          <div className="mt-4">{children}</div>
-          <div className="mt-6 flex justify-end gap-3">
-            <Button
-              slot="close"
-              className="rounded-full px-4 py-2 text-muted hover:bg-muted/10"
-            >
-              {cancelLabel}
-            </Button>
-            <Button
-              onPress={onConfirm}
-              className="rounded-full bg-primary px-4 py-2 text-white"
-            >
-              {confirmLabel}
-            </Button>
-          </div>
-        </Dialog>
-      </Modal>
-    </DialogTrigger>
-  );
-}
-```
-
-#### RadioGroup
-
-```tsx
-import { RadioGroup, Radio, Label } from "react-aria-components";
-
-type RadioOption = { value: string; label: string };
-
-type FormRadioGroupProps = {
-  label: string;
-  options: RadioOption[];
-  isRequired?: boolean;
-};
-
-export function FormRadioGroup({ label, options, isRequired, ...props }: FormRadioGroupProps) {
-  return (
-    <RadioGroup isRequired={isRequired} {...props}>
-      <Label className="font-medium text-sm">{label}</Label>
-      <div className="mt-2 space-y-2">
-        {options.map((option) => (
-          <Radio
-            key={option.value}
-            value={option.value}
-            className="group flex cursor-pointer items-center gap-3"
-          >
-            <div className="flex h-5 w-5 items-center justify-center rounded-full border-2
-                           group-selected:border-primary group-selected:bg-primary
-                           group-focus-visible:ring-2 group-focus-visible:ring-ring">
-              <div className="h-2 w-2 rounded-full bg-white opacity-0
-                             group-selected:opacity-100" />
-            </div>
-            <span className="text-sm">{option.label}</span>
-          </Radio>
-        ))}
-      </div>
-    </RadioGroup>
-  );
-}
-```
-
-### Focus Management
-
-React Aria manages focus rings with the `useFocusRing` hook.
-
-```tsx
-import { useFocusRing, mergeProps } from "react-aria";
-
-function CustomButton({ children, ...props }) {
-  const ref = useRef(null);
-  const { focusProps, isFocusVisible } = useFocusRing();
-  const { buttonProps } = useButton(props, ref);
-
-  return (
-    <button
-      {...mergeProps(buttonProps, focusProps)}
-      ref={ref}
-      className={cn(
-        "rounded-full px-4 py-2",
-        isFocusVisible && "ring-2 ring-ring ring-offset-2"
-      )}
-    >
-      {children}
-    </button>
-  );
-}
-```
-
-### Styling (MUI + Emotion)
-
-React Aria components expose state via data attributes. In this project, style them using MUI's `sx` prop or Emotion `styled()`.
-
-```tsx
-import { styled } from "@mui/material/styles";
-import { Button } from "react-aria-components";
-
-const StyledButton = styled(Button)(({ theme }) => ({
-  backgroundColor: theme.vars.palette.primary.main,
-  color: theme.vars.palette.primary.contrastText,
-  "&[data-hovered]": { opacity: 0.9 },
-  "&[data-pressed]": { transform: "scale(0.95)" },
-  "&[data-focus-visible]": {
-    outline: `2px solid ${theme.vars.palette.primary.main}`,
-    outlineOffset: 2,
-  },
-  "&[data-disabled]": { opacity: 0.5 },
-}));
-```
-
-**Available data attributes for styling:**
-
-- `[data-hovered]` - On hover
-- `[data-focused]` - On focus
-- `[data-focus-visible]` - On keyboard focus
-- `[data-pressed]` - On press
-- `[data-selected]` - On selection
-- `[data-disabled]` - When disabled
-- `[data-invalid]` - On validation error
-
-### Migration Guide
-
-Steps for replacing existing components with React Aria:
-
-1. **Button**: Replace `<button>` with `<Button>`, change `onClick` to `onPress`
-2. **Input**: Replace `<input>` with `<TextField>` + `<Input>` for integrated label/error
-3. **Select**: Replace `<select>` with `<Select>` + `<ListBox>` for improved keyboard interaction
-4. **Modal**: Replace custom implementation with `<Modal>` + `<Dialog>` for automatic focus trapping
+MUI's `sx` prop and Emotion `styled()` are used for all component styling, including accessibility-related styles (focus rings, contrast adjustments). See [Styling Guide](./styling.md) for details.
 
 ---
 
@@ -423,9 +127,9 @@ Group related form elements.
 
 ### 3. Modal/Dialog
 
-Use React Aria's `<Modal>` + `<Dialog>` components (see [React Aria section](#modal--dialog) above), which handle focus trapping, ESC dismissal, and focus restoration automatically.
+MUI's `<Dialog>` / `<Modal>` components handle focus trapping, ESC dismissal, and focus restoration automatically.
 
-If building a custom modal without React Aria, ensure:
+When building a custom modal without MUI, ensure:
 
 - `role="dialog"` and `aria-modal="true"` are set
 - Title is associated via `aria-labelledby`
@@ -801,7 +505,7 @@ describe("Accessibility", () => {
 
 - [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
 - [WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/)
-- [React Aria](https://react-spectrum.adobe.com/react-aria/) / [Components](https://react-spectrum.adobe.com/react-aria/components.html)
+- [MUI Accessibility](https://mui.com/material-ui/getting-started/accessibility/)
 - [axe-core](https://github.com/dequelabs/axe-core)
 - [Biome Accessibility Rules](https://biomejs.dev/linter/rules/#accessibility)
 - [Design Checklist](../design/accessibility.md)

--- a/docs/web-frontend/architecture.md
+++ b/docs/web-frontend/architecture.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-Next.js 15 application using the **Pages Router**, deployed to Cloudflare Workers via OpenNextJS. UI is built with **MUI v7 + Emotion**. Code is organized into feature modules following the **Container/Presenter** pattern.
+Next.js 15 application using the **Pages Router**, deployed to Cloudflare Workers via OpenNextJS. UI is built with **MUI v7 (Material UI) + Emotion**, integrated via `@mui/material-nextjs/v14-pagesRouter` (the `v14` in the import path refers to the Next.js Pages Router integration, not the MUI version). Code is organized into feature modules following the **Container/Presenter** pattern.
 
 ## Tech Stack
 
 | Layer | Technology |
 |-------|------------|
 | Framework | Next.js 15 (Pages Router) |
-| UI Library | MUI v7 (Material UI) + Emotion CSS-in-JS |
+| UI Library | MUI v7 (Material UI) + Emotion CSS-in-JS, integrated via `@mui/material-nextjs/v14-pagesRouter` |
 | Language | TypeScript 5.9 (strict mode, Zod Schema First) |
 | i18n | next-i18next (ja, en, cn, tw, ko) |
 | Error Handling | Result type (`@vspo-lab/error`) |

--- a/docs/web-frontend/error-handling.md
+++ b/docs/web-frontend/error-handling.md
@@ -105,6 +105,42 @@ Available codes: `BAD_REQUEST`, `FORBIDDEN`, `INTERNAL_SERVER_ERROR`, `USAGE_EXC
 
 ---
 
+## React Error Boundaries
+
+In addition to the Result type, the codebase uses **React Error Boundaries** to catch
+render-time exceptions in component trees. Error Boundaries are class components that
+implement `getDerivedStateFromError` and `componentDidCatch`.
+
+### When to Use Each Approach
+
+| Approach | Use When |
+|----------|----------|
+| **Result type (`wrap`, `Ok`, `Err`)** | Handling async operations: API calls, data fetching, file reads. Used in `serverSideProps`, API services, and data orchestration layers. |
+| **React Error Boundary** | Catching unexpected render errors in a React component subtree. Provides a fallback UI instead of crashing the entire page. |
+
+### Existing Error Boundary
+
+`MultiviewErrorBoundary` (`features/multiview/components/containers/MultiviewErrorBoundary.tsx`)
+wraps the multiview page's component tree. On error it renders a recoverable fallback with
+a retry button, preventing the entire page from crashing due to an unexpected render error.
+
+```tsx
+// Usage in multiview page container
+<MultiviewErrorBoundary>
+  <PlaybackProvider>
+    <Presenter ... />
+  </PlaybackProvider>
+</MultiviewErrorBoundary>
+```
+
+**Guidelines:**
+
+- Use Error Boundaries around feature subtrees that are complex or may fail at render time.
+- Keep Result types for all async/data operations; Error Boundaries are not a substitute.
+- Error Boundaries do not catch errors in event handlers, async code, or server-side rendering.
+
+---
+
 ## Planned: Domain Error Codes
 
 > **Status: Not yet implemented.** The files referenced below — `domain-code.ts`,

--- a/docs/web-frontend/react-hooks.md
+++ b/docs/web-frontend/react-hooks.md
@@ -161,6 +161,11 @@ function useTaskData(taskId: string) {
 
 ## React 19 Hooks
 
+> **Status: Not yet used in this codebase.** The hooks below are available in React 19
+> but are not currently adopted in this project. The codebase uses the Pages Router
+> without Server Components or Server Actions (`"use server"`). These examples are
+> kept as reference for future adoption.
+
 ### use (Server Components)
 
 ```tsx

--- a/service/bot-dashboard/astro.config.ts
+++ b/service/bot-dashboard/astro.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
+  site: "https://discord.vspo-schedule.com",
   output: "server",
   i18n: {
     defaultLocale: "ja",

--- a/service/bot-dashboard/package.json
+++ b/service/bot-dashboard/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.8",
     "@astrojs/cloudflare": "^13.1.3",
+    "@vspo-lab/dayjs": "workspace:^",
     "@vspo-lab/error": "workspace:^",
     "astro": "^6.0.0",
     "zod": "catalog:"

--- a/service/bot-dashboard/pnpm-lock.yaml
+++ b/service/bot-dashboard/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@astrojs/cloudflare':
         specifier: ^13.1.3
         version: 13.1.3(@types/node@22.19.15)(astro@6.0.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.32.0)(workerd@1.20260312.1)(wrangler@4.73.0(@cloudflare/workers-types@4.20260313.1))(yaml@2.8.2)
+      '@vspo-lab/dayjs':
+        specifier: workspace:^
+        version: link:../../packages/dayjs
       '@vspo-lab/error':
         specifier: workspace:^
         version: link:../../packages/errors

--- a/service/bot-dashboard/src/features/auth/domain/discord-user.ts
+++ b/service/bot-dashboard/src/features/auth/domain/discord-user.ts
@@ -22,6 +22,14 @@ type DiscordUser = z.infer<typeof DiscordUserSchema>;
 const DiscordUser = {
   schema: DiscordUserSchema,
 
+  /**
+   * Parses a Discord API user payload into the domain user shape.
+   *
+   * @param raw - Unknown Discord API payload to validate and normalize
+   * @returns Parsed Discord user, or an AppError when validation fails
+   * @precondition raw matches the expected Discord user response shape or the caller handles Err
+   * @postcondition On Ok, return.val.displayName is `global_name` when present, otherwise `username`
+   */
   fromApiResponse: (raw: unknown): Result<DiscordUser, AppError> => {
     const apiResult = parseResult(DiscordApiUserSchema, raw);
     if (apiResult.err) return apiResult;
@@ -34,6 +42,7 @@ const DiscordUser = {
     });
   },
 
+  /** Resolves the Discord CDN avatar URL for a user, or null if no avatar is set. */
   avatarUrl: (user: DiscordUser): string | null =>
     user.avatar
       ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`

--- a/service/bot-dashboard/src/features/auth/usecase/login.test.ts
+++ b/service/bot-dashboard/src/features/auth/usecase/login.test.ts
@@ -1,3 +1,4 @@
+import { getCurrentUTCDate } from "@vspo-lab/dayjs";
 import { AppError, Err, Ok } from "@vspo-lab/error";
 import { DiscordApiRepository } from "../repository/discord-api";
 import { LoginUsecase } from "./login";
@@ -71,9 +72,9 @@ describe("LoginUsecase", () => {
         Ok(apiUser),
       );
 
-      const before = Date.now();
+      const before = getCurrentUTCDate().getTime();
       const result = await LoginUsecase.handleCallback("auth-code", env);
-      const after = Date.now();
+      const after = getCurrentUTCDate().getTime();
 
       expect(result.err).toBeUndefined();
       expect(result.val).toBeDefined();

--- a/service/bot-dashboard/src/features/auth/usecase/login.ts
+++ b/service/bot-dashboard/src/features/auth/usecase/login.ts
@@ -1,3 +1,4 @@
+import { getCurrentUTCDate } from "@vspo-lab/dayjs";
 import type { Result } from "@vspo-lab/error";
 import { type AppError, Ok } from "@vspo-lab/error";
 import { z } from "zod";
@@ -35,8 +36,13 @@ const AuthorizationUrlResultSchema = z.object({
 type AuthorizationUrlResult = z.infer<typeof AuthorizationUrlResultSchema>;
 
 /**
- * Generate a Discord OAuth2 Authorization URL
- * @postcondition Returns a valid Discord OAuth2 URL and a state value for CSRF protection
+ * Generates a Discord OAuth2 authorization URL.
+ *
+ * @param env - Discord OAuth2 client settings used to build the authorization URL
+ * @returns Authorization URL parameters containing the redirect target and a CSRF protection state
+ * @precondition env.DISCORD_CLIENT_ID !== "" && env.DISCORD_REDIRECT_URI !== ""
+ * @postcondition return.url contains return.state as the `state` query parameter for Discord OAuth2
+ * @idempotent false - A new random `state` value is generated on every invocation
  */
 const buildAuthorizationUrl = (env: AuthUrlEnv): AuthorizationUrlResult => {
   const state = crypto.randomUUID();
@@ -54,9 +60,14 @@ const buildAuthorizationUrl = (env: AuthUrlEnv): AuthorizationUrlResult => {
 };
 
 /**
- * Handle the OAuth2 callback
- * @precondition A valid authorization code is required
- * @postcondition Returns user information and tokens. Session persistence is the caller's responsibility.
+ * Exchanges a Discord OAuth2 callback code for authenticated user data and tokens.
+ *
+ * @param code - Authorization code received from the Discord OAuth2 callback
+ * @param env - Discord OAuth2 client credentials and redirect URI used for token exchange
+ * @returns Parsed Discord user information together with access and refresh tokens, or an AppError
+ * @precondition code !== "" && env.DISCORD_CLIENT_ID !== "" && env.DISCORD_CLIENT_SECRET !== "" && env.DISCORD_REDIRECT_URI !== ""
+ * @postcondition On Ok, return.val.user is parsed from the Discord API response and return.val.expiresAt is later than the invocation time
+ * @idempotent false - Discord authorization codes are single-use and repeated calls can fail or yield different tokens
  */
 const handleCallback = async (
   code: string,
@@ -82,7 +93,8 @@ const handleCallback = async (
     user: parsedUser.val,
     accessToken: tokenResult.val.access_token,
     refreshToken: tokenResult.val.refresh_token,
-    expiresAt: Date.now() + tokenResult.val.expires_in * 1000,
+    expiresAt:
+      getCurrentUTCDate().getTime() + tokenResult.val.expires_in * 1000,
     locale: userResult.val.locale,
   });
 };

--- a/service/bot-dashboard/src/features/channel/usecase/delete-channel.ts
+++ b/service/bot-dashboard/src/features/channel/usecase/delete-channel.ts
@@ -8,9 +8,13 @@ type DeleteChannelParams = {
 };
 
 /**
- * Remove a channel's Bot configuration entry for a given guild.
- * @precondition Valid appWorker, guildId, and channelId are required
- * @postcondition The channel is removed from the Bot configuration; idempotent
+ * Removes a channel configuration entry from a guild.
+ *
+ * @param params - App worker binding and the guild/channel identifiers to delete
+ * @returns Ok(undefined) after delegating the deletion, or an AppError
+ * @precondition params.guildId !== "" && params.channelId !== "" && params.appWorker is a configured Fetcher
+ * @postcondition On Ok, the channel identified by params.channelId is absent from the guild configuration
+ * @idempotent Delegates to repository; idempotency depends on repository implementation
  */
 const execute = async (
   params: DeleteChannelParams,

--- a/service/bot-dashboard/src/features/channel/usecase/toggle-channel.ts
+++ b/service/bot-dashboard/src/features/channel/usecase/toggle-channel.ts
@@ -9,9 +9,13 @@ type ToggleChannelParams = {
 };
 
 /**
- * Toggle a channel's enabled/disabled state
- * @precondition Valid appWorker, guildId, and channelId are required
- * @postcondition Enables the channel if enable is true, disables it if false
+ * Applies the requested enabled state to a guild channel configuration.
+ *
+ * @param params - App worker binding, target guild/channel IDs, and the desired enabled state
+ * @returns Ok(undefined) after delegating the state change, or an AppError
+ * @precondition params.guildId !== "" && params.channelId !== "" && params.appWorker is a configured Fetcher
+ * @postcondition On Ok, the repository method matching params.enable has been invoked for params.guildId and params.channelId
+ * @idempotent Delegates to repository; idempotency depends on repository implementation
  */
 const execute = async (
   params: ToggleChannelParams,

--- a/service/bot-dashboard/src/features/guild/domain/guild.ts
+++ b/service/bot-dashboard/src/features/guild/domain/guild.ts
@@ -28,6 +28,15 @@ type GuildSummary = z.infer<typeof GuildSummarySchema>;
 const GuildSummary = {
   schema: GuildSummarySchema,
 
+  /**
+   * Builds a guild summary from a Discord guild payload.
+   *
+   * @param raw - Discord guild data including the permission bitset string
+   * @param botGuildIds - Guild IDs where the bot is already installed
+   * @returns Guild summary with installation and manageability flags derived from the inputs
+   * @precondition raw.id !== "" && raw.name !== "" && Number.isFinite(Number(raw.permissions))
+   * @postcondition return.id === raw.id && return.name === raw.name && return.botInstalled === botGuildIds.has(raw.id)
+   */
   fromDiscordGuild: (
     raw: {
       id: string;
@@ -44,14 +53,24 @@ const GuildSummary = {
     botInstalled: botGuildIds.has(raw.id),
   }),
 
+  /** Resolves the Discord CDN icon URL for a guild, or null if no icon is set. */
   iconUrl: (guild: GuildSummary): string | null =>
     guild.icon
       ? `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}.png`
       : null,
 
+  /** Filters guild summaries to those the user can manage (isAdmin === true). */
   filterManageable: (guilds: readonly GuildSummary[]): GuildSummary[] =>
     guilds.filter((g) => g.isAdmin),
 
+  /**
+   * Splits guild summaries by bot installation state.
+   *
+   * @param guilds - Guild summaries to partition
+   * @returns Guild summaries grouped into installed and not-installed arrays
+   * @precondition Every element of guilds satisfies GuildSummary.schema
+   * @postcondition Each input guild appears in exactly one output array, preserving relative order within each partition
+   */
   partition: (
     guilds: readonly GuildSummary[],
   ): {
@@ -62,13 +81,18 @@ const GuildSummary = {
     notInstalled: guilds.filter((g) => !g.botInstalled),
   }),
 
+  /** Builds a Discord bot invite URL preselecting the given guild. */
   inviteUrl: (guild: GuildSummary, botClientId: string): string =>
     `https://discord.com/oauth2/authorize?client_id=${botClientId}&guild_id=${guild.id}&permissions=2048&scope=bot%20applications.commands`,
 
   /**
-   * Attach a channel summary to an existing GuildSummary.
+   * Attaches a derived channel summary to an existing guild summary.
+   *
+   * @param guild - Guild summary previously constructed for the target guild
+   * @param channels - Channel configurations belonging to the guild
+   * @returns New guild summary including enabled-count, total-count, and preview-name aggregates
    * @precondition guild must already be constructed via fromDiscordGuild
-   * @postcondition Returns a new object; does not mutate the input
+   * @postcondition Returns a new GuildSummary with channelSummary derived from channels
    */
   withChannelSummary: (
     guild: GuildSummary,

--- a/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
+++ b/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
@@ -18,9 +18,13 @@ type ListGuildsResult = {
 };
 
 /**
- * Retrieve the list of servers the user can manage
- * @precondition Valid accessToken and appWorker are required
- * @postcondition Returns results categorized into installed / notInstalled / sidebarGuilds
+ * Retrieves the guilds the current user can manage and categorizes them for the dashboard.
+ *
+ * @param params - Discord access token and app worker binding used to query guild data
+ * @returns Installed guilds, not-installed guilds, and sidebar guild metadata, or an AppError
+ * @precondition params.accessToken !== "" && params.appWorker is a configured Fetcher
+ * @postcondition On Ok, every guild in return.val.installed has botInstalled === true and return.val.sidebarGuilds is derived from return.val.installed
+ * @idempotent true - The use case is read-only and repeated calls against unchanged upstream data yield the same categorization
  */
 const execute = async (
   params: ListGuildsParams,

--- a/service/bot-dashboard/src/features/shared/domain/creator.ts
+++ b/service/bot-dashboard/src/features/shared/domain/creator.ts
@@ -14,14 +14,24 @@ type Creator = z.infer<typeof CreatorSchema>;
 const Creator = {
   schema: CreatorSchema,
 
+  /**
+   * Parses a creator API response into domain creator models.
+   *
+   * @param raw - Unknown API payload expected to contain an array of creators
+   * @returns Parsed creator array, or an AppError when validation fails
+   * @precondition raw is compatible with `CreatorSchema[]` or the caller handles Err
+   * @postcondition On Ok, every element in return.val satisfies Creator.schema
+   */
   fromApiResponse: (raw: unknown): Result<Creator[], AppError> =>
     parseResult(z.array(CreatorSchema), raw),
 
+  /** Filters creators by member type. */
   filterByType: (
     creators: readonly Creator[],
     type: "vspo_jp" | "vspo_en",
   ): Creator[] => creators.filter((c) => c.memberType === type),
 
+  /** Filters creators by a set of creator IDs. */
   filterByIds: (
     creators: readonly Creator[],
     ids: ReadonlySet<string>,

--- a/service/bot-dashboard/src/layouts/Base.astro
+++ b/service/bot-dashboard/src/layouts/Base.astro
@@ -4,10 +4,21 @@ import { t } from "~/i18n/dict";
 
 interface Props {
   title: string;
+  description?: string;
+  canonicalPath?: string;
+  noindex?: boolean;
 }
 
-const { title } = Astro.props;
+const { title, description, canonicalPath, noindex } = Astro.props;
 const { locale } = Astro.locals;
+
+const siteUrl = "https://discord.vspo-schedule.com";
+const pageTitle = `${title} | ${t(locale, "app.title")}`;
+const canonicalUrl = canonicalPath ? `${siteUrl}${canonicalPath}` : undefined;
+const altLocale = locale === "ja" ? "en" : "ja";
+const altPath = canonicalPath
+  ? `${siteUrl}/${altLocale}${canonicalPath}`
+  : undefined;
 ---
 
 <!doctype html>
@@ -15,6 +26,38 @@ const { locale } = Astro.locals;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {description && <meta name="description" content={description} />}
+    {noindex && <meta name="robots" content="noindex, nofollow" />}
+    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+    {canonicalUrl && (
+      <link rel="alternate" hreflang={locale} href={canonicalUrl} />
+    )}
+    {altPath && <link rel="alternate" hreflang={altLocale} href={altPath} />}
+    {canonicalUrl && (
+      <link rel="alternate" hreflang="x-default" href={`${siteUrl}${canonicalPath}`} />
+    )}
+
+    {/* OGP */}
+    {description && (
+      <>
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
+        <meta property="og:site_name" content={t(locale, "app.title")} />
+        <meta property="og:locale" content={locale === "ja" ? "ja_JP" : "en_US"} />
+      </>
+    )}
+
+    {/* Twitter Card */}
+    {description && (
+      <>
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={description} />
+      </>
+    )}
+
     <script is:inline>
       (function () {
         var stored = localStorage.getItem("theme");
@@ -38,7 +81,7 @@ const { locale } = Astro.locals;
         rel="stylesheet"
       />
     </noscript>
-    <title>{title} | {t(locale, "app.title")}</title>
+    <title>{pageTitle}</title>
   </head>
   <body class="min-h-screen bg-background text-foreground antialiased">
     <slot />

--- a/service/bot-dashboard/src/layouts/Dashboard.astro
+++ b/service/bot-dashboard/src/layouts/Dashboard.astro
@@ -25,7 +25,7 @@ const navLinkClass = (path: string) =>
     : "text-muted-foreground hover:bg-accent hover:text-accent-foreground";
 ---
 
-<Base title={title}>
+<Base title={title} noindex>
   <div class="flex min-h-screen flex-col">
     <header
       class="sticky top-0 z-30 flex h-14 items-center justify-between bg-vspo-purple px-4 text-white sm:px-6"

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -18,7 +18,11 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
   : null;
 ---
 
-<Base title={t(locale, "login.title")}>
+<Base
+  title={t(locale, "login.title")}
+  description={t(locale, "login.description")}
+  canonicalPath="/"
+>
   <main
     class="relative flex min-h-screen flex-col items-center justify-center gap-8 p-4"
   >

--- a/service/bot-dashboard/src/pages/robots.txt.ts
+++ b/service/bot-dashboard/src/pages/robots.txt.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from "astro";
+
+const robotsTxt = `User-agent: *
+Allow: /
+Allow: /en/
+Disallow: /dashboard/
+Disallow: /en/dashboard/
+Disallow: /auth/
+Disallow: /en/auth/
+Disallow: /api/
+`;
+
+export const GET: APIRoute = () =>
+  new Response(robotsTxt, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });

--- a/service/bot-dashboard/wrangler.storybook.jsonc
+++ b/service/bot-dashboard/wrangler.storybook.jsonc
@@ -9,5 +9,11 @@
   },
   "observability": {
     "enabled": true
-  }
+  },
+  "routes": [
+    {
+      "pattern": "storybook-bot.vspo-schedule.com",
+      "custom_domain": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- **CI修正**: `deploy-web-workers.yaml` の `wranglerVersion` を `4.6.0` → `4.76.0` に更新（カタログ `^4.73.0` との不整合を解消）
- **docs↔実装の乖離修正**: 未実装機能の記載削除（React Aria、OKLch トークン、FloatArea/StepFormDialog）、実装に合わせた更新（MUIバージョン、テストスクリプト、Error Boundary）
- **JSDoc追加**: bot-dashboard のドメイン・ユースケース関数に `@param`/`@returns`/`@precondition`/`@postcondition`/`@idempotent` を追加
- **Date.now() → getCurrentUTCDate()**: `@vspo-lab/dayjs` 規約に統一

## Deep Sync レポート
実行日時: 2026-03-22 / ブランチ: develop / 総ラウンド: 2 (Expert 4 JSDoc, Expert 11 DateTime)
検出乖離: 16 / 修正適用: 14 / 未対応: 2
Quality Review: Claude /simplify / CRITICAL:0 WARNING:2(適用済) INFO:3

### 未対応（要人間判断）
- [ ] GAP-009 INFO: `getCurrentUTCDate().getTime()` は `Date.now()` より冗長。`@vspo-lab/dayjs` に `getCurrentUTCTimestamp(): number` ヘルパー追加を検討
- [ ] JSDoc INFO: `buildAuthorizationUrl` の `@idempotent false` は `crypto.randomUUID()` から自明だが規約統一のため残置