### PR TITLE
feat(bot-dashboard): show bot installation status on guild list

### DIFF
--- a/docs/backend/server-architecture.md
+++ b/docs/backend/server-architecture.md
@@ -175,7 +175,7 @@ Each feature follows the domain/repository/usecase pattern:
 ```text
 features/<name>/
 ├── domain/       # Zod schemas + companion objects
-├── repository/   # API access (currently mocked, Phase 5: vspo-server)
+├── repository/   # API access via vspo-server RPC (guild: implemented, channel: mocked)
 └── usecase/      # Business logic orchestration
 ```
 
@@ -195,4 +195,4 @@ Server-side form handlers defined in `src/actions/index.ts`. Each action:
 
 ### Service Binding
 
-The bot-dashboard connects to `vspo-server` via Cloudflare Workers Service Binding (`APP_WORKER`). All channel/guild API calls go through this binding. Currently mocked pending Phase 5 integration.
+The bot-dashboard connects to `vspo-server` via Cloudflare Workers Service Binding (`APP_WORKER`), typed as `ApplicationService` from the shared `api.d.ts` (symlinked from vspo-schedule). Guild membership detection (`getBotGuildIds`) is implemented via `DiscordService.listBotGuildIds()` RPC. Channel configuration APIs remain mocked pending Phase 5 integration.

