### PR TITLE
fix(bot-dashboard): complete i18n for hardcoded strings

### DIFF
--- a/service/bot-dashboard/src/components/guild/GuildCard.astro
+++ b/service/bot-dashboard/src/components/guild/GuildCard.astro
@@ -25,7 +25,7 @@ const iconUrl = GuildSummary.iconUrl(guild);
       </h3>
       {guild.botInstalled ? (
         <span class="mt-1 inline-block rounded-full bg-vspo-purple/20 px-2 py-0.5 text-xs text-foreground">
-          Bot {t(locale, "guild.active")}
+          {t(locale, "dashboard.installed")}
         </span>
       ) : (
         <span class="mt-1 inline-block rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">

--- a/service/bot-dashboard/src/components/guild/GuildCard.test.ts
+++ b/service/bot-dashboard/src/components/guild/GuildCard.test.ts
@@ -69,24 +69,22 @@ describe("GuildCard", () => {
     expect(link.getAttribute("href")).toContain("guild-456");
   });
 
-  it("shows 'Active' badge when bot is installed (en locale)", async () => {
+  it("shows 'Bot Installed' badge when bot is installed (en locale)", async () => {
     const html = await container.renderToString(GuildCard, {
       props: { guild: installedGuild, botClientId },
       locals: { locale: "en" },
     });
     const body = parseHtml(html);
-    // en locale: guild.active = "Active"
-    expect(getByText(body, /Active/)).toBeTruthy();
+    expect(getByText(body, /Bot Installed/)).toBeTruthy();
   });
 
-  it("shows '導入済み' badge when bot is installed (ja locale)", async () => {
+  it("shows 'Bot 導入済み' badge when bot is installed (ja locale)", async () => {
     const html = await container.renderToString(GuildCard, {
       props: { guild: installedGuild, botClientId },
       locals: { locale: "ja" },
     });
     const body = parseHtml(html);
-    // ja locale: guild.active = "導入済み"
-    expect(getByText(body, /導入済み/)).toBeTruthy();
+    expect(getByText(body, /Bot 導入済み/)).toBeTruthy();
   });
 
   it("shows channel summary when bot is installed with channelSummary", async () => {
@@ -116,6 +114,6 @@ describe("GuildCard", () => {
       locals: { locale: "en" },
     });
     const body = parseHtml(html);
-    expect(body.textContent).not.toContain("Bot Active");
+    expect(body.textContent).not.toContain("Bot Installed");
   });
 });

--- a/service/bot-dashboard/src/components/ui/ThemeToggle.astro
+++ b/service/bot-dashboard/src/components/ui/ThemeToggle.astro
@@ -1,8 +1,11 @@
 ---
+import { t } from "~/i18n/dict";
+
 interface Props {
   variant?: "header" | "page";
 }
 const { variant = "header" } = Astro.props;
+const { locale } = Astro.locals;
 
 const buttonClass = variant === "header"
   ? "text-white/80 hover:bg-white/20 focus-visible:ring-white/50"
@@ -12,7 +15,7 @@ const buttonClass = variant === "header"
 <button
   id="theme-toggle"
   type="button"
-  aria-label="Toggle theme"
+  aria-label={t(locale, "settings.theme.toggle")}
   class={`flex h-9 w-9 items-center justify-center rounded-[--radius-sm] transition-colors duration-[--duration-fast] ease-[--ease-standard] focus-visible:outline-none focus-visible:ring-2 ${buttonClass}`}
 >
   <!-- Sun icon: shown in dark mode -->

--- a/service/bot-dashboard/src/i18n/dict.test.ts
+++ b/service/bot-dashboard/src/i18n/dict.test.ts
@@ -5,8 +5,8 @@ describe("t (translation)", () => {
     ["ja", "app.name", "Spodule Bot"],
     ["en", "app.name", "Spodule Bot"],
     ["ja", "login.title", "ログイン"],
-    ["en", "guild.active", "Active"],
-    ["ja", "guild.active", "導入済み"],
+    ["en", "dashboard.installed", "Bot Installed"],
+    ["ja", "dashboard.installed", "Bot 導入済み"],
   ] as const)("t(%s, %s) → %s", (locale, key, expected) => {
     expect(t(locale, key)).toBe(expected);
   });

--- a/service/bot-dashboard/src/i18n/dict.ts
+++ b/service/bot-dashboard/src/i18n/dict.ts
@@ -15,6 +15,8 @@ const ja = {
   "login.feature.filter": "通知メンバーを細かく指定",
   "login.feature.filter.desc":
     "チャンネルごとに JP・EN・カスタムで通知対象を絞り込み",
+  "login.pageSettings": "ページ設定",
+  "login.features": "機能紹介",
   "login.feature.realtime": "コマンド不要",
   "login.feature.realtime.desc":
     "ブラウザ操作だけで設定完了、コマンド入力は不要",
@@ -77,6 +79,7 @@ const ja = {
 
   // Settings
   "settings.theme": "テーマ",
+  "settings.theme.toggle": "テーマ切替",
   "settings.theme.light": "ライト",
   "settings.theme.dark": "ダーク",
   "settings.theme.system": "システム",
@@ -120,6 +123,8 @@ const en: Record<keyof typeof ja, string> = {
   "login.feature.filter": "Precise notifications",
   "login.feature.filter.desc":
     "Choose JP, EN, or pick specific members per channel",
+  "login.pageSettings": "Page settings",
+  "login.features": "Features",
   "login.feature.realtime": "No commands needed",
   "login.feature.realtime.desc":
     "Skip slash commands \u2014 click to enable, filter, and go",
@@ -183,6 +188,7 @@ const en: Record<keyof typeof ja, string> = {
 
   // Settings
   "settings.theme": "Theme",
+  "settings.theme.toggle": "Toggle theme",
   "settings.theme.light": "Light",
   "settings.theme.dark": "Dark",
   "settings.theme.system": "System",

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -34,7 +34,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
     ></div>
 
     {/* Page settings */}
-    <nav aria-label="Page settings" class="absolute right-4 top-4 flex items-center gap-2">
+    <nav aria-label={t(locale, "login.pageSettings")} class="absolute right-4 top-4 flex items-center gap-2">
       <LanguageSelector currentLocale={locale} returnTo="/" variant="dropdown" />
       <ThemeToggle variant="page" />
     </nav>
@@ -75,7 +75,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
     )}
 
     {/* Feature cards */}
-    <section aria-label="Features" class="grid w-full max-w-2xl gap-3 sm:gap-4 sm:grid-cols-3">
+    <section aria-label={t(locale, "login.features")} class="grid w-full max-w-2xl gap-3 sm:gap-4 sm:grid-cols-3">
       <Card class="animate-fade-in-up border-t-2 border-t-vspo-purple/30">
         <div class="flex items-center gap-3 p-4 sm:flex-col sm:items-start sm:gap-0 sm:space-y-2 sm:p-6 sm:pb-2">
           <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-[--radius-sm] bg-vspo-purple/10 ring-1 ring-vspo-purple/20 dark:bg-vspo-purple/20 sm:h-12 sm:w-12">


### PR DESCRIPTION
## Summary
- GuildCard の "Bot " ハードコードプレフィックスを既存の `dashboard.installed` 翻訳キーに置換
- ThemeToggle の `aria-label="Toggle theme"` を i18n 対応（`settings.theme.toggle` キー追加）
- ログインページの `aria-label="Page settings"` / `aria-label="Features"` を i18n 対応（`login.pageSettings`, `login.features` キー追加）