### PR TITLE
feat(bot-dashboard): add channel-add feature, a11y fixes, and i18n improvements

### DIFF
--- a/service/bot-dashboard/src/actions/index.ts
+++ b/service/bot-dashboard/src/actions/index.ts
@@ -2,6 +2,7 @@ import { ActionError, defineAction } from "astro:actions";
 import { z } from "astro:schema";
 import { env } from "cloudflare:workers";
 import { VspoChannelApiRepository } from "~/features/channel/repository/vspo-channel-api";
+import { AddChannelUsecase } from "~/features/channel/usecase/add-channel";
 import { DeleteChannelUsecase } from "~/features/channel/usecase/delete-channel";
 import { ToggleChannelUsecase } from "~/features/channel/usecase/toggle-channel";
 
@@ -13,6 +14,30 @@ const requireAuth = (context: { locals: { user: unknown } }) => {
 };
 
 export const server = {
+  addChannel: defineAction({
+    accept: "form",
+    input: z.object({
+      guildId: z.string(),
+      channelId: z.string(),
+    }),
+    handler: async (input, context) => {
+      requireAuth(context);
+
+      const result = await AddChannelUsecase.execute({
+        appWorker: env.APP_WORKER,
+        guildId: input.guildId,
+        channelId: input.channelId,
+      });
+
+      if (result.err) {
+        throw new ActionError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: result.err.message,
+        });
+      }
+    },
+  }),
+
   updateChannel: defineAction({
     accept: "form",
     input: z.object({

--- a/service/bot-dashboard/src/components/channel/ChannelAddModal.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelAddModal.astro
@@ -1,0 +1,166 @@
+---
+import { actions } from "astro:actions";
+import Button from "~/components/ui/Button.astro";
+import { t } from "~/i18n/dict";
+
+interface Props {
+  guildId: string;
+  registeredChannelIds: ReadonlySet<string>;
+  availableChannels: { id: string; name: string }[];
+}
+
+const { guildId, registeredChannelIds, availableChannels } = Astro.props;
+const { locale } = Astro.locals;
+const unregistered = availableChannels.filter(
+  (ch) => !registeredChannelIds.has(ch.id),
+);
+---
+
+<dialog
+  open
+  class="fixed inset-0 z-50 flex items-center justify-center"
+  id="add-channel-modal"
+  aria-labelledby="add-channel-heading"
+  aria-modal="true"
+  style="animation: backdrop-in 200ms var(--ease-standard); background: rgba(0,0,0,0.5);"
+>
+  <div
+    class="mx-4 w-full max-w-lg rounded-[--radius] border border-border bg-card p-6 shadow-action"
+    style="animation: modal-in 200ms var(--ease-standard);"
+  >
+    <div class="mb-4 flex items-center justify-between">
+      <h2 id="add-channel-heading" class="text-lg font-semibold">
+        {t(locale, "channel.add")}
+      </h2>
+      <button
+        type="button"
+        class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-[--radius-sm] text-muted-foreground transition-colors duration-[--duration-fast] ease-[--ease-standard] hover:bg-accent hover:text-foreground"
+        aria-label={t(locale, "channelConfig.close")}
+        data-close-href={`/dashboard/${guildId}`}
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <div class="mb-4">
+      <label for="channel-search" class="sr-only">{t(locale, "channel.add.search")}</label>
+      <input
+        id="channel-search"
+        type="search"
+        placeholder={t(locale, "channel.add.search")}
+        class="w-full rounded-[--radius-sm] border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-vspo-purple focus:outline-none focus:ring-1 focus:ring-vspo-purple"
+        data-search-input
+      />
+    </div>
+
+    <div class="max-h-64 space-y-1 overflow-y-auto" role="listbox" aria-label={t(locale, "channel.add")}>
+      {unregistered.length === 0 && (
+        <p class="py-8 text-center text-sm text-muted-foreground">
+          {t(locale, "channel.add.empty")}
+        </p>
+      )}
+      {unregistered.map((ch) => (
+        <form method="post" action={actions.addChannel} data-channel-item>
+          <input type="hidden" name="guildId" value={guildId} />
+          <input type="hidden" name="channelId" value={ch.id} />
+          <button
+            type="submit"
+            role="option"
+            aria-selected="false"
+            class="flex w-full items-center justify-between rounded-[--radius-sm] px-3 py-2 text-left text-sm transition-colors duration-[--duration-fast] hover:bg-accent/50"
+            data-channel-name={ch.name.toLowerCase()}
+          >
+            <span class="flex items-center gap-2">
+              <svg class="h-4 w-4 shrink-0 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
+              </svg>
+              <span>{ch.name}</span>
+            </span>
+            <span class="text-xs font-medium text-vspo-purple">{t(locale, "channel.add.submit")}</span>
+          </button>
+        </form>
+      ))}
+      {availableChannels
+        .filter((ch) => registeredChannelIds.has(ch.id))
+        .map((ch) => (
+          <div
+            class="flex items-center justify-between rounded-[--radius-sm] px-3 py-2 text-sm text-muted-foreground opacity-50"
+            data-channel-item
+            data-channel-name={ch.name.toLowerCase()}
+          >
+            <span class="flex items-center gap-2">
+              <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
+              </svg>
+              <span>{ch.name}</span>
+            </span>
+            <span class="text-xs">{t(locale, "channel.add.registered")}</span>
+          </div>
+        ))}
+    </div>
+
+    <div class="mt-4 flex justify-end">
+      <Button as="a" href={`/dashboard/${guildId}`} variant="ghost">
+        {t(locale, "channel.add.cancel")}
+      </Button>
+    </div>
+  </div>
+</dialog>
+
+<script>
+  const dialog = document.getElementById("add-channel-modal");
+  if (dialog) {
+    const closeBtn = dialog.querySelector<HTMLButtonElement>("button[data-close-href]");
+    const closeHref = closeBtn?.dataset.closeHref;
+    const searchInput = dialog.querySelector<HTMLInputElement>("[data-search-input]");
+    const items = dialog.querySelectorAll("[data-channel-item]");
+
+    const navigateClose = () => {
+      if (closeHref) window.location.href = closeHref;
+    };
+
+    closeBtn?.addEventListener("click", navigateClose);
+
+    // Search filter
+    searchInput?.addEventListener("input", () => {
+      const query = searchInput.value.toLowerCase();
+      for (const item of items) {
+        const el = item as HTMLElement;
+        const name = el.dataset.channelName ?? el.querySelector("[data-channel-name]")?.getAttribute("data-channel-name") ?? "";
+        el.style.display = name.includes(query) ? "" : "none";
+      }
+    });
+
+    // Focus management
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const focusableEls = dialog.querySelectorAll(focusableSelector);
+    const firstEl = focusableEls[0] as HTMLElement | undefined;
+    const lastEl = focusableEls[focusableEls.length - 1] as HTMLElement | undefined;
+
+    firstEl?.focus();
+
+    dialog.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        navigateClose();
+        return;
+      }
+      if (e.key === "Tab" && focusableEls.length > 0) {
+        if (e.shiftKey && document.activeElement === firstEl) {
+          e.preventDefault();
+          lastEl?.focus();
+        } else if (!e.shiftKey && document.activeElement === lastEl) {
+          e.preventDefault();
+          firstEl?.focus();
+        }
+      }
+    });
+
+    dialog.addEventListener("click", (e: MouseEvent) => {
+      if (e.target === dialog) navigateClose();
+    });
+  }
+</script>

--- a/service/bot-dashboard/src/components/channel/ChannelTable.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelTable.astro
@@ -1,7 +1,7 @@
 ---
 import { actions } from "astro:actions";
 import type { ChannelConfigType } from "~/features/channel/domain/channel-config";
-import { t, memberTypeKey } from "~/i18n/dict";
+import { t, memberTypeKey, languageDisplayKey } from "~/i18n/dict";
 
 interface Props {
   channels: ChannelConfigType[];
@@ -50,7 +50,7 @@ const { locale } = Astro.locals;
               </form>
             </td>
             <td class="hidden px-4 py-3 text-muted-foreground sm:table-cell">
-              {ch.language.toUpperCase()}
+              {t(locale, languageDisplayKey(ch.language))}
             </td>
             <td class="hidden px-4 py-3 text-muted-foreground md:table-cell">
               {t(locale, memberTypeKey(ch.memberType))}

--- a/service/bot-dashboard/src/components/channel/ChannelTable.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelTable.astro
@@ -92,4 +92,15 @@ const { locale } = Astro.locals;
       </div>
     )
   }
