### PR TITLE
fix(bot-dashboard): add token refresh, fix redirect loop, always show sidebar

### DIFF
--- a/service/bot-dashboard/src/layouts/Dashboard.astro
+++ b/service/bot-dashboard/src/layouts/Dashboard.astro
@@ -25,7 +25,7 @@ const returnTo = Astro.url.pathname + Astro.url.search;
 const sidebarChannelsHref = activeGuild ? `/dashboard/${activeGuild.id}` : "/dashboard";
 const sidebarAnnouncementsHref = activeGuild
   ? `/dashboard/${activeGuild.id}/announcements`
-  : "/dashboard";
+  : "/dashboard/announcements";
 ---
 
 <Base title={title} description={description} noindex>

--- a/service/bot-dashboard/src/middleware.ts
+++ b/service/bot-dashboard/src/middleware.ts
@@ -1,5 +1,10 @@
+import { getCurrentUTCDate } from "@vspo-lab/dayjs";
 import { defineMiddleware } from "astro:middleware";
 import { env } from "cloudflare:workers";
+import { DiscordApiRepository } from "~/features/auth/repository/discord-api";
+
+/** Buffer in ms — refresh 5 minutes before actual expiry. */
+const REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
 const MOCK_USER = {
   id: "000000000000000000",
@@ -21,12 +26,46 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   const user = await context.session?.get("user");
   context.locals.user = user ?? null;
-  context.locals.accessToken = user
-    ? ((await context.session?.get("accessToken")) ?? null)
-    : null;
 
-  if (!user && context.url.pathname.startsWith("/dashboard")) {
-    return context.redirect("/");
+  if (!user) {
+    context.locals.accessToken = null;
+    if (context.url.pathname.startsWith("/dashboard")) {
+      return context.redirect("/");
+    }
+    return next();
+  }
+
+  // Check token expiry and refresh if needed
+  const expiresAt = (await context.session?.get("expiresAt")) ?? 0;
+  const now = getCurrentUTCDate().getTime();
+
+  if (now >= expiresAt - REFRESH_BUFFER_MS) {
+    const refreshToken = await context.session?.get("refreshToken");
+    if (!refreshToken) {
+      context.session?.destroy();
+      return context.redirect("/?error=auth_failed");
+    }
+
+    const refreshResult = await DiscordApiRepository.refreshToken({
+      refreshToken,
+      clientId: env.DISCORD_CLIENT_ID,
+      clientSecret: env.DISCORD_CLIENT_SECRET,
+    });
+
+    if (refreshResult.err) {
+      context.session?.destroy();
+      return context.redirect("/?error=auth_failed");
+    }
+
+    const tokens = refreshResult.val;
+    const newExpiresAt = now + tokens.expires_in * 1000;
+    context.session?.set("accessToken", tokens.access_token);
+    context.session?.set("refreshToken", tokens.refresh_token);
+    context.session?.set("expiresAt", newExpiresAt);
+    context.locals.accessToken = tokens.access_token;
+  } else {
+    context.locals.accessToken =
+      (await context.session?.get("accessToken")) ?? null;
   }
 
   return next();

--- a/service/bot-dashboard/src/middleware.ts
+++ b/service/bot-dashboard/src/middleware.ts
@@ -1,6 +1,6 @@
-import { getCurrentUTCDate } from "@vspo-lab/dayjs";
 import { defineMiddleware } from "astro:middleware";
 import { env } from "cloudflare:workers";
+import { getCurrentUTCDate } from "@vspo-lab/dayjs";
 import { DiscordApiRepository } from "~/features/auth/repository/discord-api";
 
 /** Buffer in ms — refresh 5 minutes before actual expiry. */

--- a/service/bot-dashboard/src/pages/dashboard/announcements.astro
+++ b/service/bot-dashboard/src/pages/dashboard/announcements.astro
@@ -1,0 +1,71 @@
+---
+import Dashboard from "~/layouts/Dashboard.astro";
+import { t } from "~/i18n/dict";
+import { announcements } from "~/features/announcement/data/announcements";
+
+const accessToken = Astro.locals.accessToken;
+if (!accessToken) return Astro.redirect("/");
+
+const locale = Astro.locals.locale;
+---
+
+<Dashboard
+  title={t(locale, "announcements.title")}
+  showSidebar
+  activeGuild={null}
+>
+  <div class="space-y-6">
+    <div>
+      <h1 class="font-heading text-2xl font-extrabold tracking-tight sm:text-3xl">
+        {t(locale, "announcements.title")}
+      </h1>
+    </div>
+
+    {announcements.length === 0 ? (
+      <p class="py-12 text-center text-on-surface-variant">
+        {t(locale, "announcements.empty")}
+      </p>
+    ) : (
+      <div class="space-y-4">
+        {announcements.map((item) => {
+          const typeColors = {
+            info: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+            update: "bg-vspo-purple/10 text-vspo-purple",
+            maintenance: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+          };
+          const typeKey = `announcements.type.${item.type}` as const;
+          return (
+            <article class="rounded-xl bg-surface-container-low p-6">
+              <div class="mb-3 flex items-center gap-3">
+                <span
+                  class={`rounded-full px-2.5 py-0.5 text-xs font-medium ${typeColors[item.type]}`}
+                >
+                  {t(locale, typeKey)}
+                </span>
+                <time
+                  class="text-xs text-on-surface-variant"
+                  datetime={item.date}
+                >
+                  {new Date(item.date).toLocaleDateString(
+                    locale === "ja" ? "ja-JP" : "en-US",
+                    {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    },
+                  )}
+                </time>
+              </div>
+              <h2 class="mb-2 font-heading text-lg font-bold text-on-surface">
+                {item.title[locale as keyof typeof item.title] ?? item.title.ja}
+              </h2>
+              <p class="text-sm leading-relaxed text-on-surface-variant">
+                {item.body[locale as keyof typeof item.body] ?? item.body.ja}
+              </p>
+            </article>
+          );
+        })}
+      </div>
+    )}
+  </div>
+</Dashboard>

--- a/service/bot-dashboard/src/pages/dashboard/index.astro
+++ b/service/bot-dashboard/src/pages/dashboard/index.astro
@@ -16,15 +16,13 @@ const result = await ListGuildsUsecase.execute({
   appWorker: env.APP_WORKER,
 });
 
-if (result.err) {
-  return Astro.redirect("/?error=fetch_failed");
-}
-
-const { installed, notInstalled } = result.val;
+const fetchError = result.err ?? null;
+const installed = result.err ? [] : result.val.installed;
+const notInstalled = result.err ? [] : result.val.notInstalled;
 const botClientId = env.DISCORD_BOT_CLIENT_ID;
 ---
 
-<Dashboard title={t(locale, "dashboard.servers")} description={t(locale, "meta.dashboard.description")}>
+<Dashboard title={t(locale, "dashboard.servers")} description={t(locale, "meta.dashboard.description")} showSidebar>
   <div class="mx-auto max-w-7xl space-y-10">
     <div class="space-y-2">
       <h1 class="font-heading text-3xl font-extrabold tracking-tight text-on-surface sm:text-4xl">{t(locale, "dashboard.servers")}</h1>
@@ -32,6 +30,18 @@ const botClientId = env.DISCORD_BOT_CLIENT_ID;
         {t(locale, "dashboard.servers.desc")}
       </p>
     </div>
+
+    {
+      fetchError && (
+        <div role="alert" class="flex items-center gap-3 rounded-xl bg-destructive/10 p-4 text-sm text-on-surface">
+          <svg class="h-5 w-5 shrink-0 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" /></svg>
+          <span class="flex-1">{t(locale, "error.fetch_failed")}</span>
+          <a href="/dashboard" class="shrink-0 rounded-lg px-3 py-2 text-xs font-medium text-on-surface-variant hover:bg-surface-container-highest hover:text-on-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vspo-purple/50">
+            {t(locale, "toast.retry")}
+          </a>
+        </div>
+      )
+    }
 
     {
       installed.length > 0 && (
@@ -62,7 +72,7 @@ const botClientId = env.DISCORD_BOT_CLIENT_ID;
     }
 
     {
-      installed.length === 0 && notInstalled.length === 0 && (
+      !fetchError && installed.length === 0 && notInstalled.length === 0 && (
         <p class="text-on-surface-variant">
           {t(locale, "dashboard.noServers")}
         </p>

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -7,7 +7,7 @@ import ThemeToggle from "~/components/ui/ThemeToggle.astro";
 import { t } from "~/i18n/dict";
 import { VspoGuildApiRepository } from "~/features/guild/repository/vspo-guild-api";
 
-if (Astro.locals.user && !Astro.url.searchParams.has("preview")) {
+if (Astro.locals.user && !Astro.url.searchParams.has("preview") && !Astro.url.searchParams.has("error")) {
   return Astro.redirect("/dashboard");
 }
 


### PR DESCRIPTION
## Summary

- **トークン自動リフレッシュ追加**: ミドルウェアで `expiresAt` をチェックし、期限切れ5分前に `DiscordApiRepository.refreshToken()` で自動更新。失敗時はセッション破棄→再ログインへ
- **リダイレクトループ修正**: ログイン済みユーザーがAPI失敗で `/?error=fetch_failed` に飛ばされた際、ランディングページが `/dashboard` に戻す無限ループを修正
- **サイドバー常時表示**: ギルド一覧ページでもサイドバーを表示し、お知らせ等へのナビゲーションを確保
- **ギルドID不要のお知らせページ新設**: `/dashboard/announcements` でギルドに依存せずお知らせを閲覧可能に
- **インラインエラー表示**: API エラー時にリダイレクトせず、ダッシュボード内でエラーバナーを表示