### PR TITLE
fix(bot-dashboard): connect channel API to real vspo-server RPC and fix UI

### DIFF
--- a/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
@@ -37,16 +37,16 @@ const showCustomMembers = MemberType.requiresCustomSelection(
   >
     <div class="mb-4 flex items-center justify-between">
       <h2 id="config-modal-heading" class="text-lg font-semibold">{t(locale, "channelConfig.title", { channelName: channel.channelName })}</h2>
-      <a
-        href={`/dashboard/${guildId}`}
-        class="inline-flex h-9 w-9 items-center justify-center rounded-[--radius-sm] text-muted-foreground transition-colors duration-[--duration-fast] ease-[--ease-standard] hover:bg-accent hover:text-foreground"
-        role="button"
+      <button
+        type="button"
+        class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-[--radius-sm] text-muted-foreground transition-colors duration-[--duration-fast] ease-[--ease-standard] hover:bg-accent hover:text-foreground"
         aria-label={t(locale, "channelConfig.close")}
+        data-close-href={`/dashboard/${guildId}`}
       >
         <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
-      </a>
+      </button>
     </div>
 
     <form method="post" action={actions.updateChannel} class="space-y-4">
@@ -127,6 +127,15 @@ const showCustomMembers = MemberType.requiresCustomSelection(
 <script>
   const dialog = document.getElementById("config-modal");
   if (dialog) {
+    const closeBtn = dialog.querySelector<HTMLButtonElement>('button[data-close-href]');
+    const closeHref = closeBtn?.dataset.closeHref;
+
+    const navigateClose = () => {
+      if (closeHref) window.location.href = closeHref;
+    };
+
+    closeBtn?.addEventListener("click", navigateClose);
+
     const focusableSelector =
       'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
     const focusableEls = dialog.querySelectorAll(focusableSelector);
@@ -138,8 +147,7 @@ const showCustomMembers = MemberType.requiresCustomSelection(
     dialog.addEventListener("keydown", (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
-        const closeLink = dialog.querySelector<HTMLAnchorElement>('a[aria-label]');
-        closeLink?.click();
+        navigateClose();
         return;
       }
       if (e.key === "Tab" && focusableEls.length > 0) {
@@ -155,8 +163,7 @@ const showCustomMembers = MemberType.requiresCustomSelection(
 
     dialog.addEventListener("click", (e: MouseEvent) => {
       if (e.target === dialog) {
-        const closeLink = dialog.querySelector<HTMLAnchorElement>('a[aria-label]');
-        closeLink?.click();
+        navigateClose();
       }
     });
   }

--- a/service/bot-dashboard/src/components/channel/ChannelTable.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelTable.astro
@@ -40,8 +40,7 @@ const { locale } = Astro.locals;
                   type="submit"
                   role="switch"
                   aria-checked={ch.enabled ? "true" : "false"}
-                  class={`relative inline-flex h-7 w-12 cursor-pointer items-center rounded-full transition-colors duration-[--duration-fast] ease-[--ease-standard] ${ch.enabled ? "bg-vspo-purple" : "bg-muted"}`}
-                  style="min-height:44px;min-width:44px;padding:8px 0;"
+                  class={`relative inline-flex h-7 w-12 cursor-pointer items-center rounded-full p-[8px_0] box-content transition-colors duration-[--duration-fast] ease-[--ease-standard] ${ch.enabled ? "bg-vspo-purple" : "bg-muted"}`}
                   aria-label={t(locale, ch.enabled ? "channel.disable" : "channel.enable")}
                 >
                   <span

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -1,97 +1,246 @@
 import type { Result } from "@vspo-lab/error";
-import { type AppError, Ok } from "@vspo-lab/error";
+import { AppError, Err, Ok } from "@vspo-lab/error";
 import type { GuildBotConfigType } from "~/features/guild/domain/guild";
+import type { MemberTypeValue } from "../domain/member-type";
 import type { ApplicationService } from "~/types/api";
 
 /**
- * Channel configuration API access layer for vspo-server
- * @precondition APP_WORKER Service Binding must be configured
+ * Maps the vspo-server memberType to the bot-dashboard's MemberType domain value.
+ * @precondition serverMemberType is one of the vspo-server API values or undefined
+ * @postcondition Returns a valid MemberTypeValue
+ */
+const toFrontendMemberType = (
+  serverMemberType:
+    | "vspo_jp"
+    | "vspo_en"
+    | "vspo_ch"
+    | "vspo_all"
+    | "general"
+    | undefined,
+): MemberTypeValue => {
+  switch (serverMemberType) {
+    case "vspo_jp":
+      return "vspo_jp";
+    case "vspo_en":
+      return "vspo_en";
+    case "vspo_all":
+    case "general":
+    case undefined:
+      return "all";
+    case "vspo_ch":
+      return "all";
+  }
+};
+
+/**
+ * Maps the bot-dashboard's MemberType to the vspo-server API value.
+ * @precondition frontendMemberType is a valid MemberTypeValue
+ * @postcondition Returns a vspo-server API memberType string
+ */
+const toServerMemberType = (
+  frontendMemberType: string,
+): "vspo_jp" | "vspo_en" | "vspo_all" | "general" => {
+  switch (frontendMemberType) {
+    case "vspo_jp":
+      return "vspo_jp";
+    case "vspo_en":
+      return "vspo_en";
+    case "all":
+      return "vspo_all";
+    default:
+      return "vspo_all";
+  }
+};
+
+/**
+ * Channel configuration API access layer for vspo-server.
+ * Communicates via Cloudflare Workers RPC through the APP_WORKER service binding.
+ * @precondition APP_WORKER Service Binding must be configured (except in dev-mock mode)
  */
 const VspoChannelApiRepository = {
-  /** Retrieve the Bot configuration for a server */
+  /**
+   * Retrieve the Bot configuration for a server.
+   * Calls vspo-server's DiscordService.get() via RPC and transforms the response
+   * into the bot-dashboard's GuildBotConfig domain model.
+   *
+   * @param appWorker - APP_WORKER service binding to vspo-server
+   * @param guildId - Discord guild ID
+   * @returns GuildBotConfig with all registered channels marked as enabled
+   * @precondition appWorker is a valid service binding with DiscordService RPC
+   * @postcondition On Ok, all channels in the result have enabled === true
+   * @idempotent true
+   */
   getGuildConfig: async (
-    _appWorker: ApplicationService,
+    appWorker: ApplicationService,
     guildId: string,
   ): Promise<Result<GuildBotConfigType, AppError>> => {
-    // TODO: Connect to vspo-server API in Phase 5
-    // Mock data
+    // Dev-mock fallback: APP_WORKER has no RPC methods in local dev
+    if (!appWorker || typeof appWorker.newDiscordUsecase !== "function") {
+      return Ok({ guildId, channels: [] });
+    }
+
+    const discord = appWorker.newDiscordUsecase();
+    const result = await discord.get(guildId);
+    if (result.err) return result;
+
+    const server = result.val;
     return Ok({
-      guildId,
-      channels: [
-        {
-          channelId: "ch-1",
-          channelName: "general",
-          enabled: true,
-          language: "ja",
-          memberType: "all" as const,
-          customMembers: undefined,
-        },
-        {
-          channelId: "ch-2",
-          channelName: "notifications",
-          enabled: true,
-          language: "ja",
-          memberType: "vspo_jp" as const,
-          customMembers: undefined,
-        },
-        {
-          channelId: "ch-3",
-          channelName: "en-streams",
-          enabled: false,
-          language: "en",
-          memberType: "vspo_en" as const,
-          customMembers: undefined,
-        },
-      ],
+      guildId: server.rawId,
+      channels: server.discordChannels.map((ch) => ({
+        channelId: ch.rawId,
+        channelName: ch.name,
+        enabled: true,
+        language: ch.languageCode,
+        memberType: toFrontendMemberType(ch.memberType),
+        customMembers: undefined,
+      })),
     });
   },
 
-  /** Update a channel's configuration */
+  /**
+   * Update a channel's configuration by re-adding it with new parameters.
+   * Uses adjustBotChannel with type "add" to upsert the channel config.
+   *
+   * @param appWorker - APP_WORKER service binding
+   * @param guildId - Discord guild ID
+   * @param channelId - Discord channel ID
+   * @param data - Fields to update (language, memberType, customMembers)
+   * @precondition Channel must already be registered in the guild config
+   * @postcondition On Ok, channel config is updated with the provided values
+   */
   updateChannel: async (
-    _appWorker: ApplicationService,
-    _guildId: string,
-    _channelId: string,
-    _data: {
+    appWorker: ApplicationService,
+    guildId: string,
+    channelId: string,
+    data: {
       language?: string;
       memberType?: string;
       customMembers?: string[] | undefined;
     },
   ): Promise<Result<void, AppError>> => {
-    // TODO: Connect to vspo-server API in Phase 5
+    if (!appWorker || typeof appWorker.newDiscordUsecase !== "function") {
+      return Err(
+        new AppError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "APP_WORKER is not available",
+          context: {},
+        }),
+      );
+    }
+
+    const discord = appWorker.newDiscordUsecase();
+    const result = await discord.adjustBotChannel({
+      type: "add",
+      serverId: guildId,
+      targetChannelId: channelId,
+      channelLangaugeCode: data.language,
+      memberType: data.memberType
+        ? toServerMemberType(data.memberType)
+        : undefined,
+    });
+    if (result.err) return result;
     return Ok(undefined);
   },
 
-  /** Enable the Bot */
+  /**
+   * Enable (register) a channel with the Bot for a guild.
+   * Uses adjustBotChannel with type "add".
+   *
+   * @param appWorker - APP_WORKER service binding
+   * @param guildId - Discord guild ID
+   * @param channelId - Discord channel ID
+   * @postcondition On Ok, the channel is present in the guild's bot configuration
+   */
   enableChannel: async (
-    _appWorker: ApplicationService,
-    _guildId: string,
-    _channelId: string,
+    appWorker: ApplicationService,
+    guildId: string,
+    channelId: string,
   ): Promise<Result<void, AppError>> => {
-    // TODO: Connect to vspo-server API in Phase 5
+    if (!appWorker || typeof appWorker.newDiscordUsecase !== "function") {
+      return Err(
+        new AppError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "APP_WORKER is not available",
+          context: {},
+        }),
+      );
+    }
+
+    const discord = appWorker.newDiscordUsecase();
+    const result = await discord.adjustBotChannel({
+      type: "add",
+      serverId: guildId,
+      targetChannelId: channelId,
+    });
+    if (result.err) return result;
     return Ok(undefined);
   },
 
-  /** Disable the Bot */
+  /**
+   * Disable (unregister) a channel from the Bot for a guild.
+   * Uses adjustBotChannel with type "remove".
+   *
+   * @param appWorker - APP_WORKER service binding
+   * @param guildId - Discord guild ID
+   * @param channelId - Discord channel ID
+   * @postcondition On Ok, the channel is absent from the guild's bot configuration
+   */
   disableChannel: async (
-    _appWorker: ApplicationService,
-    _guildId: string,
-    _channelId: string,
+    appWorker: ApplicationService,
+    guildId: string,
+    channelId: string,
   ): Promise<Result<void, AppError>> => {
-    // TODO: Connect to vspo-server API in Phase 5
+    if (!appWorker || typeof appWorker.newDiscordUsecase !== "function") {
+      return Err(
+        new AppError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "APP_WORKER is not available",
+          context: {},
+        }),
+      );
+    }
+
+    const discord = appWorker.newDiscordUsecase();
+    const result = await discord.adjustBotChannel({
+      type: "remove",
+      serverId: guildId,
+      targetChannelId: channelId,
+    });
+    if (result.err) return result;
     return Ok(undefined);
   },
 
   /**
    * Remove a channel from Bot configuration for a guild.
-   * @precondition guildId and channelId must refer to an existing configuration
-   * @postcondition The channel entry is permanently removed; idempotent on repeated calls
+   * Uses adjustBotChannel with type "remove".
+   *
+   * @param appWorker - APP_WORKER service binding
+   * @param guildId - Discord guild ID
+   * @param channelId - Discord channel ID
+   * @postcondition On Ok, the channel entry is permanently removed; idempotent on repeated calls
    */
   deleteChannel: async (
-    _appWorker: ApplicationService,
-    _guildId: string,
-    _channelId: string,
+    appWorker: ApplicationService,
+    guildId: string,
+    channelId: string,
   ): Promise<Result<void, AppError>> => {
-    // TODO: Connect to vspo-server API in Phase 5
+    if (!appWorker || typeof appWorker.newDiscordUsecase !== "function") {
+      return Err(
+        new AppError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "APP_WORKER is not available",
+          context: {},
+        }),
+      );
+    }
+
+    const discord = appWorker.newDiscordUsecase();
+    const result = await discord.adjustBotChannel({
+      type: "remove",
+      serverId: guildId,
+      targetChannelId: channelId,
+    });
+    if (result.err) return result;
     return Ok(undefined);
   },
 } as const;

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -1,8 +1,8 @@
 import type { Result } from "@vspo-lab/error";
 import { AppError, Err, Ok } from "@vspo-lab/error";
 import type { GuildBotConfigType } from "~/features/guild/domain/guild";
-import type { MemberTypeValue } from "../domain/member-type";
 import type { ApplicationService } from "~/types/api";
+import type { MemberTypeValue } from "../domain/member-type";
 
 /**
  * Maps the vspo-server memberType to the bot-dashboard's MemberType domain value.


### PR DESCRIPTION
## Summary
- チャンネル設定 API をモックデータから実際の vspo-server DiscordService RPC 呼び出しに接続
  - `getGuildConfig`: `discord.get()` で実チャンネルを取得し `GuildBotConfig` に変換
  - `updateChannel`/`enableChannel`/`disableChannel`/`deleteChannel`: `discord.adjustBotChannel()` で実操作
  - memberType マッピング (`vspo_all` → `all` 等) を追加
  - ローカル開発用の dev-mock フォールバックを維持
- トグルスイッチの UI 修正: インライン `style` を Tailwind の `p-[8px_0] box-content` に置換し、WCAG 2.2 推奨の 44px タッチターゲットを維持しつつレイアウト崩れを解消
- モーダル閉じるボタンの a11y 修正: `<a role="button">` を `<button>` に変更し、Space キーでも操作可能に