+  <div class="flex justify-end border-t border-border px-4 py-3">
+    <a
+      href={`?add=true`}
+      class="inline-flex items-center gap-1.5 rounded-[--radius-sm] bg-vspo-purple px-4 py-2 text-sm font-medium text-white transition-colors duration-[--duration-fast] ease-[--ease-standard] hover:bg-vspo-purple/90"
+    >
+      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+      </svg>
+      {t(locale, "channel.add")}
+    </a>
+  </div>
 </div>

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -76,7 +76,38 @@ const VspoChannelApiRepository = {
   ): Promise<Result<GuildBotConfigType, AppError>> => {
     // Dev-mock fallback: APP_WORKER has no RPC methods in local dev
     if (!appWorker || typeof appWorker.newDiscordUsecase !== "function") {
-      return Ok({ guildId, channels: [] });
+      return Ok({
+        guildId,
+        channels:
+          guildId === "111111111111111111"
+            ? [
+                {
+                  channelId: "ch-001",
+                  channelName: "vspo-notifications",
+                  enabled: true,
+                  language: "ja",
+                  memberType: "all" as const,
+                  customMembers: undefined,
+                },
+                {
+                  channelId: "ch-002",
+                  channelName: "schedule-en",
+                  enabled: true,
+                  language: "en",
+                  memberType: "vspo_en" as const,
+                  customMembers: undefined,
+                },
+                {
+                  channelId: "ch-003",
+                  channelName: "archives",
+                  enabled: false,
+                  language: "ja",
+                  memberType: "vspo_jp" as const,
+                  customMembers: undefined,
+                },
+              ]
+            : [],
+      });
     }
 
     const discord = appWorker.newDiscordUsecase();

--- a/service/bot-dashboard/src/features/channel/usecase/add-channel.test.ts
+++ b/service/bot-dashboard/src/features/channel/usecase/add-channel.test.ts
@@ -1,0 +1,47 @@
+import { AppError, Err, Ok } from "@vspo-lab/error";
+import type { ApplicationService } from "~/types/api";
+import { VspoChannelApiRepository } from "../repository/vspo-channel-api";
+import { AddChannelUsecase } from "./add-channel";
+
+vi.mock("../repository/vspo-channel-api", () => ({
+  VspoChannelApiRepository: {
+    enableChannel: vi.fn(),
+  },
+}));
+
+describe("AddChannelUsecase", () => {
+  const params = {
+    appWorker: {} as ApplicationService,
+    guildId: "guild-1",
+    channelId: "ch-new",
+  };
+
+  it("delegates to enableChannel and returns Ok on success", async () => {
+    vi.mocked(VspoChannelApiRepository.enableChannel).mockResolvedValue(
+      Ok(undefined),
+    );
+
+    const result = await AddChannelUsecase.execute(params);
+
+    expect(result.err).toBeUndefined();
+    expect(VspoChannelApiRepository.enableChannel).toHaveBeenCalledWith(
+      params.appWorker,
+      params.guildId,
+      params.channelId,
+    );
+  });
+
+  it("propagates Err from enableChannel", async () => {
+    const error = new AppError({
+      message: "channel not found",
+      code: "NOT_FOUND",
+    });
+    vi.mocked(VspoChannelApiRepository.enableChannel).mockResolvedValue(
+      Err(error),
+    );
+
+    const result = await AddChannelUsecase.execute(params);
+
+    expect(result.err).toBe(error);
+  });
+});

--- a/service/bot-dashboard/src/features/channel/usecase/add-channel.ts
+++ b/service/bot-dashboard/src/features/channel/usecase/add-channel.ts
@@ -1,0 +1,29 @@
+import type { AppError, Result } from "@vspo-lab/error";
+import type { ApplicationService } from "~/types/api";
+import { VspoChannelApiRepository } from "../repository/vspo-channel-api";
+
+type AddChannelParams = {
+  appWorker: ApplicationService;
+  guildId: string;
+  channelId: string;
+};
+
+/**
+ * Registers a new Discord channel with the Bot for a guild.
+ *
+ * @param params - App worker binding and target guild/channel IDs
+ * @returns Ok(undefined) on success, or an AppError
+ * @precondition params.guildId !== "" && params.channelId !== ""
+ * @postcondition On Ok, the channel is registered in the guild's bot configuration
+ */
+const execute = async (
+  params: AddChannelParams,
+): Promise<Result<void, AppError>> => {
+  return VspoChannelApiRepository.enableChannel(
+    params.appWorker,
+    params.guildId,
+    params.channelId,
+  );
+};
+
+export const AddChannelUsecase = { execute } as const;

--- a/service/bot-dashboard/src/features/guild/repository/vspo-guild-api.ts
+++ b/service/bot-dashboard/src/features/guild/repository/vspo-guild-api.ts
@@ -23,7 +23,7 @@ const VspoGuildApiRepository = {
   ): Promise<Result<ReadonlySet<string>, AppError>> => {
     // Dev-mock fallback: APP_WORKER has no RPC methods in local dev
     if (!appWorker || typeof appWorker.newDiscordUsecase !== "function") {
-      return Ok(new Set<string>());
+      return Ok(new Set<string>(["111111111111111111"]));
     }
 
     const discord = appWorker.newDiscordUsecase();

--- a/service/bot-dashboard/src/i18n/dict.test.ts
+++ b/service/bot-dashboard/src/i18n/dict.test.ts
@@ -60,16 +60,13 @@ describe("new landing page keys", () => {
 });
 
 describe("languageDisplayKey", () => {
-  it("returns ja key for 'ja'", () => {
-    expect(languageDisplayKey("ja")).toBe("channelConfig.language.ja");
-  });
-
-  it("returns en key for 'en'", () => {
-    expect(languageDisplayKey("en")).toBe("channelConfig.language.en");
-  });
-
-  it("returns unknown key for unrecognized code", () => {
-    expect(languageDisplayKey("fr")).toBe("channelConfig.language.unknown");
+  it.each([
+    { langCode: "ja", expectedKey: "channelConfig.language.ja" },
+    { langCode: "en", expectedKey: "channelConfig.language.en" },
+    { langCode: "fr", expectedKey: "channelConfig.language.unknown" },
+    { langCode: "", expectedKey: "channelConfig.language.unknown" },
+  ])("maps $langCode to $expectedKey", ({ langCode, expectedKey }) => {
+    expect(languageDisplayKey(langCode)).toBe(expectedKey);
   });
 });
 

--- a/service/bot-dashboard/src/i18n/dict.test.ts
+++ b/service/bot-dashboard/src/i18n/dict.test.ts
@@ -1,4 +1,4 @@
-import { memberTypeKey, t } from "./dict";
+import { languageDisplayKey, memberTypeKey, t } from "./dict";
 
 describe("t (translation)", () => {
   it.each([
@@ -39,6 +39,37 @@ describe("t (translation)", () => {
     const result = t("en", "nonexistent.key" as Parameters<typeof t>[1]);
     // If key doesn't exist in either dict, falls back to key itself
     expect(result).toBe("nonexistent.key");
+  });
+});
+
+describe("new landing page keys", () => {
+  it.each([
+    "login.addBot",
+    "login.manageSettings",
+    "login.previewCaption",
+    "channel.add",
+    "channel.add.search",
+    "channel.add.registered",
+    "channel.add.empty",
+    "channel.add.submit",
+    "channelConfig.language.unknown",
+  ] as const)("key '%s' exists in both locales", (key) => {
+    expect(t("ja", key)).not.toBe(key);
+    expect(t("en", key)).not.toBe(key);
+  });
+});
+
+describe("languageDisplayKey", () => {
+  it("returns ja key for 'ja'", () => {
+    expect(languageDisplayKey("ja")).toBe("channelConfig.language.ja");
+  });
+
+  it("returns en key for 'en'", () => {
+    expect(languageDisplayKey("en")).toBe("channelConfig.language.en");
+  });
+
+  it("returns unknown key for unrecognized code", () => {
+    expect(languageDisplayKey("fr")).toBe("channelConfig.language.unknown");
   });
 });
 

--- a/service/bot-dashboard/src/i18n/dict.ts
+++ b/service/bot-dashboard/src/i18n/dict.ts
@@ -5,21 +5,25 @@ const ja = {
 
   // Login page
   "login.title": "ログイン",
-  "login.headline": "配信通知を、ウェブから一括管理",
+  "login.headline": "すぽじゅーる Bot をサーバーに追加",
   "login.description":
-    "チャンネルごとの通知設定をブラウザで確認・変更できます。",
+    "ぶいすぽっ!メンバーの配信予定を Discord に自動で届けます",
   "login.button": "Discord でログイン",
-  "login.permissions_note": "サーバー一覧の読み取りのみ許可されます",
-  "login.feature.list": "複数サーバーを一括管理",
-  "login.feature.list.desc": "サーバーを切り替えずにまとめて設定を確認・変更",
-  "login.feature.filter": "通知メンバーを細かく指定",
+  "login.addBot": "サーバーに追加する",
+  "login.manageSettings": "通知設定を管理する",
+  "login.previewCaption": "配信予定を、こんな感じで通知します",
+  "login.permissions_note": "サーバー一覧の読み取り権限のみ使用します",
+  "login.feature.list": "まとめて管理",
+  "login.feature.list.desc":
+    "複数サーバーの設定をひとつの画面で確認・変更",
+  "login.feature.filter": "通知対象を選べる",
   "login.feature.filter.desc":
-    "チャンネルごとに JP・EN・カスタムで通知対象を絞り込み",
+    "チャンネルごとに JP / EN メンバーやカスタム選択で絞り込み",
   "login.pageSettings": "ページ設定",
   "login.features": "機能紹介",
-  "login.feature.realtime": "コマンド不要",
+  "login.feature.realtime": "コマンド入力なし",
   "login.feature.realtime.desc":
-    "ブラウザ操作だけで設定完了、コマンド入力は不要",
+    "ブラウザ操作だけで完了。スラッシュコマンドは使いません",
 
   // Dashboard
   "dashboard.servers": "サーバー一覧",
@@ -48,6 +52,11 @@ const ja = {
   "channel.enable": "有効化",
   "channel.edit": "編集",
   "channel.delete": "削除",
+  "channel.add": "チャンネルを追加",
+  "channel.add.search": "チャンネル名で検索",
+  "channel.add.registered": "登録済み",
+  "channel.add.empty": "チャンネルが見つかりません",
+  "channel.add.submit": "追加する",
   "channel.empty": "設定済みのチャンネルがありません。",
   "channel.table": "チャンネル設定",
   "channel.deleteConfirm": "#{channelName} を削除しますか？",
@@ -61,6 +70,7 @@ const ja = {
   "channelConfig.language": "言語",
   "channelConfig.language.ja": "日本語",
   "channelConfig.language.en": "英語",
+  "channelConfig.language.unknown": "未設定",
   "channelConfig.memberType": "メンバータイプ",
   "channelConfig.customMembers": "カスタムメンバー",
   "channelConfig.close": "閉じる",
@@ -112,22 +122,25 @@ const en: Record<keyof typeof ja, string> = {
 
   // Login page
   "login.title": "Login",
-  "login.headline": "Manage stream notifications from one dashboard",
+  "login.headline": "Add Spodule Bot to your server",
   "login.description":
-    "View and update notification settings per channel, right from your browser.",
+    "Get automatic Discord notifications for VSPO member streams",
   "login.button": "Login with Discord",
+  "login.addBot": "Add to Server",
+  "login.manageSettings": "Manage notification settings",
+  "login.previewCaption": "Here's what notifications look like",
   "login.permissions_note": "Only requests read access to your server list",
-  "login.feature.list": "Multi-server at once",
+  "login.feature.list": "All servers, one screen",
   "login.feature.list.desc":
-    "Switch between servers without leaving the dashboard",
-  "login.feature.filter": "Precise notifications",
+    "Check and change settings across servers without switching",
+  "login.feature.filter": "Pick who to notify",
   "login.feature.filter.desc":
-    "Choose JP, EN, or pick specific members per channel",
+    "Filter by JP, EN, or select individual members per channel",
   "login.pageSettings": "Page settings",
   "login.features": "Features",
   "login.feature.realtime": "No commands needed",
   "login.feature.realtime.desc":
-    "Skip slash commands \u2014 click to enable, filter, and go",
+    "Everything works from the browser. No slash commands involved",
 
   // Dashboard
   "dashboard.servers": "Servers",
@@ -157,6 +170,11 @@ const en: Record<keyof typeof ja, string> = {
   "channel.enable": "Enable",
   "channel.edit": "Edit",
   "channel.delete": "Delete",
+  "channel.add": "Add Channel",
+  "channel.add.search": "Search by channel name",
+  "channel.add.registered": "Registered",
+  "channel.add.empty": "No channels found",
+  "channel.add.submit": "Add",
   "channel.empty": "No channels configured.",
   "channel.table": "Channel settings",
   "channel.deleteConfirm": "Delete #{channelName}?",
@@ -170,6 +188,7 @@ const en: Record<keyof typeof ja, string> = {
   "channelConfig.language": "Language",
   "channelConfig.language.ja": "Japanese",
   "channelConfig.language.en": "English",
+  "channelConfig.language.unknown": "Not set",
   "channelConfig.memberType": "Member Type",
   "channelConfig.customMembers": "Custom Members",
   "channelConfig.close": "Close",
@@ -254,3 +273,12 @@ const memberTypeKeys = {
 export const memberTypeKey = (
   value: import("~/features/channel/domain/member-type").MemberTypeValue,
 ): MemberTypeKey => memberTypeKeys[value];
+
+const languageDisplayKeys: Record<string, TranslationKey> = {
+  ja: "channelConfig.language.ja",
+  en: "channelConfig.language.en",
+};
+
+/** Map a language code to its translation key, falling back to "unknown". */
+export const languageDisplayKey = (langCode: string): TranslationKey =>
+  languageDisplayKeys[langCode] ?? "channelConfig.language.unknown";

--- a/service/bot-dashboard/src/i18n/dict.ts
+++ b/service/bot-dashboard/src/i18n/dict.ts
@@ -13,6 +13,7 @@ const ja = {
   "login.manageSettings": "通知設定を管理する",
   "login.previewCaption": "配信予定を、こんな感じで通知します",
   "login.permissions_note": "サーバー一覧の読み取り権限のみ使用します",
+  "login.footer": "vspo-schedule.com",
   "login.feature.list": "まとめて管理",
   "login.feature.list.desc":
     "複数サーバーの設定をひとつの画面で確認・変更",
@@ -80,6 +81,7 @@ const ja = {
   // Navigation
   "nav.sidebar": "サーバーナビゲーション",
   "nav.menu": "メニュー",
+  "nav.skipToContent": "メインコンテンツへスキップ",
 
   // Member types
   "memberType.vspo_jp": "VSPO JP",
@@ -130,6 +132,7 @@ const en: Record<keyof typeof ja, string> = {
   "login.manageSettings": "Manage notification settings",
   "login.previewCaption": "Here's what notifications look like",
   "login.permissions_note": "Only requests read access to your server list",
+  "login.footer": "vspo-schedule.com",
   "login.feature.list": "All servers, one screen",
   "login.feature.list.desc":
     "Check and change settings across servers without switching",
@@ -198,6 +201,7 @@ const en: Record<keyof typeof ja, string> = {
   // Navigation
   "nav.sidebar": "Server Navigation",
   "nav.menu": "Menu",
+  "nav.skipToContent": "Skip to main content",
 
   // Member types
   "memberType.vspo_jp": "VSPO JP",

--- a/service/bot-dashboard/src/i18n/dict.ts
+++ b/service/bot-dashboard/src/i18n/dict.ts
@@ -58,6 +58,7 @@ const ja = {
   "channel.add.registered": "登録済み",
   "channel.add.empty": "チャンネルが見つかりません",
   "channel.add.submit": "追加する",
+  "channel.add.cancel": "キャンセル",
   "channel.empty": "設定済みのチャンネルがありません。",
   "channel.table": "チャンネル設定",
   "channel.deleteConfirm": "#{channelName} を削除しますか？",
@@ -107,6 +108,7 @@ const ja = {
   "error.invalid_state": "無効な認証リクエストです。もう一度お試しください。",
 
   // Toast / feedback
+  "toast.addSuccess": "チャンネルを追加しました。",
   "toast.updateSuccess": "チャンネル設定を更新しました。",
   "toast.toggleSuccess": "チャンネルの有効/無効を切り替えました。",
   "toast.deleteSuccess": "チャンネル設定を削除しました。",
@@ -178,6 +180,7 @@ const en: Record<keyof typeof ja, string> = {
   "channel.add.registered": "Registered",
   "channel.add.empty": "No channels found",
   "channel.add.submit": "Add",
+  "channel.add.cancel": "Cancel",
   "channel.empty": "No channels configured.",
   "channel.table": "Channel settings",
   "channel.deleteConfirm": "Delete #{channelName}?",
@@ -226,6 +229,7 @@ const en: Record<keyof typeof ja, string> = {
   "error.invalid_state": "Invalid authentication request. Please try again.",
 
   // Toast / feedback
+  "toast.addSuccess": "Channel added successfully.",
   "toast.updateSuccess": "Channel settings updated.",
   "toast.toggleSuccess": "Channel toggled successfully.",
   "toast.deleteSuccess": "Channel configuration deleted.",

--- a/service/bot-dashboard/src/i18n/dict.ts
+++ b/service/bot-dashboard/src/i18n/dict.ts
@@ -15,8 +15,7 @@ const ja = {
   "login.permissions_note": "サーバー一覧の読み取り権限のみ使用します",
   "login.footer": "vspo-schedule.com",
   "login.feature.list": "まとめて管理",
-  "login.feature.list.desc":
-    "複数サーバーの設定をひとつの画面で確認・変更",
+  "login.feature.list.desc": "複数サーバーの設定をひとつの画面で確認・変更",
   "login.feature.filter": "通知対象を選べる",
   "login.feature.filter.desc":
     "チャンネルごとに JP / EN メンバーやカスタム選択で絞り込み",

--- a/service/bot-dashboard/src/layouts/Base.astro
+++ b/service/bot-dashboard/src/layouts/Base.astro
@@ -84,6 +84,12 @@ const altPath = canonicalPath
     <title>{pageTitle}</title>
   </head>
   <body class="min-h-screen bg-background text-foreground antialiased">
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-[--radius-sm] focus:bg-vspo-purple focus:px-4 focus:py-2 focus:text-white focus:shadow-action"
+    >
+      {t(locale, "nav.skipToContent")}
+    </a>
     <slot />
   </body>
 </html>

--- a/service/bot-dashboard/src/layouts/Dashboard.astro
+++ b/service/bot-dashboard/src/layouts/Dashboard.astro
@@ -45,6 +45,7 @@ const navLinkClass = (path: string) =>
               <a
                 href="/dashboard"
                 class={`flex items-center gap-2 rounded-[--radius-sm] px-3 py-2 text-sm ${navLinkClass("/dashboard")}`}
+                {...(isActive("/dashboard") ? { "aria-current": "page" as const } : {})}
               >
                 <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1" /></svg>
                 <span>{t(locale, "dashboard.allServers")}</span>
@@ -53,6 +54,7 @@ const navLinkClass = (path: string) =>
                 <a
                   href={`/dashboard/${guild.id}`}
                   class={`flex items-center gap-2 rounded-[--radius-sm] px-3 py-2 text-sm ${navLinkClass(`/dashboard/${guild.id}`)}`}
+                  {...(isActive(`/dashboard/${guild.id}`) ? { "aria-current": "page" as const } : {})}
                 >
                   <AvatarFallback src={guild.iconUrl} name={guild.name} size="xs" />
                   <span class="truncate">{guild.name}</span>
@@ -100,7 +102,7 @@ const navLinkClass = (path: string) =>
           }
         </nav>
       </aside>
-      <main class="flex-1 p-4 sm:p-6">
+      <main id="main-content" class="flex-1 p-4 sm:p-6">
         <slot />
       </main>
     </div>

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -1,6 +1,7 @@
 ---
 import { actions } from "astro:actions";
 import { env } from "cloudflare:workers";
+import ChannelAddModal from "~/components/channel/ChannelAddModal.astro";
 import ChannelConfigForm from "~/components/channel/ChannelConfigForm.astro";
 import ChannelTable from "~/components/channel/ChannelTable.astro";
 import DeleteChannelDialog from "~/components/channel/DeleteChannelDialog.astro";
@@ -37,22 +38,26 @@ const fetchError = guildsResult.err ?? channelsResult.err ?? null;
 const enabledCount = channels.filter((c) => c.enabled).length;
 
 // Handle action results
+const addResult = Astro.getActionResult(actions.addChannel);
 const updateResult = Astro.getActionResult(actions.updateChannel);
 const toggleResult = Astro.getActionResult(actions.toggleChannel);
 const deleteResult = Astro.getActionResult(actions.deleteChannel);
-const actionError = updateResult?.error ?? toggleResult?.error ?? deleteResult?.error;
+const actionError = addResult?.error ?? updateResult?.error ?? toggleResult?.error ?? deleteResult?.error;
 const actionSuccess = !actionError && (
+  (addResult?.data != null ? "add" : null) ??
   (updateResult?.data != null ? "update" : null) ??
   (toggleResult?.data != null ? "toggle" : null) ??
   (deleteResult?.data != null ? "delete" : null)
 );
-const successMessageKey = actionSuccess === "update"
-  ? "toast.updateSuccess" as const
-  : actionSuccess === "toggle"
-    ? "toast.toggleSuccess" as const
-    : actionSuccess === "delete"
-      ? "toast.deleteSuccess" as const
-      : null;
+const successMessageKey = actionSuccess === "add"
+  ? "toast.addSuccess" as const
+  : actionSuccess === "update"
+    ? "toast.updateSuccess" as const
+    : actionSuccess === "toggle"
+      ? "toast.toggleSuccess" as const
+      : actionSuccess === "delete"
+        ? "toast.deleteSuccess" as const
+        : null;
 
 // Editing state via query param
 const editChannelId = Astro.url.searchParams.get("edit");
@@ -65,6 +70,9 @@ const deleteChannelId = Astro.url.searchParams.get("delete");
 const deletingChannel = deleteChannelId
   ? channels.find((c) => c.channelId === deleteChannelId)
   : null;
+
+// Add channel modal state via query param
+const showAddModal = Astro.url.searchParams.get("add") === "true";
 ---
 
 <Dashboard title={guildName} guilds={sidebarGuilds}>
@@ -147,6 +155,16 @@ const deletingChannel = deleteChannelId
         <DeleteChannelDialog
           channel={deletingChannel}
           guildId={guildId}
+        />
+      )
+    }
+
+    {
+      showAddModal && (
+        <ChannelAddModal
+          guildId={guildId}
+          registeredChannelIds={new Set(channels.map((c) => c.channelId))}
+          availableChannels={[]}
         />
       )
     }

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -163,7 +163,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
 
     {/* Footer */}
     <footer class="mt-auto pt-6 text-center text-xs text-muted-foreground">
-      <span>vspo-schedule.com</span>
+      <span>{t(locale, "login.footer")}</span>
     </footer>
   </main>
 </Base>


### PR DESCRIPTION
## Summary
- チャンネル追加機能: AddChannelUsecase + サーバーアクション + ChannelAddModal（検索・登録済み表示付き）
- a11y改善: skip-to-content リンク、モバイルナビの aria-current、Dashboard main に id 付与
- ChannelTable の言語カラムを翻訳表示に修正（`toUpperCase()` → `languageDisplayKey`）
- i18n キー追加・コピー改善（channel-add、skip link、footer 等）
- dev-mock データ拡充（Bot導入済みギルド + チャンネル設定サンプル）