### PR TITLE
feat(bot-dashboard): add landing page stats and update headline

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -70,6 +70,7 @@ nimg
 nonempty
 noto
 nuki
+nums
 oembed
 ofuse
 oklch

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -19,6 +19,7 @@ datetime
 dayjs
 dcdn
 dearu
+defu
 desaturation
 desumasu
 devcontainer

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "pnpm": {
     "overrides": {
       "path-to-regexp@>=8.0.0 <8.4.0": ">=8.4.0",
-      "picomatch@>=4.0.0 <4.0.4": ">=4.0.4"
+      "picomatch@>=4.0.0 <4.0.4": ">=4.0.4",
+      "defu@>=6.0.0 <6.1.5": ">=6.1.5"
     }
   },
   "packageManager": "pnpm@10.32.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,7 @@ catalogs:
 overrides:
   path-to-regexp@>=8.0.0 <8.4.0: '>=8.4.0'
   picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
+  defu@>=6.0.0 <6.1.5: '>=6.1.5'
 
 importers:
 
@@ -5278,8 +5279,8 @@ packages:
     resolution: {integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==}
     engines: {node: '>=0.10.0'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.6:
+    resolution: {integrity: sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -15265,7 +15266,7 @@ snapshots:
       is-descriptor: 1.0.3
       isobject: 3.0.1
 
-  defu@6.1.4: {}
+  defu@6.1.6: {}
 
   delayed-stream@1.0.0: {}
 
@@ -16103,7 +16104,7 @@ snapshots:
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.5
-      defu: 6.1.4
+      defu: 6.1.6
       destr: 2.0.5
       iron-webcrypto: 1.2.1
       node-mock-http: 1.0.4

--- a/service/bot-dashboard/src/features/guild/domain/guild.test.ts
+++ b/service/bot-dashboard/src/features/guild/domain/guild.test.ts
@@ -54,6 +54,22 @@ describe("GuildSummary", () => {
         },
       },
       {
+        label: "admin via ADMINISTRATOR only (0x08)",
+        raw: {
+          id: "guild-2",
+          name: "Admin Only",
+          icon: null,
+          permissions: "8",
+        },
+        expected: {
+          id: "guild-2",
+          name: "Admin Only",
+          icon: null,
+          isAdmin: true,
+          botInstalled: false,
+        },
+      },
+      {
         label: "admin via combined permission bits (0x20 | 0x08 = 40)",
         raw: {
           id: "guild-2",

--- a/service/bot-dashboard/src/features/guild/domain/guild.ts
+++ b/service/bot-dashboard/src/features/guild/domain/guild.ts
@@ -4,6 +4,7 @@ import {
   type ChannelConfigType,
 } from "~/features/channel/domain/channel-config";
 
+const ADMINISTRATOR = 0x8;
 const MANAGE_GUILD = 0x20;
 
 const ChannelSummarySchema = z.object({
@@ -49,7 +50,7 @@ const GuildSummary = {
     id: raw.id,
     name: raw.name,
     icon: raw.icon,
-    isAdmin: (Number(raw.permissions) & MANAGE_GUILD) === MANAGE_GUILD,
+    isAdmin: (Number(raw.permissions) & (ADMINISTRATOR | MANAGE_GUILD)) !== 0,
     botInstalled: botGuildIds.has(raw.id),
   }),
 

--- a/service/bot-dashboard/src/features/guild/repository/vspo-guild-api.ts
+++ b/service/bot-dashboard/src/features/guild/repository/vspo-guild-api.ts
@@ -31,6 +31,27 @@ const VspoGuildApiRepository = {
     if (result.err) return result;
     return Ok(new Set(result.val));
   },
+
+  /**
+   * Retrieve bot statistics (guild count and total member count).
+   * Calls vspo-server's DiscordService.getBotStats() via RPC.
+   *
+   * @param appWorker - APP_WORKER service binding to vspo-server
+   * @returns Bot statistics with guild count and total member count
+   * @idempotent true
+   */
+  getBotStats: async (
+    appWorker: ApplicationService,
+  ): Promise<
+    Result<{ guildCount: number; totalMemberCount: number }, AppError>
+  > => {
+    if (isRpcUnavailable(appWorker)) {
+      return Ok(devMock.botStats);
+    }
+
+    const discord = appWorker.newDiscordUsecase();
+    return discord.getBotStats();
+  },
 } as const;
 
 export { VspoGuildApiRepository };

--- a/service/bot-dashboard/src/features/shared/dev-mock.ts
+++ b/service/bot-dashboard/src/features/shared/dev-mock.ts
@@ -129,4 +129,6 @@ export const devMock = {
   }),
 
   botGuildIds: new Set<string>([DEV_GUILD_ID]),
+
+  botStats: { guildCount: 42, totalMemberCount: 1234 },
 } as const;

--- a/service/bot-dashboard/src/i18n/dict.ts
+++ b/service/bot-dashboard/src/i18n/dict.ts
@@ -5,7 +5,7 @@ const ja = {
 
   // Login page
   "login.title": "ログイン",
-  "login.headline": "すぽじゅーる Bot をサーバーに追加",
+  "login.headline": "ぶいすぽっ!の配信予定を\nDiscord に届ける",
   "login.description":
     "ぶいすぽっ!メンバーの配信予定を Discord に自動で届けます",
   "login.button": "Discord でログイン",
@@ -13,6 +13,8 @@ const ja = {
   "login.previewCaption": "配信予定を、こんな感じで通知します",
   "login.previewAlt1": "ぶいすぽっ!公式メンバーの配信通知例",
   "login.previewAlt2": "個別メンバーの配信通知例",
+  "login.stat.servers": "サーバー",
+  "login.stat.users": "総利用者数",
   "login.permissions_note": "サーバー一覧の読み取り権限のみ使用します",
   "login.footer": "Powered by すぽじゅーる",
   "login.footer.link": "配信予定を確認する",
@@ -176,7 +178,7 @@ const en: Record<keyof typeof ja, string> = {
 
   // Login page
   "login.title": "Login",
-  "login.headline": "Add Spodule Bot to your server",
+  "login.headline": "Deliver VSPO stream\nschedules to Discord",
   "login.description":
     "Get automatic Discord notifications for VSPO member streams",
   "login.button": "Login with Discord",
@@ -184,6 +186,8 @@ const en: Record<keyof typeof ja, string> = {
   "login.previewCaption": "Here's what notifications look like",
   "login.previewAlt1": "Example notification for official VSPO member streams",
   "login.previewAlt2": "Example notification for individual member streams",
+  "login.stat.servers": "Servers",
+  "login.stat.users": "Total Users",
   "login.permissions_note": "Only requests read access to your server list",
   "login.footer": "Powered by Spodule",
   "login.footer.link": "View stream schedules",

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -5,6 +5,7 @@ import Button from "~/components/ui/Button.astro";
 import LanguageSelector from "~/components/ui/LanguageSelector.astro";
 import ThemeToggle from "~/components/ui/ThemeToggle.astro";
 import { t } from "~/i18n/dict";
+import { VspoGuildApiRepository } from "~/features/guild/repository/vspo-guild-api";
 
 if (Astro.locals.user && !Astro.url.searchParams.has("preview")) {
   return Astro.redirect("/dashboard");
@@ -13,6 +14,9 @@ if (Astro.locals.user && !Astro.url.searchParams.has("preview")) {
 const locale = Astro.locals.locale;
 const botClientId = env.DISCORD_BOT_CLIENT_ID;
 const botInviteUrl = `https://discord.com/oauth2/authorize?client_id=${botClientId}&permissions=2048&scope=bot%20applications.commands`;
+
+const statsResult = await VspoGuildApiRepository.getBotStats(env.APP_WORKER);
+const stats = statsResult.err ? null : statsResult.val;
 
 const errorParam = Astro.url.searchParams.get("error");
 const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || errorParam === "fetch_failed" || errorParam === "invalid_state"
@@ -48,13 +52,36 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
           </div>
 
           {/* Headline */}
-          <h1 class="mb-6 font-heading text-4xl font-extrabold tracking-tight text-on-surface sm:text-5xl md:text-6xl">
+          <h1 class="mb-6 font-heading text-4xl font-extrabold tracking-tight text-on-surface sm:text-5xl md:text-6xl" style="white-space: pre-line;">
             {t(locale, "login.headline")}
           </h1>
 
-          <p class="mb-10 max-w-xl text-base leading-relaxed text-on-surface-variant sm:text-lg" style="text-wrap: balance;">
+          <p class="mb-8 max-w-xl text-base leading-relaxed text-on-surface-variant sm:text-lg" style="text-wrap: balance;">
             {t(locale, "login.description")}
           </p>
+
+          {/* Stats */}
+          {stats && (
+            <div class="mb-10 flex items-center justify-center gap-6">
+              <div class="text-center">
+                <div class="text-2xl font-extrabold tabular-nums text-on-surface sm:text-3xl">
+                  {stats.guildCount.toLocaleString()}
+                </div>
+                <div class="text-xs font-medium tracking-wide text-on-surface-variant">
+                  {t(locale, "login.stat.servers")}
+                </div>
+              </div>
+              <div class="h-8 w-px bg-border/50" aria-hidden="true"></div>
+              <div class="text-center">
+                <div class="text-2xl font-extrabold tabular-nums text-on-surface sm:text-3xl">
+                  {stats.totalMemberCount.toLocaleString()}
+                </div>
+                <div class="text-xs font-medium tracking-wide text-on-surface-variant">
+                  {t(locale, "login.stat.users")}
+                </div>
+              </div>
+            </div>
+          )}
 
           {/* Error */}
           {errorKey && (

--- a/service/vspo-schedule/v2/web/src/features/shared/types/api.d.ts
+++ b/service/vspo-schedule/v2/web/src/features/shared/types/api.d.ts
@@ -2505,6 +2505,12 @@ declare class DiscordService extends RpcTarget {
   listBotGuildIds(): Promise<
     _vspo_lab_error.Result<string[], _vspo_lab_error.AppError>
   >;
+  getBotStats(): Promise<
+    _vspo_lab_error.Result<
+      { guildCount: number; totalMemberCount: number },
+      _vspo_lab_error.AppError
+    >
+  >;
   listGuildChannels(guildId: string): Promise<
     _vspo_lab_error.Result<
       { id: string; name: string; type: number; position: number }[],


### PR DESCRIPTION
## Summary
- ヘッドラインを「ぶいすぽっ!の配信予定を Discord に届ける」に変更（プロダクト紹介型）
- Bot 統計（サーバー数・総利用者数）を RPC `getBotStats()` 経由で取得しヒーローセクションに表示
- 取得失敗時はスタッツ非表示でページ自体はブロックしない

## Dependencies
- vspo-server 側で `getBotStats` RPC の追加が必要（別 PR: vspo-lab/vspo-server#TBD）

## Test plan
- [x] `pnpm vitest run src/i18n/dict.test.ts` — パス
- [x] `pnpm vitest run src/features/guild/domain/guild.test.ts` — パス
- [ ] vspo-server 側の `getBotStats` デプロイ後、ランディングページで統計が表示されることを確認