### PR TITLE
fix(bot-dashboard): humanize UI text, remove AI writing patterns

### DIFF
--- a/service/bot-dashboard/src/features/announcement/data/announcements.ts
+++ b/service/bot-dashboard/src/features/announcement/data/announcements.ts
@@ -31,8 +31,8 @@ const announcements: readonly AnnouncementType[] = [
       en: "Multi-language Notifications Now Available",
     },
     body: {
-      ja: "日本語・英語に加えて、フランス語・ドイツ語・スペイン語・中国語（簡体/繁体）・韓国語での通知に対応しました。",
-      en: "Notifications are now available in French, German, Spanish, Simplified/Traditional Chinese, and Korean, in addition to Japanese and English.",
+      ja: "フランス語・ドイツ語・スペイン語・中国語（簡体/繁体）・韓国語での通知を追加しました。",
+      en: "Added French, German, Spanish, Chinese (Simplified/Traditional), and Korean.",
     },
     date: "2026-03-15T00:00:00Z",
     type: "update",
@@ -44,8 +44,8 @@ const announcements: readonly AnnouncementType[] = [
       en: "Spodule Bot Service Launch",
     },
     body: {
-      ja: "ぶいすぽっ!メンバーの配信予定をDiscordに自動通知するBotのサービスを開始しました。",
-      en: "We've launched the bot service that automatically notifies VSPO member stream schedules to Discord.",
+      ja: "ぶいすぽっ!メンバーの配信予定をDiscordに届けるBotを公開しました。",
+      en: "The bot now sends VSPO stream schedules to Discord.",
     },
     date: "2026-03-01T00:00:00Z",
     type: "info",

--- a/service/bot-dashboard/src/i18n/dict.ts
+++ b/service/bot-dashboard/src/i18n/dict.ts
@@ -31,8 +31,7 @@ const ja = {
   "login.cta.headline": "使ってみる",
   "login.cta.description": "スラッシュコマンド不要、登録だけで使えます。",
   "login.feature.realtime": "コマンド入力なし",
-  "login.feature.realtime.desc":
-    "設定はすべてブラウザで完結します",
+  "login.feature.realtime.desc": "設定はすべてブラウザで完結します",
   "login.feature.settings": "Webで設定管理",
   "login.feature.settings.desc":
     "ダッシュボードから通知チャンネルや対象メンバーを変更",

--- a/service/bot-dashboard/src/i18n/dict.ts
+++ b/service/bot-dashboard/src/i18n/dict.ts
@@ -27,16 +27,15 @@ const ja = {
     "チャンネルごとに JP / EN メンバーやカスタム選択で絞り込み",
   "login.pageSettings": "ページ設定",
   "login.features": "機能紹介",
-  "login.features.desc":
-    "コマンド不要。ブラウザだけで権限・言語・メンバーを管理。",
-  "login.cta.headline": "はじめよう",
-  "login.cta.description": "無料で今すぐ始められます。スラッシュコマンド不要。",
+  "login.features.desc": "コマンド不要。ブラウザだけで設定できます。",
+  "login.cta.headline": "使ってみる",
+  "login.cta.description": "スラッシュコマンド不要、登録だけで使えます。",
   "login.feature.realtime": "コマンド入力なし",
   "login.feature.realtime.desc":
-    "ブラウザ操作だけで完了。スラッシュコマンドは使いません",
-  "login.feature.settings": "ブラウザで設定管理",
+    "設定はすべてブラウザで完結します",
+  "login.feature.settings": "Webで設定管理",
   "login.feature.settings.desc":
-    "Webダッシュボードから通知チャンネルや対象メンバーを変更",
+    "ダッシュボードから通知チャンネルや対象メンバーを変更",
 
   // Dashboard
   "dashboard.servers": "サーバー一覧",
@@ -178,9 +177,9 @@ const en: Record<keyof typeof ja, string> = {
 
   // Login page
   "login.title": "Login",
-  "login.headline": "Deliver VSPO stream\nschedules to Discord",
+  "login.headline": "VSPO stream schedules,\nright in Discord",
   "login.description":
-    "Get automatic Discord notifications for VSPO member streams",
+    "Automatic Discord notifications for VSPO member streams",
   "login.button": "Login with Discord",
   "login.addBot": "Add to Server",
   "login.previewCaption": "Here's what notifications look like",
@@ -195,22 +194,22 @@ const en: Record<keyof typeof ja, string> = {
   "login.footer.privacy": "Privacy Policy",
   "login.feature.list": "All servers, one screen",
   "login.feature.list.desc":
-    "Check and change settings across servers without switching",
+    "View and edit settings for all your servers in one place",
   "login.feature.filter": "Pick who to notify",
   "login.feature.filter.desc":
     "Filter by JP, EN, or select individual members per channel",
   "login.pageSettings": "Page settings",
   "login.features": "Features",
   "login.features.desc":
-    "No commands required. Manage permissions, language, and members from your browser.",
-  "login.cta.headline": "Get Started",
+    "No commands required. Set everything up in your browser.",
+  "login.cta.headline": "Try it out",
   "login.cta.description": "Free to use. No slash commands needed.",
-  "login.feature.realtime": "No commands needed",
+  "login.feature.realtime": "Browser only",
   "login.feature.realtime.desc":
-    "Everything works from the browser. No slash commands involved",
-  "login.feature.settings": "Browser-based settings",
+    "All setup happens in your browser, no slash commands",
+  "login.feature.settings": "Settings from the web",
   "login.feature.settings.desc":
-    "Change notification channels and target members from the web dashboard",
+    "Change notification channels and target members from the dashboard",
 
   // Dashboard
   "dashboard.servers": "Servers",
@@ -250,7 +249,7 @@ const en: Record<keyof typeof ja, string> = {
   "channel.table": "Channel settings",
   "channel.deleteConfirm": "Delete #{channelName}?",
   "channel.deleteConfirm.desc":
-    "This action cannot be undone. The Bot configuration for this channel will be permanently removed.",
+    "This permanently deletes the Bot configuration for this channel.",
   "channel.deleteConfirm.cancel": "Cancel",
   "channel.deleteConfirm.submit": "Delete",
 
@@ -326,10 +325,10 @@ const en: Record<keyof typeof ja, string> = {
   "error.invalid_state": "Invalid authentication request. Please try again.",
 
   // Toast / feedback
-  "toast.addSuccess": "Channel added successfully.",
+  "toast.addSuccess": "Channel added.",
   "toast.updateSuccess": "Channel settings updated.",
   "toast.deleteSuccess": "Channel configuration deleted.",
-  "toast.resetSuccess": "Channel settings have been reset to default.",
+  "toast.resetSuccess": "Settings reset to default.",
   "toast.dismiss": "Dismiss",
   "toast.retry": "Reload",
 
@@ -338,7 +337,7 @@ const en: Record<keyof typeof ja, string> = {
 
   // Meta descriptions
   "meta.login.description":
-    "Get automatic Discord notifications for VSPO member streams. No commands needed — set up everything from your browser.",
+    "Discord notifications for VSPO streams. Set up from your browser, no commands needed.",
   "meta.dashboard.description":
     "Manage notification settings for your Discord servers.",
   "meta.guildDetail.description":


### PR DESCRIPTION
## Summary

- Rule of Three、広告調コピー、冗長 filler を除去
- 「コマンド不要」「ブラウザだけ」の重複表現を整理
- トースト・削除確認の EN テキストを簡潔化
- アナウンスメントの JA/EN コピーをシンプルに