### PR TITLE
fix(web): limit upcoming schedule query to 1 day ahead

### DIFF
--- a/packages/dayjs/dayjs.ts
+++ b/packages/dayjs/dayjs.ts
@@ -54,6 +54,10 @@ const getPreviousDay = (
   return dayjs.tz(dateStr, tz).subtract(1, "day").format("YYYY-MM-DD");
 };
 
+const getNextDay = (dateStr: Date | string | number, tz: string): string => {
+  return dayjs.tz(dateStr, tz).add(1, "day").format("YYYY-MM-DD");
+};
+
 /**
  * Returns a date formatted according to the specified language and time zone.
  * @param input Date | string | number (ISO8601, UNIX timestamp, Date object)
@@ -87,5 +91,6 @@ export {
   getCurrentUTCDate,
   getCurrentUTCString,
   getEndOfDayUTC,
+  getNextDay,
   getPreviousDay,
 };

--- a/service/vspo-schedule/v2/web/src/features/shared/api/livestream.ts
+++ b/service/vspo-schedule/v2/web/src/features/shared/api/livestream.ts
@@ -6,7 +6,11 @@ import {
   type ListStreamsPlatform,
   VSPOApi,
 } from "@vspo-lab/api";
-import { convertToUTCTimestamp, getEndOfDayUTC } from "@vspo-lab/dayjs";
+import {
+  convertToUTCTimestamp,
+  getEndOfDayUTC,
+  getNextDay,
+} from "@vspo-lab/dayjs";
 import type { BaseError, Result } from "@vspo-lab/error";
 import { AppError, wrap } from "@vspo-lab/error";
 import { getCloudflareEnvironmentContext } from "@/lib/cloudflare/context";
@@ -131,6 +135,17 @@ export const fetchLivestreams = async (
           : undefined;
       }
 
+      // Limit upcoming streams to 1 day ahead of the selected date
+      if (params.status === "upcoming" && params.startedDate) {
+        workerParams.startDateFrom = startDateFrom
+          ? new Date(startDateFrom)
+          : undefined;
+        const nextDay = getNextDay(params.startedDate, params.timezone);
+        workerParams.startDateTo = new Date(
+          getEndOfDayUTC(nextDay, params.timezone),
+        );
+      }
+
       // Add 30 day limit for ended (archive) streams
       if (params.status === "archive") {
         const thirtyDaysAgo = new Date();
@@ -186,6 +201,13 @@ export const fetchLivestreams = async (
       if (params.status === "all") {
         param.startDateFrom = startDateFrom;
         param.startDateTo = startDateTo;
+      }
+
+      // Limit upcoming streams to 1 day ahead of the selected date
+      if (params.status === "upcoming" && params.startedDate) {
+        param.startDateFrom = startDateFrom;
+        const nextDay = getNextDay(params.startedDate, params.timezone);
+        param.startDateTo = getEndOfDayUTC(nextDay, params.timezone);
       }
 
       // Add 30 day limit for ended (archive) streams

--- a/service/vspo-schedule/v2/web/src/features/shared/api/livestream.ts
+++ b/service/vspo-schedule/v2/web/src/features/shared/api/livestream.ts
@@ -7,6 +7,7 @@ import {
   VSPOApi,
 } from "@vspo-lab/api";
 import {
+  convertToUTCDate,
   convertToUTCTimestamp,
   getEndOfDayUTC,
   getNextDay,
@@ -138,10 +139,10 @@ export const fetchLivestreams = async (
       // Limit upcoming streams to 1 day ahead of the selected date
       if (params.status === "upcoming" && params.startedDate) {
         workerParams.startDateFrom = startDateFrom
-          ? new Date(startDateFrom)
+          ? convertToUTCDate(startDateFrom)
           : undefined;
         const nextDay = getNextDay(params.startedDate, params.timezone);
-        workerParams.startDateTo = new Date(
+        workerParams.startDateTo = convertToUTCDate(
           getEndOfDayUTC(nextDay, params.timezone),
         );
       }


### PR DESCRIPTION
## Summary
- 配信予定（upcoming）ステータスのクエリに日付範囲フィルターを追加し、選択日から翌日末までに制限
- `getNextDay` ユーティリティ関数を `@vspo-lab/dayjs` に追加
- Cloudflare Workers（cfEnv）と通常APIの両方のコードパスに適用