--- a/service/bot-dashboard/src/env.d.ts
+++ b/service/bot-dashboard/src/env.d.ts
@@ -3,7 +3,7 @@
 
 declare namespace Cloudflare {
   interface Env {
-    APP_WORKER: Fetcher;
+    APP_WORKER: import("~/types/api").ApplicationService;
     DISCORD_CLIENT_ID: string;
     DISCORD_BOT_CLIENT_ID: string;
     DISCORD_CLIENT_SECRET: string;

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -1,6 +1,7 @@
 import type { Result } from "@vspo-lab/error";
 import { type AppError, Ok } from "@vspo-lab/error";
 import type { GuildBotConfigType } from "~/features/guild/domain/guild";
+import type { ApplicationService } from "~/types/api";
 
 /**
  * Channel configuration API access layer for vspo-server
@@ -9,7 +10,7 @@ import type { GuildBotConfigType } from "~/features/guild/domain/guild";
 const VspoChannelApiRepository = {
   /** Retrieve the Bot configuration for a server */
   getGuildConfig: async (
-    _appWorker: Fetcher,
+    _appWorker: ApplicationService,
     guildId: string,
   ): Promise<Result<GuildBotConfigType, AppError>> => {
     // TODO: Connect to vspo-server API in Phase 5
@@ -47,7 +48,7 @@ const VspoChannelApiRepository = {
 
   /** Update a channel's configuration */
   updateChannel: async (
-    _appWorker: Fetcher,
+    _appWorker: ApplicationService,
     _guildId: string,
     _channelId: string,
     _data: {
@@ -62,7 +63,7 @@ const VspoChannelApiRepository = {
 
   /** Enable the Bot */
   enableChannel: async (
-    _appWorker: Fetcher,
+    _appWorker: ApplicationService,
     _guildId: string,
     _channelId: string,
   ): Promise<Result<void, AppError>> => {
@@ -72,7 +73,7 @@ const VspoChannelApiRepository = {
 
   /** Disable the Bot */
   disableChannel: async (
-    _appWorker: Fetcher,
+    _appWorker: ApplicationService,
     _guildId: string,
     _channelId: string,
   ): Promise<Result<void, AppError>> => {
@@ -86,7 +87,7 @@ const VspoChannelApiRepository = {
    * @postcondition The channel entry is permanently removed; idempotent on repeated calls
    */
   deleteChannel: async (
-    _appWorker: Fetcher,
+    _appWorker: ApplicationService,
     _guildId: string,
     _channelId: string,
   ): Promise<Result<void, AppError>> => {

--- a/service/bot-dashboard/src/features/channel/usecase/delete-channel.ts
+++ b/service/bot-dashboard/src/features/channel/usecase/delete-channel.ts
@@ -1,8 +1,9 @@
 import type { AppError, Result } from "@vspo-lab/error";
+import type { ApplicationService } from "~/types/api";
 import { VspoChannelApiRepository } from "../repository/vspo-channel-api";
 
 type DeleteChannelParams = {
-  appWorker: Fetcher;
+  appWorker: ApplicationService;
   guildId: string;
   channelId: string;
 };
@@ -12,7 +13,7 @@ type DeleteChannelParams = {
  *
  * @param params - App worker binding and the guild/channel identifiers to delete
  * @returns Ok(undefined) after delegating the deletion, or an AppError
- * @precondition params.guildId !== "" && params.channelId !== "" && params.appWorker is a configured Fetcher
+ * @precondition params.guildId !== "" && params.channelId !== "" && params.appWorker is a configured ApplicationService
  * @postcondition On Ok, the channel identified by params.channelId is absent from the guild configuration
  * @idempotent Delegates to repository; idempotency depends on repository implementation
  */

--- a/service/bot-dashboard/src/features/channel/usecase/toggle-channel.test.ts
+++ b/service/bot-dashboard/src/features/channel/usecase/toggle-channel.test.ts
@@ -1,4 +1,5 @@
 import { AppError, Err, Ok } from "@vspo-lab/error";
+import type { ApplicationService } from "~/types/api";
 import { VspoChannelApiRepository } from "../repository/vspo-channel-api";
 import { ToggleChannelUsecase } from "./toggle-channel";
 
@@ -11,7 +12,7 @@ vi.mock("../repository/vspo-channel-api", () => ({
 
 describe("ToggleChannelUsecase", () => {
   const params = {
-    appWorker: {} as Fetcher,
+    appWorker: {} as ApplicationService,
     guildId: "guild-1",
     channelId: "ch-1",
   };

--- a/service/bot-dashboard/src/features/channel/usecase/toggle-channel.ts
+++ b/service/bot-dashboard/src/features/channel/usecase/toggle-channel.ts
@@ -1,8 +1,9 @@
 import type { AppError, Result } from "@vspo-lab/error";
+import type { ApplicationService } from "~/types/api";
 import { VspoChannelApiRepository } from "../repository/vspo-channel-api";
 
 type ToggleChannelParams = {
-  appWorker: Fetcher;
+  appWorker: ApplicationService;
   guildId: string;
   channelId: string;
   enable: boolean;
@@ -13,7 +14,7 @@ type ToggleChannelParams = {
  *
  * @param params - App worker binding, target guild/channel IDs, and the desired enabled state
  * @returns Ok(undefined) after delegating the state change, or an AppError
- * @precondition params.guildId !== "" && params.channelId !== "" && params.appWorker is a configured Fetcher
+ * @precondition params.guildId !== "" && params.channelId !== "" && params.appWorker is a configured ApplicationService
  * @postcondition On Ok, the repository method matching params.enable has been invoked for params.guildId and params.channelId
  * @idempotent Delegates to repository; idempotency depends on repository implementation
  */

--- a/service/bot-dashboard/src/features/guild/repository/vspo-guild-api.ts
+++ b/service/bot-dashboard/src/features/guild/repository/vspo-guild-api.ts
@@ -1,18 +1,35 @@
 import type { Result } from "@vspo-lab/error";
 import { type AppError, Ok } from "@vspo-lab/error";
+import type { ApplicationService } from "~/types/api";
 
 /**
  * Guild configuration API access layer for vspo-server
- * @precondition APP_WORKER Service Binding must be configured
+ * @precondition APP_WORKER Service Binding must be configured (except in dev-mock mode)
  */
 const VspoGuildApiRepository = {
-  /** Retrieve list of server IDs where the Bot is installed */
+  /**
+   * Retrieve list of server IDs where the Bot is currently installed.
+   * Calls vspo-server's DiscordService.listBotGuildIds() via RPC.
+   * Falls back to empty set in dev-mock mode where APP_WORKER is unavailable.
+   *
+   * @param appWorker - APP_WORKER service binding to vspo-server
+   * @returns Set of Discord guild ID strings where the bot is a member
+   * @precondition appWorker is a valid service binding with DiscordService RPC
+   * @postcondition On Ok, every string in the set is a Discord guild ID
+   * @idempotent true
+   */
   getBotGuildIds: async (
-    _appWorker: Fetcher,
+    appWorker: ApplicationService,
   ): Promise<Result<ReadonlySet<string>, AppError>> => {
-    // TODO: Connect to vspo-server API in Phase 5
-    // Currently returns mock data
-    return Ok(new Set<string>());
+    // Dev-mock fallback: APP_WORKER has no RPC methods in local dev
+    if (!appWorker || typeof appWorker.newDiscordUsecase !== "function") {
+      return Ok(new Set<string>());
+    }
+
+    const discord = appWorker.newDiscordUsecase();
+    const result = await discord.listBotGuildIds();
+    if (result.err) return result;
+    return Ok(new Set(result.val));
   },
 } as const;
 

--- a/service/bot-dashboard/src/features/guild/usecase/list-guilds.test.ts
+++ b/service/bot-dashboard/src/features/guild/usecase/list-guilds.test.ts
@@ -1,5 +1,6 @@
 import { AppError, Err, Ok } from "@vspo-lab/error";
 import { DiscordApiRepository } from "~/features/auth/repository/discord-api";
+import type { ApplicationService } from "~/types/api";
 import { VspoGuildApiRepository } from "../repository/vspo-guild-api";
 import { ListGuildsUsecase } from "./list-guilds";
 
@@ -15,7 +16,7 @@ vi.mock("../repository/vspo-guild-api", () => ({
   },
 }));
 
-const appWorker = {} as Fetcher;
+const appWorker = {} as ApplicationService;
 
 const adminGuild = {
   id: "1",

--- a/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
+++ b/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
@@ -2,13 +2,14 @@ import type { Result } from "@vspo-lab/error";
 import { type AppError, Ok } from "@vspo-lab/error";
 import { DiscordApiRepository } from "~/features/auth/repository/discord-api";
 import { VspoChannelApiRepository } from "~/features/channel/repository/vspo-channel-api";
+import type { ApplicationService } from "~/types/api";
 import type { GuildSummaryType } from "../domain/guild";
 import { GuildSummary } from "../domain/guild";
 import { VspoGuildApiRepository } from "../repository/vspo-guild-api";
 
 type ListGuildsParams = {
   accessToken: string;
-  appWorker: Fetcher;
+  appWorker: ApplicationService;
 };
 
 type ListGuildsResult = {
@@ -22,7 +23,7 @@ type ListGuildsResult = {
  *
  * @param params - Discord access token and app worker binding used to query guild data
  * @returns Installed guilds, not-installed guilds, and sidebar guild metadata, or an AppError
- * @precondition params.accessToken !== "" && params.appWorker is a configured Fetcher
+ * @precondition params.accessToken !== "" && params.appWorker is a configured ApplicationService
  * @postcondition On Ok, every guild in return.val.installed has botInstalled === true and return.val.sidebarGuilds is derived from return.val.installed
  * @idempotent true - The use case is read-only and repeated calls against unchanged upstream data yield the same categorization
  */

--- a/service/bot-dashboard/src/types/api.d.ts
+++ b/service/bot-dashboard/src/types/api.d.ts
@@ -1,0 +1,1 @@
+../../../vspo-schedule/v2/web/src/features/shared/types/api.d.ts

--- a/service/vspo-schedule/v2/web/src/features/shared/types/api.d.ts
+++ b/service/vspo-schedule/v2/web/src/features/shared/types/api.d.ts
@@ -2502,6 +2502,9 @@ declare class DiscordService extends RpcTarget {
     >
   >;
   deleteMessageInChannelEnqueue(channelId: string): Promise<void>;
+  listBotGuildIds(): Promise<
+    _vspo_lab_error.Result<string[], _vspo_lab_error.AppError>
+  >;
 }
 declare class EventService extends RpcTarget {
   #private;


### PR DESCRIPTION
## Summary

- vspo-schedule の `api.d.ts` をシンボリックリンクで共有し、`ApplicationService` の型を直接参照
- `Fetcher` → `ApplicationService` に全置換で型安全な RPC 呼び出しに移行
- `VspoGuildApiRepository.getBotGuildIds()` を `DiscordService.listBotGuildIds()` RPC で実装（dev-mock フォールバック付き）
- `docs/backend/server-architecture.md` を実装状況に合わせて更新

## Dependencies

- vspo-server 側 PR: https://github.com/vspo-lab/vspo-server/pull/69
  - vspo-server が先にデプロイされる必要あり
  - マージ後、`sync-api-types` ワークフローが `api.d.ts` を自動更新する PR を作成