### PR TITLE
feat(bot-dashboard): fix guild admin detection with owner field and server-side role check

### DIFF
--- a/service/bot-dashboard/src/features/auth/repository/discord-api.ts
+++ b/service/bot-dashboard/src/features/auth/repository/discord-api.ts
@@ -32,7 +32,8 @@ const DiscordApiGuildSchema = z.object({
   id: z.string(),
   name: z.string(),
   icon: z.string().nullable(),
-  permissions: z.string(),
+  owner: z.boolean().optional().default(false),
+  permissions: z.string().optional().default("0"),
 });
 
 type DiscordApiGuild = z.infer<typeof DiscordApiGuildSchema>;
@@ -152,13 +153,15 @@ const DiscordApiRepository = {
           id: "111111111111111111",
           name: "Dev Server 1",
           icon: null,
-          permissions: "32",
+          owner: true,
+          permissions: "0",
         },
         {
           id: "222222222222222222",
           name: "Dev Server 2",
           icon: null,
-          permissions: "32",
+          owner: false,
+          permissions: "0",
         },
       ]);
     }

--- a/service/bot-dashboard/src/features/guild/domain/guild.test.ts
+++ b/service/bot-dashboard/src/features/guild/domain/guild.test.ts
@@ -6,12 +6,12 @@ describe("GuildSummary", () => {
   describe("fromDiscordGuild", () => {
     it.each([
       {
-        label: "admin with bot installed",
+        label: "owner with bot installed",
         raw: {
           id: "guild-1",
           name: "My Server",
           icon: "abc123",
-          permissions: "32",
+          owner: true,
         },
         expected: {
           id: "guild-1",
@@ -22,28 +22,28 @@ describe("GuildSummary", () => {
         },
       },
       {
-        label: "admin without bot",
+        label: "non-owner without bot",
         raw: {
           id: "guild-2",
           name: "Other",
           icon: null,
-          permissions: "32",
+          owner: false,
         },
         expected: {
           id: "guild-2",
           name: "Other",
           icon: null,
-          isAdmin: true,
+          isAdmin: false,
           botInstalled: false,
         },
       },
       {
-        label: "non-admin (permissions=0)",
+        label: "non-owner with bot (isAdmin defaults to false)",
         raw: {
           id: "guild-1",
           name: "No Admin",
           icon: null,
-          permissions: "0",
+          owner: false,
         },
         expected: {
           id: "guild-1",
@@ -53,40 +53,34 @@ describe("GuildSummary", () => {
           botInstalled: true,
         },
       },
-      {
-        label: "admin via ADMINISTRATOR only (0x08)",
-        raw: {
-          id: "guild-2",
-          name: "Admin Only",
-          icon: null,
-          permissions: "8",
-        },
-        expected: {
-          id: "guild-2",
-          name: "Admin Only",
-          icon: null,
-          isAdmin: true,
-          botInstalled: false,
-        },
-      },
-      {
-        label: "admin via combined permission bits (0x20 | 0x08 = 40)",
-        raw: {
-          id: "guild-2",
-          name: "Combined",
-          icon: null,
-          permissions: "40",
-        },
-        expected: {
-          id: "guild-2",
-          name: "Combined",
-          icon: null,
-          isAdmin: true,
-          botInstalled: false,
-        },
-      },
     ])("$label", ({ raw, expected }) => {
       expect(GuildSummary.fromDiscordGuild(raw, botGuildIds)).toEqual(expected);
+    });
+  });
+
+  describe("withAdminOverride", () => {
+    it("sets isAdmin to true when server check is true", () => {
+      const guild: GuildSummaryType = {
+        id: "1",
+        name: "A",
+        icon: null,
+        isAdmin: false,
+        botInstalled: true,
+      };
+      const result = GuildSummary.withAdminOverride(guild, true);
+      expect(result.isAdmin).toBe(true);
+    });
+
+    it("preserves isAdmin true when server check is false (owner)", () => {
+      const guild: GuildSummaryType = {
+        id: "1",
+        name: "A",
+        icon: null,
+        isAdmin: true,
+        botInstalled: true,
+      };
+      const result = GuildSummary.withAdminOverride(guild, false);
+      expect(result.isAdmin).toBe(true);
     });
   });
 

--- a/service/bot-dashboard/src/features/guild/domain/guild.ts
+++ b/service/bot-dashboard/src/features/guild/domain/guild.ts
@@ -4,9 +4,6 @@ import {
   type ChannelConfigType,
 } from "~/features/channel/domain/channel-config";
 
-const ADMINISTRATOR = 0x8;
-const MANAGE_GUILD = 0x20;
-
 const ChannelSummarySchema = z.object({
   enabledCount: z.number().int().nonnegative(),
   totalCount: z.number().int().nonnegative(),
@@ -32,10 +29,10 @@ const GuildSummary = {
   /**
    * Builds a guild summary from a Discord guild payload.
    *
-   * @param raw - Discord guild data including the permission bitset string
+   * @param raw - Discord guild data including the owner flag
    * @param botGuildIds - Guild IDs where the bot is already installed
-   * @returns Guild summary with installation and manageability flags derived from the inputs
-   * @precondition raw.id !== "" && raw.name !== "" && Number.isFinite(Number(raw.permissions))
+   * @returns Guild summary with installation and admin flags derived from the inputs
+   * @precondition raw.id !== "" && raw.name !== ""
    * @postcondition return.id === raw.id && return.name === raw.name && return.botInstalled === botGuildIds.has(raw.id)
    */
   fromDiscordGuild: (
@@ -43,14 +40,14 @@ const GuildSummary = {
       id: string;
       name: string;
       icon: string | null;
-      permissions: string;
+      owner: boolean;
     },
     botGuildIds: ReadonlySet<string>,
   ): GuildSummary => ({
     id: raw.id,
     name: raw.name,
     icon: raw.icon,
-    isAdmin: (Number(raw.permissions) & (ADMINISTRATOR | MANAGE_GUILD)) !== 0,
+    isAdmin: raw.owner,
     botInstalled: botGuildIds.has(raw.id),
   }),
 
@@ -109,6 +106,20 @@ const GuildSummary = {
       },
     };
   },
+
+  /**
+   * Returns a new guild summary with isAdmin overridden by a server-side check.
+   *
+   * @param guild - Existing guild summary
+   * @param isAdmin - Result of a server-side admin role check
+   * @returns New guild summary where isAdmin is true if either the guild or the server check indicates admin
+   * @precondition guild must already be constructed via fromDiscordGuild
+   * @postcondition return.isAdmin === (guild.isAdmin || isAdmin)
+   */
+  withAdminOverride: (guild: GuildSummary, isAdmin: boolean): GuildSummary => ({
+    ...guild,
+    isAdmin: guild.isAdmin || isAdmin,
+  }),
 } as const;
 
 const GuildBotConfigSchema = z.object({

--- a/service/bot-dashboard/src/features/guild/repository/vspo-guild-api.ts
+++ b/service/bot-dashboard/src/features/guild/repository/vspo-guild-api.ts
@@ -59,6 +59,8 @@ const VspoGuildApiRepository = {
    * @param userId - Discord user ID to check
    * @param guildIds - Guild IDs to check (must be guilds where bot is installed)
    * @returns Record mapping guild ID to admin boolean
+   * @precondition userId is a non-empty string and guildIds are guilds where the bot is installed
+   * @postcondition On Ok, returned record maps each input guild ID to a boolean indicating admin status
    * @idempotent true
    */
   checkUserGuildAdmin: async (

--- a/service/bot-dashboard/src/features/guild/repository/vspo-guild-api.ts
+++ b/service/bot-dashboard/src/features/guild/repository/vspo-guild-api.ts
@@ -52,6 +52,27 @@ const VspoGuildApiRepository = {
     const discord = appWorker.newDiscordUsecase();
     return discord.getBotStats();
   },
+  /**
+   * Check if a user has admin permissions in the specified guilds via bot token.
+   *
+   * @param appWorker - APP_WORKER service binding
+   * @param userId - Discord user ID to check
+   * @param guildIds - Guild IDs to check (must be guilds where bot is installed)
+   * @returns Record mapping guild ID to admin boolean
+   * @idempotent true
+   */
+  checkUserGuildAdmin: async (
+    appWorker: ApplicationService,
+    userId: string,
+    guildIds: string[],
+  ): Promise<Result<Record<string, boolean>, AppError>> => {
+    if (isRpcUnavailable(appWorker)) {
+      return Ok(devMock.userGuildAdmin);
+    }
+
+    const discord = appWorker.newDiscordUsecase();
+    return discord.checkUserGuildAdmin(userId, guildIds);
+  },
 } as const;
 
 export { VspoGuildApiRepository };

--- a/service/bot-dashboard/src/features/guild/usecase/list-guilds.test.ts
+++ b/service/bot-dashboard/src/features/guild/usecase/list-guilds.test.ts
@@ -1,5 +1,6 @@
 import { AppError, Err, Ok } from "@vspo-lab/error";
 import { DiscordApiRepository } from "~/features/auth/repository/discord-api";
+import { VspoChannelApiRepository } from "~/features/channel/repository/vspo-channel-api";
 import type { ApplicationService } from "~/types/api";
 import { VspoGuildApiRepository } from "../repository/vspo-guild-api";
 import { ListGuildsUsecase } from "./list-guilds";
@@ -10,47 +11,93 @@ vi.mock("~/features/auth/repository/discord-api", () => ({
   },
 }));
 
+vi.mock("~/features/channel/repository/vspo-channel-api", () => ({
+  VspoChannelApiRepository: {
+    getGuildConfig: vi.fn(),
+  },
+}));
+
 vi.mock("../repository/vspo-guild-api", () => ({
   VspoGuildApiRepository: {
     getBotGuildIds: vi.fn(),
+    checkUserGuildAdmin: vi.fn(),
   },
 }));
 
 const appWorker = {} as ApplicationService;
 
-const adminGuild = {
+const ownerGuild = {
   id: "1",
-  name: "Admin Guild",
+  name: "Owner Guild",
   icon: "icon1",
-  permissions: "32", // MANAGE_GUILD (0x20)
-};
-
-const nonAdminGuild = {
-  id: "2",
-  name: "Non-Admin Guild",
-  icon: null,
+  owner: true,
   permissions: "0",
 };
 
-const anotherAdminGuild = {
+const nonOwnerGuild = {
+  id: "2",
+  name: "Non-Owner Guild",
+  icon: null,
+  owner: false,
+  permissions: "0",
+};
+
+const anotherNonOwnerGuild = {
   id: "3",
-  name: "Another Admin",
+  name: "Another Non-Owner",
   icon: "icon3",
-  permissions: "32",
+  owner: false,
+  permissions: "0",
 };
 
 describe("ListGuildsUsecase", () => {
   describe("execute", () => {
-    it("returns only admin guilds partitioned into installed and notInstalled", async () => {
+    it("owner guilds are always admin, server check upgrades non-owner installed guilds", async () => {
       vi.mocked(DiscordApiRepository.getUserGuilds).mockResolvedValue(
-        Ok([adminGuild, nonAdminGuild, anotherAdminGuild]),
+        Ok([ownerGuild, nonOwnerGuild, anotherNonOwnerGuild]),
       );
       vi.mocked(VspoGuildApiRepository.getBotGuildIds).mockResolvedValue(
-        Ok(new Set(["1"])),
+        Ok(new Set(["1", "2"])),
+      );
+      vi.mocked(VspoGuildApiRepository.checkUserGuildAdmin).mockResolvedValue(
+        Ok({ "1": true, "2": true }),
+      );
+      vi.mocked(VspoChannelApiRepository.getGuildConfig).mockResolvedValue(
+        Ok({ channels: [] } as never),
       );
 
       const result = await ListGuildsUsecase.execute({
         accessToken: "token",
+        userId: "user-1",
+        appWorker,
+      });
+
+      expect(result.err).toBeUndefined();
+      if (result.err) return;
+      expect(result.val.installed).toHaveLength(2);
+      expect(result.val.installed.map((g) => g.id)).toEqual(["1", "2"]);
+      expect(result.val.notInstalled).toHaveLength(0);
+    });
+
+    it("falls back to owner-only when checkUserGuildAdmin fails", async () => {
+      vi.mocked(DiscordApiRepository.getUserGuilds).mockResolvedValue(
+        Ok([ownerGuild, nonOwnerGuild]),
+      );
+      vi.mocked(VspoGuildApiRepository.getBotGuildIds).mockResolvedValue(
+        Ok(new Set(["1", "2"])),
+      );
+      vi.mocked(VspoGuildApiRepository.checkUserGuildAdmin).mockResolvedValue(
+        Err(
+          new AppError({ message: "rpc error", code: "INTERNAL_SERVER_ERROR" }),
+        ),
+      );
+      vi.mocked(VspoChannelApiRepository.getGuildConfig).mockResolvedValue(
+        Ok({ channels: [] } as never),
+      );
+
+      const result = await ListGuildsUsecase.execute({
+        accessToken: "token",
+        userId: "user-1",
         appWorker,
       });
 
@@ -58,22 +105,25 @@ describe("ListGuildsUsecase", () => {
       if (result.err) return;
       expect(result.val.installed).toHaveLength(1);
       expect(result.val.installed[0].id).toBe("1");
-      expect(result.val.installed[0].botInstalled).toBe(true);
-      expect(result.val.notInstalled).toHaveLength(1);
-      expect(result.val.notInstalled[0].id).toBe("3");
-      expect(result.val.notInstalled[0].botInstalled).toBe(false);
     });
 
-    it("builds sidebarGuilds from installed guilds with iconUrl", async () => {
+    it("builds sidebarGuilds from installed admin guilds", async () => {
       vi.mocked(DiscordApiRepository.getUserGuilds).mockResolvedValue(
-        Ok([adminGuild]),
+        Ok([ownerGuild]),
       );
       vi.mocked(VspoGuildApiRepository.getBotGuildIds).mockResolvedValue(
         Ok(new Set(["1"])),
       );
+      vi.mocked(VspoGuildApiRepository.checkUserGuildAdmin).mockResolvedValue(
+        Ok({ "1": true }),
+      );
+      vi.mocked(VspoChannelApiRepository.getGuildConfig).mockResolvedValue(
+        Ok({ channels: [] } as never),
+      );
 
       const result = await ListGuildsUsecase.execute({
         accessToken: "token",
+        userId: "user-1",
         appWorker,
       });
 
@@ -82,29 +132,10 @@ describe("ListGuildsUsecase", () => {
       expect(result.val.sidebarGuilds).toEqual([
         {
           id: "1",
-          name: "Admin Guild",
+          name: "Owner Guild",
           iconUrl: "https://cdn.discordapp.com/icons/1/icon1.png",
         },
       ]);
-    });
-
-    it("returns sidebarGuilds with null iconUrl when icon is absent", async () => {
-      const adminNoIcon = { ...adminGuild, icon: null };
-      vi.mocked(DiscordApiRepository.getUserGuilds).mockResolvedValue(
-        Ok([adminNoIcon]),
-      );
-      vi.mocked(VspoGuildApiRepository.getBotGuildIds).mockResolvedValue(
-        Ok(new Set(["1"])),
-      );
-
-      const result = await ListGuildsUsecase.execute({
-        accessToken: "token",
-        appWorker,
-      });
-
-      expect(result.err).toBeUndefined();
-      if (result.err) return;
-      expect(result.val.sidebarGuilds[0].iconUrl).toBeNull();
     });
 
     it("returns Err when getUserGuilds fails", async () => {
@@ -121,6 +152,7 @@ describe("ListGuildsUsecase", () => {
 
       const result = await ListGuildsUsecase.execute({
         accessToken: "token",
+        userId: "user-1",
         appWorker,
       });
 
@@ -133,7 +165,7 @@ describe("ListGuildsUsecase", () => {
         code: "INTERNAL_SERVER_ERROR",
       });
       vi.mocked(DiscordApiRepository.getUserGuilds).mockResolvedValue(
-        Ok([adminGuild]),
+        Ok([ownerGuild]),
       );
       vi.mocked(VspoGuildApiRepository.getBotGuildIds).mockResolvedValue(
         Err(error),
@@ -141,6 +173,7 @@ describe("ListGuildsUsecase", () => {
 
       const result = await ListGuildsUsecase.execute({
         accessToken: "token",
+        userId: "user-1",
         appWorker,
       });
 
@@ -152,9 +185,13 @@ describe("ListGuildsUsecase", () => {
       vi.mocked(VspoGuildApiRepository.getBotGuildIds).mockResolvedValue(
         Ok(new Set()),
       );
+      vi.mocked(VspoGuildApiRepository.checkUserGuildAdmin).mockResolvedValue(
+        Ok({}),
+      );
 
       const result = await ListGuildsUsecase.execute({
         accessToken: "token",
+        userId: "user-1",
         appWorker,
       });
 

--- a/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
+++ b/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
@@ -26,7 +26,7 @@ type ListGuildsResult = {
  * @returns Installed guilds, not-installed guilds, and sidebar guild metadata, or an AppError
  * @precondition params.accessToken !== "" && params.userId !== "" && params.appWorker is configured
  * @postcondition On Ok, installed guilds have botInstalled === true and isAdmin === true
- * @idempotent true
+ * @idempotent true - repeated calls with unchanged upstream data yield the same categorization
  */
 const execute = async (
   params: ListGuildsParams,

--- a/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
+++ b/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
@@ -9,6 +9,7 @@ import { VspoGuildApiRepository } from "../repository/vspo-guild-api";
 
 type ListGuildsParams = {
   accessToken: string;
+  userId: string;
   appWorker: ApplicationService;
 };
 
@@ -21,11 +22,11 @@ type ListGuildsResult = {
 /**
  * Retrieves the guilds the current user can manage and categorizes them for the dashboard.
  *
- * @param params - Discord access token and app worker binding used to query guild data
+ * @param params - Discord access token, user ID, and app worker binding
  * @returns Installed guilds, not-installed guilds, and sidebar guild metadata, or an AppError
- * @precondition params.accessToken !== "" && params.appWorker is a configured ApplicationService
- * @postcondition On Ok, every guild in return.val.installed has botInstalled === true and return.val.sidebarGuilds is derived from return.val.installed
- * @idempotent true - The use case is read-only and repeated calls against unchanged upstream data yield the same categorization
+ * @precondition params.accessToken !== "" && params.userId !== "" && params.appWorker is configured
+ * @postcondition On Ok, installed guilds have botInstalled === true and isAdmin === true
+ * @idempotent true
  */
 const execute = async (
   params: ListGuildsParams,
@@ -41,7 +42,31 @@ const execute = async (
   const guilds = guildsResult.val.map((g) =>
     GuildSummary.fromDiscordGuild(g, botGuildIdsResult.val),
   );
-  const manageable = GuildSummary.filterManageable(guilds);
+
+  // For installed guilds, check admin permissions via bot token
+  const installedGuildIds = guilds
+    .filter((g) => g.botInstalled)
+    .map((g) => g.id);
+
+  const adminCheckResult =
+    installedGuildIds.length > 0
+      ? await VspoGuildApiRepository.checkUserGuildAdmin(
+          params.appWorker,
+          params.userId,
+          installedGuildIds,
+        )
+      : Ok({} as Record<string, boolean>);
+
+  const adminMap = adminCheckResult.err ? {} : adminCheckResult.val;
+
+  // Apply server-side admin check results to installed guilds
+  const resolvedGuilds = guilds.map((g) =>
+    g.botInstalled
+      ? GuildSummary.withAdminOverride(g, adminMap[g.id] ?? false)
+      : g,
+  );
+
+  const manageable = GuildSummary.filterManageable(resolvedGuilds);
   const { installed, notInstalled } = GuildSummary.partition(manageable);
 
   // Fetch channel configs for all installed guilds in parallel.

--- a/service/bot-dashboard/src/features/shared/dev-mock.ts
+++ b/service/bot-dashboard/src/features/shared/dev-mock.ts
@@ -131,4 +131,6 @@ export const devMock = {
   botGuildIds: new Set<string>([DEV_GUILD_ID]),
 
   botStats: { guildCount: 42, totalMemberCount: 1234 },
+
+  userGuildAdmin: { [DEV_GUILD_ID]: true } as Record<string, boolean>,
 } as const;

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -19,7 +19,8 @@ if (!guildId) {
 }
 
 const accessToken = Astro.locals.accessToken;
-if (!accessToken) {
+const user = Astro.locals.user;
+if (!accessToken || !user) {
   return Astro.redirect("/");
 }
 
@@ -29,6 +30,7 @@ const showAddModal = Astro.url.searchParams.get("add") === "true";
 const [guildsResult, channelsResult, availableChannelsResult, creatorsResult] = await Promise.all([
   ListGuildsUsecase.execute({
     accessToken,
+    userId: user.id,
     appWorker: env.APP_WORKER,
   }),
   VspoChannelApiRepository.getGuildConfig(env.APP_WORKER, guildId),

--- a/service/bot-dashboard/src/pages/dashboard/[guildId]/announcements.astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId]/announcements.astro
@@ -10,12 +10,14 @@ const { guildId } = Astro.params;
 if (!guildId) return Astro.redirect("/dashboard");
 
 const accessToken = Astro.locals.accessToken;
-if (!accessToken) return Astro.redirect("/");
+const user = Astro.locals.user;
+if (!accessToken || !user) return Astro.redirect("/");
 
 const locale = Astro.locals.locale;
 
 const guildsResult = await ListGuildsUsecase.execute({
   accessToken,
+  userId: user.id,
   appWorker: env.APP_WORKER,
 });
 

--- a/service/bot-dashboard/src/pages/dashboard/index.astro
+++ b/service/bot-dashboard/src/pages/dashboard/index.astro
@@ -7,12 +7,14 @@ import { t } from "~/i18n/dict";
 
 const locale = Astro.locals.locale;
 const accessToken = Astro.locals.accessToken;
-if (!accessToken) {
+const user = Astro.locals.user;
+if (!accessToken || !user) {
   return Astro.redirect("/");
 }
 
 const result = await ListGuildsUsecase.execute({
   accessToken,
+  userId: user.id,
   appWorker: env.APP_WORKER,
 });
 

--- a/service/vspo-schedule/v2/web/src/features/shared/types/api.d.ts
+++ b/service/vspo-schedule/v2/web/src/features/shared/types/api.d.ts
@@ -2517,6 +2517,10 @@ declare class DiscordService extends RpcTarget {
       _vspo_lab_error.AppError
     >
   >;
+  checkUserGuildAdmin(
+    userId: string,
+    guildIds: string[],
+  ): Promise<_vspo_lab_error.Result<Record<string, boolean>, _vspo_lab_error.AppError>>;
 }
 declare class EventService extends RpcTarget {
   #private;


### PR DESCRIPTION
## Summary
- Discord OAuth `permissions` フィールドが正確な権限を返さなくなった問題を修正
- `DiscordApiGuildSchema` に `owner` フィールドを追加、`permissions` をオプショナルに変更
- `GuildSummary.fromDiscordGuild` で `owner` ベースの admin 判定に移行
- インストール済みギルドは vspo-server の `checkUserGuildAdmin` RPC でロールベースの権限検証
- RPC 失敗時は `owner` のみにフォールバック

## Dependencies
- vspo-lab/vspo-server#79 (server-side `checkUserGuildAdmin` RPC)

## Test plan
- [ ] `npx vitest run` — 202/202 テスト pass
- [ ] サーバーオーナーのギルドがダッシュボードに表示されること
- [ ] 非オーナー管理者のギルド（bot インストール済み）が表示されること
- [ ] RPC エラー時にサーバーオーナーのギルドのみ表示されること