### PR TITLE
feat(bot-dashboard): convert MPA modals to SPA-like client-side interactions

### DIFF
--- a/service/bot-dashboard/src/actions/index.ts
+++ b/service/bot-dashboard/src/actions/index.ts
@@ -14,7 +14,7 @@ const requireAuth = (context: { locals: { user: unknown } }) => {
 
 export const server = {
   addChannel: defineAction({
-    accept: "form",
+    accept: "json",
     input: z.object({
       guildId: z.string(),
       channelId: z.string(),
@@ -38,7 +38,7 @@ export const server = {
   }),
 
   updateChannel: defineAction({
-    accept: "form",
+    accept: "json",
     input: z.object({
       guildId: z.string(),
       channelId: z.string(),
@@ -70,7 +70,7 @@ export const server = {
   }),
 
   resetChannel: defineAction({
-    accept: "form",
+    accept: "json",
     input: z.object({
       guildId: z.string(),
       channelId: z.string(),
@@ -95,7 +95,7 @@ export const server = {
   }),
 
   deleteChannel: defineAction({
-    accept: "form",
+    accept: "json",
     input: z.object({
       guildId: z.string(),
       channelId: z.string(),

--- a/service/bot-dashboard/src/components/channel/ChannelAddModal.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelAddModal.astro
@@ -1,24 +1,17 @@
 ---
-import { actions } from "astro:actions";
 import Button from "~/components/ui/Button.astro";
 import { t } from "~/i18n/dict";
 
 interface Props {
   guildId: string;
-  registeredChannelIds: ReadonlySet<string>;
-  availableChannels: { id: string; name: string }[];
 }
 
-const { guildId, registeredChannelIds, availableChannels } = Astro.props;
+const { guildId } = Astro.props;
 const { locale } = Astro.locals;
-const unregistered = availableChannels.filter(
-  (ch) => !registeredChannelIds.has(ch.id),
-);
 ---
 
 <dialog
-  open
-  class="animate-backdrop-in fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+  class="fixed inset-0 z-50 m-0 flex h-full w-full items-center justify-center bg-black/60 backdrop:bg-transparent"
   id="add-channel-modal"
   aria-labelledby="add-channel-heading"
   aria-modal="true"
@@ -32,9 +25,9 @@ const unregistered = availableChannels.filter(
       </h2>
       <button
         type="button"
+        data-modal-close
         class="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-surface-container-highest hover:text-on-surface"
         aria-label={t(locale, "channelConfig.close")}
-        data-close-href={`/dashboard/${guildId}`}
       >
         <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -53,100 +46,29 @@ const unregistered = availableChannels.filter(
       />
     </div>
 
-    <div class="max-h-64 space-y-1 overflow-y-auto" role="listbox" aria-label={t(locale, "channel.add")}>
-      {unregistered.length === 0 && (
-        <p class="py-8 text-center text-sm text-on-surface-variant">
-          {t(locale, "channel.add.empty")}
-        </p>
-      )}
-      <p class="hidden py-8 text-center text-sm text-on-surface-variant" data-search-empty>
-        {t(locale, "channel.add.empty")}
-      </p>
-      {unregistered.map((ch) => (
-        <form method="post" action={actions.addChannel} data-channel-item>
-          <input type="hidden" name="guildId" value={guildId} />
-          <input type="hidden" name="channelId" value={ch.id} />
-          <button
-            type="submit"
-            role="option"
-            aria-selected="false"
-            class="flex w-full items-center justify-between rounded-lg px-3 py-3 text-left text-sm transition-colors duration-[--duration-fast] hover:bg-surface-container-highest/30"
-            data-channel-name={ch.name.toLowerCase()}
-          >
-            <span class="flex items-center gap-2">
-              <svg class="h-4 w-4 shrink-0 text-on-surface-variant" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
-              </svg>
-              <span>{ch.name}</span>
-            </span>
-            <span class="text-xs font-medium text-vspo-purple">{t(locale, "channel.add.submit")}</span>
-          </button>
-        </form>
-      ))}
-      {availableChannels
-        .filter((ch) => registeredChannelIds.has(ch.id))
-        .map((ch) => (
-          <div
-            class="flex items-center justify-between rounded-lg px-3 py-3 text-sm text-on-surface-variant/50"
-            data-channel-item
-            data-channel-name={ch.name.toLowerCase()}
-          >
-            <span class="flex items-center gap-2">
-              <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
-              </svg>
-              <span>{ch.name}</span>
-            </span>
-            <span class="text-xs">{t(locale, "channel.add.registered")}</span>
-          </div>
-        ))}
+    {/* Loading state */}
+    <div class="hidden py-8 text-center" data-loading>
+      <div class="inline-block h-6 w-6 animate-spin rounded-full border-2 border-vspo-purple border-t-transparent"></div>
+    </div>
+
+    {/* No channels state */}
+    <p class="hidden py-8 text-center text-sm text-on-surface-variant" data-no-channels>
+      {t(locale, "channel.add.empty")}
+    </p>
+
+    {/* Search empty state */}
+    <p class="hidden py-8 text-center text-sm text-on-surface-variant" data-search-empty>
+      {t(locale, "channel.add.empty")}
+    </p>
+
+    {/* Channel list - populated by JS */}
+    <div class="max-h-64 space-y-1 overflow-y-auto" role="listbox" aria-label={t(locale, "channel.add")} data-channel-list>
     </div>
 
     <div class="mt-4 flex justify-end">
-      <Button as="a" href={`/dashboard/${guildId}`} variant="ghost">
+      <Button as="button" type="button" variant="ghost" data-modal-cancel>
         {t(locale, "channel.add.cancel")}
       </Button>
     </div>
   </div>
 </dialog>
-
-<script>
-  import { initModalTrap } from "~/components/ui/modal-trap";
-  const dialog = document.getElementById("add-channel-modal");
-  if (dialog) {
-    const closeBtn = dialog.querySelector<HTMLButtonElement>("button[data-close-href]");
-    const closeHref = closeBtn?.dataset.closeHref;
-    const searchInput = dialog.querySelector<HTMLInputElement>("[data-search-input]");
-    const items = dialog.querySelectorAll("[data-channel-item]");
-
-    const navigateClose = () => {
-      if (closeHref) window.location.href = closeHref;
-    };
-
-    closeBtn?.addEventListener("click", navigateClose);
-
-    // Search filter (debounced)
-    const emptyMsg = dialog.querySelector<HTMLElement>("[data-search-empty]");
-    let searchTimer: ReturnType<typeof setTimeout> | undefined;
-    searchInput?.addEventListener("input", () => {
-      clearTimeout(searchTimer);
-      searchTimer = setTimeout(() => {
-        const query = searchInput.value.toLowerCase();
-        let visibleCount = 0;
-        for (const item of items) {
-          const el = item as HTMLElement;
-          const name = el.dataset.channelName ?? el.querySelector("[data-channel-name]")?.getAttribute("data-channel-name") ?? "";
-          const show = name.includes(query);
-          el.style.display = show ? "" : "none";
-          if (show) visibleCount++;
-        }
-        if (emptyMsg) {
-          emptyMsg.classList.toggle("hidden", visibleCount > 0 || !query);
-        }
-      }, 100);
-    });
-
-    // Focus management
-    initModalTrap(dialog, navigateClose);
-  }
-</script>

--- a/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
@@ -1,35 +1,26 @@
 ---
-import { actions } from "astro:actions";
 import Button from "~/components/ui/Button.astro";
-import type { ChannelConfigType } from "~/features/channel/domain/channel-config";
 import { MemberType } from "~/features/channel/domain/member-type";
 import { Creator, type CreatorType } from "~/features/shared/domain/creator";
 import { t, memberTypeKey, memberTypeDescKey, languageDisplayKey } from "~/i18n/dict";
 
 interface Props {
-  channel: ChannelConfigType;
   creators: CreatorType[];
   guildId: string;
 }
 
-const { channel, creators, guildId } = Astro.props;
+const { creators, guildId } = Astro.props;
 const { locale } = Astro.locals;
 const memberTypeOptions = MemberType.schema.options.map((value) => ({
   value,
   label: t(locale, memberTypeKey(value)),
 }));
-const showCustomMembers = MemberType.requiresCustomSelection(
-  channel.memberType,
-);
 const jpCreators = Creator.filterByType(creators, "vspo_jp");
 const enCreators = Creator.filterByType(creators, "vspo_en");
-const customMemberSet = new Set(channel.customMembers ?? []);
-const selectedCount = customMemberSet.size;
 ---
 
 <dialog
-  open
-  class="animate-backdrop-in fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+  class="fixed inset-0 z-50 m-0 flex h-full w-full items-center justify-center bg-black/60 backdrop:bg-transparent"
   id="config-modal"
   aria-labelledby="config-modal-heading"
   aria-modal="true"
@@ -38,12 +29,12 @@ const selectedCount = customMemberSet.size;
     class="animate-modal-in glass mx-2 w-full max-w-lg rounded-xl bg-surface-container-high/90 p-4 text-on-surface shadow-hover sm:mx-4 sm:p-6"
   >
     <div class="mb-4 flex items-center justify-between">
-      <h2 id="config-modal-heading" class="font-heading text-lg font-bold text-on-surface">{t(locale, "channelConfig.title", { channelName: channel.channelName })}</h2>
+      <h2 id="config-modal-heading" data-config-heading class="font-heading text-lg font-bold text-on-surface"></h2>
       <button
         type="button"
+        data-modal-close
         class="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-surface-container-highest hover:text-on-surface"
         aria-label={t(locale, "channelConfig.close")}
-        data-close-href={`/dashboard/${guildId}`}
       >
         <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -51,9 +42,9 @@ const selectedCount = customMemberSet.size;
       </button>
     </div>
 
-    <form id="update-channel-form" method="post" action={actions.updateChannel} class="space-y-4">
+    <form id="update-channel-form" class="space-y-4">
       <input type="hidden" name="guildId" value={guildId} />
-      <input type="hidden" name="channelId" value={channel.channelId} />
+      <input type="hidden" name="channelId" value="" />
 
       <div class="space-y-2">
         <label for="language" class="text-sm font-medium">{t(locale, "channelConfig.language")}</label>
@@ -63,7 +54,7 @@ const selectedCount = customMemberSet.size;
           class="w-full rounded-md border border-outline-variant/20 bg-surface-container-low px-3 py-2 text-sm text-on-surface"
         >
           {["ja", "en", "fr", "de", "es", "cn", "tw", "ko", "default"].map((lang) => (
-            <option value={lang} selected={channel.language === lang}>
+            <option value={lang}>
               {t(locale, languageDisplayKey(lang))}
             </option>
           ))}
@@ -76,19 +67,13 @@ const selectedCount = customMemberSet.size;
           {
             memberTypeOptions.map((opt) => (
               <label
-                class:list={[
-                  "flex cursor-pointer items-start gap-2 rounded-lg p-2 transition-all",
-                  channel.memberType === opt.value
-                    ? "bg-vspo-purple/10 ring-1 ring-vspo-purple/30"
-                    : "hover:bg-surface-container-highest/50",
-                ]}
+                class="flex cursor-pointer items-start gap-2 rounded-lg p-2 transition-all hover:bg-surface-container-highest/50"
                 data-radio-label
               >
                 <input
                   type="radio"
                   name="memberType"
                   value={opt.value}
-                  checked={channel.memberType === opt.value}
                   class="mt-0.5 accent-vspo-purple"
                 />
                 <div>
@@ -102,20 +87,18 @@ const selectedCount = customMemberSet.size;
       </fieldset>
 
       <div
-        class:list={["space-y-3 overflow-hidden transition-all duration-200", showCustomMembers ? "max-h-[600px] opacity-100" : "max-h-0 opacity-0"]}
+        class="max-h-0 opacity-0 space-y-3 overflow-hidden transition-all duration-200"
         data-custom-members
-        aria-hidden={!showCustomMembers}
+        aria-hidden="true"
       >
         <div class="flex items-center justify-between">
           <span class="text-sm font-medium">{t(locale, "channelConfig.customMembers")}</span>
           <span
             class="rounded-full bg-vspo-purple/10 px-2.5 py-0.5 text-xs font-medium text-vspo-purple"
             data-selected-count
-            data-template={t(locale, "channelConfig.members.selected", { count: "{count}" })}
             aria-live="polite"
             aria-atomic="true"
           >
-            {t(locale, "channelConfig.members.selected", { count: String(selectedCount) })}
           </span>
         </div>
 
@@ -155,12 +138,7 @@ const selectedCount = customMemberSet.size;
               <div class="space-y-0.5">
                 {jpCreators.map((creator) => (
                   <label
-                    class:list={[
-                      "flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-all",
-                      customMemberSet.has(creator.id)
-                        ? "bg-vspo-purple/10 ring-1 ring-vspo-purple/20"
-                        : "hover:bg-surface-container-highest/40",
-                    ]}
+                    class="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-all hover:bg-surface-container-highest/40"
                     data-member-item
                     data-member-name={creator.name.toLowerCase()}
                     data-member-group-item="vspo_jp"
@@ -169,7 +147,6 @@ const selectedCount = customMemberSet.size;
                       type="checkbox"
                       name="customMemberIds"
                       value={creator.id}
-                      checked={customMemberSet.has(creator.id)}
                       class="shrink-0 accent-vspo-purple"
                       data-member-checkbox
                     />
@@ -212,12 +189,7 @@ const selectedCount = customMemberSet.size;
               <div class="space-y-0.5">
                 {enCreators.map((creator) => (
                   <label
-                    class:list={[
-                      "flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-all",
-                      customMemberSet.has(creator.id)
-                        ? "bg-vspo-purple/10 ring-1 ring-vspo-purple/20"
-                        : "hover:bg-surface-container-highest/40",
-                    ]}
+                    class="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-all hover:bg-surface-container-highest/40"
                     data-member-item
                     data-member-name={creator.name.toLowerCase()}
                     data-member-group-item="vspo_en"
@@ -226,7 +198,6 @@ const selectedCount = customMemberSet.size;
                       type="checkbox"
                       name="customMemberIds"
                       value={creator.id}
-                      checked={customMemberSet.has(creator.id)}
                       class="shrink-0 accent-vspo-purple"
                       data-member-checkbox
                     />
@@ -258,45 +229,34 @@ const selectedCount = customMemberSet.size;
 
     </form>
     <div class="flex justify-end gap-2 pt-2">
-      <form method="post" action={actions.resetChannel} class="mr-auto">
-        <input type="hidden" name="guildId" value={guildId} />
-        <input type="hidden" name="channelId" value={channel.channelId} />
-        <Button type="submit" variant="ghost">
-          {t(locale, "channelConfig.reset")}
-        </Button>
-      </form>
-      <Button as="a" href={`/dashboard/${guildId}`} variant="ghost">
+      <Button as="button" type="button" variant="ghost" class="mr-auto cursor-pointer" data-reset-btn>
+        {t(locale, "channelConfig.reset")}
+      </Button>
+      <Button as="button" type="button" variant="ghost" data-modal-cancel>
         {t(locale, "channelConfig.cancel")}
       </Button>
-      <Button type="submit" form="update-channel-form" variant="discord" data-save-btn>{t(locale, "channelConfig.save")}</Button>
+      <Button as="button" type="button" variant="discord" data-save-btn>{t(locale, "channelConfig.save")}</Button>
     </div>
   </div>
 </dialog>
 
 <script>
-  import { initModalTrap } from "~/components/ui/modal-trap";
-  const dialog = document.getElementById("config-modal");
-  if (dialog) {
-    const closeBtn = dialog.querySelector<HTMLButtonElement>('button[data-close-href]');
-    const closeHref = closeBtn?.dataset.closeHref;
+  /**
+   * Edit modal interactive controls: radio highlights, custom member toggles, search filter.
+   * These run within the dialog and are initialized on page load + view transitions.
+   */
+  const initConfigFormControls = () => {
+    const dialog = document.getElementById("config-modal");
+    if (!dialog) return;
 
-    const navigateClose = () => {
-      if (closeHref) window.location.href = closeHref;
-    };
-
-    closeBtn?.addEventListener("click", navigateClose);
-
-    // --- Custom member selection logic ---
     const customSection = dialog.querySelector<HTMLElement>("[data-custom-members]");
     const searchInput = dialog.querySelector<HTMLInputElement>("[data-member-search]");
     const memberItems = dialog.querySelectorAll<HTMLElement>("[data-member-item]");
     const checkboxes = dialog.querySelectorAll<HTMLInputElement>("[data-member-checkbox]");
-    const countEl = dialog.querySelector<HTMLElement>("[data-selected-count]");
     const emptyMsg = dialog.querySelector<HTMLElement>("[data-member-search-empty]");
     const saveBtn = dialog.querySelector<HTMLButtonElement>("[data-save-btn]");
     const memberTypeRadios = dialog.querySelectorAll<HTMLInputElement>('input[name="memberType"]');
 
-    /** Toggle accent highlight on an element (radio labels and member rows). */
     const toggleHighlight = (
       el: HTMLElement,
       active: boolean,
@@ -312,14 +272,15 @@ const selectedCount = customMemberSet.size;
       }
     };
 
-    /** Update the "X selected" count display and save button state. */
     const updateSelectedState = () => {
+      const countEl = dialog.querySelector<HTMLElement>("[data-selected-count]");
       if (!countEl) return;
+      const data = document.getElementById("channel-data");
+      const i18n = data ? JSON.parse(data.textContent ?? "{}").i18n ?? {} : {};
       const count = dialog.querySelectorAll<HTMLInputElement>("[data-member-checkbox]:checked").length;
-      const template = countEl.dataset.template ?? "{count}";
+      const template = i18n["channelConfig.members.selected"] ?? "{count} selected";
       countEl.textContent = template.replace("{count}", String(count));
 
-      // Disable save when custom type is selected but 0 members chosen
       const isCustom = dialog.querySelector<HTMLInputElement>('input[name="memberType"][value="custom"]')?.checked;
       if (saveBtn && isCustom) {
         saveBtn.disabled = count === 0;
@@ -328,7 +289,6 @@ const selectedCount = customMemberSet.size;
       }
     };
 
-    /** Update the toggle button label based on group checkbox state. */
     const updateToggleLabel = (groupName: string) => {
       const toggleBtn = dialog.querySelector<HTMLButtonElement>(`[data-toggle-group="${groupName}"]`);
       if (!toggleBtn) return;
@@ -341,30 +301,29 @@ const selectedCount = customMemberSet.size;
         : (toggleBtn.dataset.labelSelect ?? "Select All");
     };
 
-    // Search filtering (debounced to reduce layout thrash)
+    // Search filtering
     let searchTimer: ReturnType<typeof setTimeout> | undefined;
     searchInput?.addEventListener("input", () => {
       clearTimeout(searchTimer);
       searchTimer = setTimeout(() => {
-      const query = searchInput.value.toLowerCase();
-      let visibleCount = 0;
-      for (const item of memberItems) {
-        const name = item.dataset.memberName ?? "";
-        const show = name.includes(query);
-        item.style.display = show ? "" : "none";
-        if (show) visibleCount++;
-      }
-      if (emptyMsg) {
-        emptyMsg.classList.toggle("hidden", visibleCount > 0 || !query);
-      }
-      // Show/hide group headers when all items in group are hidden
-      for (const groupName of ["vspo_jp", "vspo_en"]) {
-        const group = dialog.querySelector<HTMLElement>(`[data-member-group="${groupName}"]`);
-        if (!group) continue;
-        const groupItems = group.querySelectorAll<HTMLElement>("[data-member-item]");
-        const anyVisible = Array.from(groupItems).some((el) => el.style.display !== "none");
-        group.style.display = anyVisible ? "" : "none";
-      }
+        const query = searchInput.value.toLowerCase();
+        let visibleCount = 0;
+        for (const item of memberItems) {
+          const name = item.dataset.memberName ?? "";
+          const show = name.includes(query);
+          item.style.display = show ? "" : "none";
+          if (show) visibleCount++;
+        }
+        if (emptyMsg) {
+          emptyMsg.classList.toggle("hidden", visibleCount > 0 || !query);
+        }
+        for (const groupName of ["vspo_jp", "vspo_en"]) {
+          const group = dialog.querySelector<HTMLElement>(`[data-member-group="${groupName}"]`);
+          if (!group) continue;
+          const groupItems = group.querySelectorAll<HTMLElement>("[data-member-item]");
+          const anyVisible = Array.from(groupItems).some((el) => el.style.display !== "none");
+          group.style.display = anyVisible ? "" : "none";
+        }
       }, 100);
     });
 
@@ -398,7 +357,6 @@ const selectedCount = customMemberSet.size;
       });
     }
 
-    /** Update radio label highlights so only the selected one is accented. */
     const updateRadioHighlights = () => {
       for (const r of memberTypeRadios) {
         const label = r.closest<HTMLElement>("[data-radio-label]");
@@ -406,7 +364,6 @@ const selectedCount = customMemberSet.size;
       }
     };
 
-    /** Toggle visibility of the custom members section with animation. */
     const toggleCustomSection = (show: boolean) => {
       if (!customSection) return;
       customSection.setAttribute("aria-hidden", String(!show));
@@ -419,7 +376,6 @@ const selectedCount = customMemberSet.size;
       }
     };
 
-    // Re-evaluate save button state and custom section when member type changes
     for (const radio of memberTypeRadios) {
       radio.addEventListener("change", () => {
         updateRadioHighlights();
@@ -434,16 +390,8 @@ const selectedCount = customMemberSet.size;
         }
       });
     }
+  };
 
-    // Initialize toggle labels and save button state
-    if (customSection) {
-      for (const groupName of ["vspo_jp", "vspo_en"]) {
-        updateToggleLabel(groupName);
-      }
-      updateSelectedState();
-    }
-
-    // --- Focus trap and modal close ---
-    initModalTrap(dialog, navigateClose);
-  }
+  initConfigFormControls();
+  document.addEventListener("astro:after-swap", initConfigFormControls);
 </script>

--- a/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
@@ -42,7 +42,7 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
       </button>
     </div>
 
-    <form id="update-channel-form" class="space-y-4">
+    <form id="update-channel-form" class="space-y-4" onsubmit="event.preventDefault()">
       <input type="hidden" name="guildId" value={guildId} />
       <input type="hidden" name="channelId" value="" />
 

--- a/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
@@ -243,9 +243,15 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
 <script>
   /**
    * Edit modal interactive controls: radio highlights, custom member toggles, search filter.
-   * These run within the dialog and are initialized on page load + view transitions.
+   * Uses AbortController to prevent duplicate listeners on view transition swaps.
    */
+  let configFormAbort: AbortController | null = null;
+
   const initConfigFormControls = () => {
+    if (configFormAbort) configFormAbort.abort();
+    configFormAbort = new AbortController();
+    const { signal } = configFormAbort;
+
     const dialog = document.getElementById("config-modal");
     if (!dialog) return;
 
@@ -325,7 +331,7 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
           group.style.display = anyVisible ? "" : "none";
         }
       }, 100);
-    });
+    }, { signal });
 
     // Select All / Deselect All per group
     for (const toggleBtn of dialog.querySelectorAll<HTMLButtonElement>("[data-toggle-group]")) {
@@ -343,7 +349,7 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
         }
         updateToggleLabel(groupName);
         updateSelectedState();
-      });
+      }, { signal });
     }
 
     // Individual checkbox changes
@@ -354,7 +360,7 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
         const groupName = cb.closest<HTMLElement>("[data-member-group-item]")?.dataset.memberGroupItem;
         if (groupName) updateToggleLabel(groupName);
         updateSelectedState();
-      });
+      }, { signal });
     }
 
     const updateRadioHighlights = () => {
@@ -388,7 +394,7 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
             updateSelectedState();
           }
         }
-      });
+      }, { signal });
     }
   };
 

--- a/service/bot-dashboard/src/components/channel/ChannelTable.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelTable.astro
@@ -42,14 +42,17 @@ const langChipLabel = (lang: string) => lang.toUpperCase();
           <th scope="col" class="px-6 py-4 text-right sm:px-8">{t(locale, "channel.actions")}</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody data-table-body>
         {
           channels.map((ch, i) => (
-            <tr class:list={[
-              "group transition-colors duration-200",
-              i % 2 === 0 ? "bg-surface" : "bg-surface-container-lowest",
-              "hover:bg-surface-container-highest/30",
-            ]}>
+            <tr
+              data-channel-row={ch.channelId}
+              class:list={[
+                "group transition-colors duration-200",
+                i % 2 === 0 ? "bg-surface" : "bg-surface-container-lowest",
+                "hover:bg-surface-container-highest/30",
+              ]}
+            >
               <td class="px-6 py-4 sm:px-8">
                 <div class="flex items-center gap-3">
                   <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-vspo-purple/10 text-vspo-purple">
@@ -115,7 +118,7 @@ const langChipLabel = (lang: string) => lang.toUpperCase();
   {/* Empty state */}
   {
     channels.length === 0 && (
-      <div class="flex flex-col items-center gap-3 p-12 text-center">
+      <div data-empty-state class="flex flex-col items-center gap-3 p-12 text-center">
         <svg class="h-12 w-12 text-on-surface-variant/30" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
         </svg>

--- a/service/bot-dashboard/src/components/channel/ChannelTable.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelTable.astro
@@ -18,15 +18,16 @@ const langChipLabel = (lang: string) => lang.toUpperCase();
   {/* Table header bar */}
   <div class="flex items-center justify-between bg-surface-container-low px-6 py-5 sm:px-8">
     <h3 class="font-heading text-lg font-bold text-on-surface">{t(locale, "channel.table")}</h3>
-    <a
-      href="?add=true"
-      class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-br from-vspo-purple to-vspo-purple-light px-5 py-2.5 font-heading text-sm font-bold text-white shadow-lg shadow-vspo-purple/20 transition-all hover:scale-[1.03] active:scale-95"
+    <button
+      type="button"
+      data-action-add
+      class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-br from-vspo-purple to-vspo-purple-light px-5 py-2.5 font-heading text-sm font-bold text-white shadow-lg shadow-vspo-purple/20 transition-all hover:scale-[1.03] active:scale-95 cursor-pointer"
     >
       <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
       </svg>
       {t(locale, "channel.add")}
-    </a>
+    </button>
   </div>
 
   {/* Table */}
@@ -86,20 +87,22 @@ const langChipLabel = (lang: string) => lang.toUpperCase();
               </td>
               <td class="px-6 py-4 sm:px-8">
                 <div class="flex items-center justify-end gap-1">
-                  <a
-                    href={`?edit=${ch.channelId}`}
-                    class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-surface-container-highest hover:text-vspo-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vspo-purple/50"
+                  <button
+                    type="button"
+                    data-action-edit={ch.channelId}
+                    class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-surface-container-highest hover:text-vspo-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vspo-purple/50 cursor-pointer"
                     aria-label={`${t(locale, "channel.edit")} #${ch.channelName}`}
                   >
                     <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
-                  </a>
-                  <a
-                    href={`?delete=${ch.channelId}`}
-                    class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/50"
+                  </button>
+                  <button
+                    type="button"
+                    data-action-delete={ch.channelId}
+                    class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/50 cursor-pointer"
                     aria-label={`${t(locale, "channel.delete")} #${ch.channelName}`}
                   >
                     <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
-                  </a>
+                  </button>
                 </div>
               </td>
             </tr>
@@ -119,13 +122,14 @@ const langChipLabel = (lang: string) => lang.toUpperCase();
         <p class="text-sm text-on-surface-variant">
           {t(locale, "channel.empty")}
         </p>
-        <a
-          href="?add=true"
-          class="mt-2 inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium text-vspo-purple transition-colors hover:bg-vspo-purple/10"
+        <button
+          type="button"
+          data-action-add
+          class="mt-2 inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium text-vspo-purple transition-colors hover:bg-vspo-purple/10 cursor-pointer"
         >
           <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>
           {t(locale, "channel.add")}
-        </a>
+        </button>
       </div>
     )
   }

--- a/service/bot-dashboard/src/components/channel/ChannelTable.test.ts
+++ b/service/bot-dashboard/src/components/channel/ChannelTable.test.ts
@@ -55,16 +55,20 @@ describe("ChannelTable", () => {
     expect(getByText(body, "No channels configured.")).toBeTruthy();
   });
 
-  it("renders edit links for each channel", async () => {
+  it("renders edit buttons for each channel", async () => {
     const html = await container.renderToString(ChannelTable, {
       props: { channels, guildId: "guild-1" },
       locals: { locale: "en" },
     });
     const body = parseHtml(html);
-    const editLinks = getAllByRole(body, "link");
-    const editHrefs = editLinks.map((l) => l.getAttribute("href"));
-    expect(editHrefs).toContain("?edit=ch-1");
-    expect(editHrefs).toContain("?edit=ch-2");
+    const editButtons = getAllByRole(body, "button").filter(
+      (btn) => btn.getAttribute("data-action-edit") !== null,
+    );
+    const editIds = editButtons.map((btn) =>
+      btn.getAttribute("data-action-edit"),
+    );
+    expect(editIds).toContain("ch-1");
+    expect(editIds).toContain("ch-2");
   });
 
   it("shows Active status for enabled channels", async () => {

--- a/service/bot-dashboard/src/components/channel/DeleteChannelDialog.astro
+++ b/service/bot-dashboard/src/components/channel/DeleteChannelDialog.astro
@@ -1,21 +1,17 @@
 ---
-import { actions } from "astro:actions";
 import Button from "~/components/ui/Button.astro";
-import type { ChannelConfigType } from "~/features/channel/domain/channel-config";
 import { t } from "~/i18n/dict";
 
 interface Props {
-  channel: ChannelConfigType;
   guildId: string;
 }
 
-const { channel, guildId } = Astro.props;
+const { guildId } = Astro.props;
 const { locale } = Astro.locals;
 ---
 
 <dialog
-  open
-  class="animate-backdrop-in fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+  class="fixed inset-0 z-50 m-0 flex h-full w-full items-center justify-center bg-black/60 backdrop:bg-transparent"
   id="delete-channel-modal"
   aria-labelledby="delete-channel-heading"
   aria-modal="true"
@@ -46,9 +42,9 @@ const { locale } = Astro.locals;
       <div class="min-w-0 flex-1">
         <h2
           id="delete-channel-heading"
+          data-delete-heading
           class="text-base font-semibold leading-snug"
         >
-          {t(locale, "channel.deleteConfirm", { channelName: channel.channelName })}
         </h2>
         <p class="mt-1 text-sm text-on-surface-variant">
           {t(locale, "channel.deleteConfirm.desc")}
@@ -56,27 +52,15 @@ const { locale } = Astro.locals;
       </div>
     </div>
 
-    <form method="post" action={actions.deleteChannel} class="flex justify-end gap-2 pt-2">
-      <input type="hidden" name="guildId" value={guildId} />
-      <input type="hidden" name="channelId" value={channel.channelId} />
+    <input type="hidden" name="channelId" value="" />
 
-      <Button as="a" href={`/dashboard/${guildId}`} variant="ghost" size="sm">
+    <div class="flex justify-end gap-2 pt-2">
+      <Button as="button" type="button" variant="ghost" size="sm" data-modal-cancel>
         {t(locale, "channel.deleteConfirm.cancel")}
       </Button>
-      <Button type="submit" variant="destructive" size="sm">
+      <Button as="button" type="button" variant="destructive" size="sm" data-modal-confirm>
         {t(locale, "channel.deleteConfirm.submit")}
       </Button>
-    </form>
+    </div>
   </div>
 </dialog>
-
-<script>
-  import { initModalTrap } from "~/components/ui/modal-trap";
-  const dialog = document.getElementById("delete-channel-modal");
-  if (dialog) {
-    const navigateClose = () => {
-      dialog.querySelector<HTMLAnchorElement>("a[href]")?.click();
-    };
-    initModalTrap(dialog, navigateClose);
-  }
-</script>

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -1,0 +1,583 @@
+/**
+ * Client-side controller for channel CRUD operations.
+ * Manages modal open/close, form submissions via Astro Actions, and DOM updates.
+ * Replaces MPA query-param navigation with SPA-like interactions.
+ *
+ * @precondition Page must contain #channel-data script with JSON payload
+ * @postcondition All modal interactions happen client-side without page reload
+ */
+import { actions } from "astro:actions";
+import { navigate } from "astro:transitions/client";
+
+/* ---------- Types ---------- */
+
+type ChannelConfig = {
+  channelId: string;
+  channelName: string;
+  enabled: boolean;
+  language: string;
+  memberType: string;
+  customMembers?: string[];
+};
+
+type Creator = {
+  id: string;
+  name: string;
+  memberType: "vspo_jp" | "vspo_en";
+  thumbnailUrl: string | null;
+};
+
+type PageData = {
+  guildId: string;
+  channels: ChannelConfig[];
+  creators: Creator[];
+  i18n: Record<string, string>;
+};
+
+/* ---------- State ---------- */
+
+const getPageData = (): PageData => {
+  const el = document.getElementById("channel-data");
+  if (!el?.textContent) throw new Error("Missing #channel-data");
+  return JSON.parse(el.textContent);
+};
+
+/* ---------- Toast ---------- */
+
+const showToast = (message: string, type: "success" | "error" = "success") => {
+  const existing = document.querySelector("[data-toast]");
+  if (existing) existing.remove();
+
+  const toast = document.createElement("div");
+  toast.setAttribute("data-toast", "");
+  toast.setAttribute("role", "status");
+  toast.setAttribute("aria-live", "polite");
+  toast.className = `toast-${type} flex items-center gap-3 rounded-xl p-4 text-sm text-on-surface ${
+    type === "success" ? "bg-vspo-purple/10" : "bg-destructive/10"
+  }`;
+
+  const icon =
+    type === "success"
+      ? `<svg class="h-5 w-5 shrink-0 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>`
+      : `<svg class="h-5 w-5 shrink-0 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" /></svg>`;
+
+  toast.innerHTML = `${icon}<span class="flex-1">${message}</span><button type="button" class="shrink-0 rounded-lg p-2 text-on-surface-variant hover:text-on-surface cursor-pointer" aria-label="close"><svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg></button>`;
+
+  toast
+    .querySelector("button")
+    ?.addEventListener("click", () => toast.remove());
+
+  const alertsContainer = document.querySelector("[data-alerts]");
+  if (alertsContainer) {
+    alertsContainer.appendChild(toast);
+  }
+
+  setTimeout(() => toast.remove(), 5000);
+};
+
+/* ---------- Modal helpers ---------- */
+
+const openDialog = (dialog: HTMLDialogElement) => {
+  dialog.showModal();
+};
+
+const closeDialog = (dialog: HTMLDialogElement) => {
+  dialog.close();
+};
+
+/* ---------- Delete ---------- */
+
+const initDelete = () => {
+  const dialog = document.getElementById(
+    "delete-channel-modal",
+  ) as HTMLDialogElement | null;
+  if (!dialog) return;
+
+  document.addEventListener("click", (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(
+      "[data-action-delete]",
+    );
+    if (!btn || !dialog) return;
+
+    const data = getPageData();
+    const channelId = btn.dataset.actionDelete;
+    if (!channelId) return;
+    const channel = data.channels.find((c) => c.channelId === channelId);
+    if (!channel) return;
+
+    // Populate dialog
+    const heading = dialog.querySelector("[data-delete-heading]");
+    if (heading)
+      heading.textContent =
+        data.i18n["channel.deleteConfirm"]?.replace(
+          "{channelName}",
+          channel.channelName,
+        ) ?? `Delete #${channel.channelName}?`;
+
+    const hiddenChannelId = dialog.querySelector<HTMLInputElement>(
+      'input[name="channelId"]',
+    );
+    if (hiddenChannelId) hiddenChannelId.value = channelId;
+
+    openDialog(dialog);
+  });
+
+  // Close handlers
+  dialog.querySelector("[data-modal-cancel]")?.addEventListener("click", () => {
+    closeDialog(dialog);
+  });
+
+  dialog.addEventListener("click", (e) => {
+    if (e.target === dialog) closeDialog(dialog);
+  });
+
+  dialog.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeDialog(dialog);
+  });
+
+  // Submit handler
+  dialog
+    .querySelector("[data-modal-confirm]")
+    ?.addEventListener("click", async () => {
+      const data = getPageData();
+      const channelId = dialog.querySelector<HTMLInputElement>(
+        'input[name="channelId"]',
+      )?.value;
+      if (!channelId) return;
+
+      const confirmBtn = dialog.querySelector<HTMLButtonElement>(
+        "[data-modal-confirm]",
+      );
+      if (confirmBtn) {
+        confirmBtn.disabled = true;
+        confirmBtn.classList.add("opacity-50");
+      }
+
+      const { error } = await actions.deleteChannel({
+        guildId: data.guildId,
+        channelId,
+      });
+
+      if (error) {
+        closeDialog(dialog);
+        showToast(error.message, "error");
+        if (confirmBtn) {
+          confirmBtn.disabled = false;
+          confirmBtn.classList.remove("opacity-50");
+        }
+        return;
+      }
+
+      closeDialog(dialog);
+      showToast(data.i18n["toast.deleteSuccess"] ?? "Deleted.");
+      // Reload page data via View Transitions (soft navigation)
+      navigate(window.location.pathname, { history: "replace" });
+    });
+};
+
+/* ---------- Add ---------- */
+
+const initAdd = () => {
+  const dialog = document.getElementById(
+    "add-channel-modal",
+  ) as HTMLDialogElement | null;
+  if (!dialog) return;
+
+  const listContainer = dialog.querySelector<HTMLElement>(
+    "[data-channel-list]",
+  );
+  const searchInput = dialog.querySelector<HTMLInputElement>(
+    "[data-search-input]",
+  );
+  const emptyMsg = dialog.querySelector<HTMLElement>("[data-search-empty]");
+  const loadingEl = dialog.querySelector<HTMLElement>("[data-loading]");
+  const noChannelsEl = dialog.querySelector<HTMLElement>("[data-no-channels]");
+
+  // Open handler
+  document.addEventListener("click", (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLElement>(
+      "[data-action-add]",
+    );
+    if (!btn || !dialog) return;
+
+    openDialog(dialog);
+    loadChannels();
+  });
+
+  // Close handlers
+  dialog.querySelector("[data-modal-close]")?.addEventListener("click", () => {
+    closeDialog(dialog);
+  });
+  dialog.querySelector("[data-modal-cancel]")?.addEventListener("click", () => {
+    closeDialog(dialog);
+  });
+  dialog.addEventListener("click", (e) => {
+    if (e.target === dialog) closeDialog(dialog);
+  });
+  dialog.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeDialog(dialog);
+  });
+
+  // Search filter
+  let searchTimer: ReturnType<typeof setTimeout> | undefined;
+  searchInput?.addEventListener("input", () => {
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => {
+      const query = searchInput.value.toLowerCase();
+      const items =
+        listContainer?.querySelectorAll("[data-channel-item]") ?? [];
+      let visibleCount = 0;
+      for (const item of items) {
+        const el = item as HTMLElement;
+        const name = el.dataset.channelName ?? "";
+        const show = name.includes(query);
+        el.style.display = show ? "" : "none";
+        if (show) visibleCount++;
+      }
+      if (emptyMsg) {
+        emptyMsg.classList.toggle("hidden", visibleCount > 0 || !query);
+      }
+    }, 100);
+  });
+
+  const loadChannels = async () => {
+    if (!listContainer) return;
+
+    // Show loading
+    if (loadingEl) loadingEl.classList.remove("hidden");
+    if (noChannelsEl) noChannelsEl.classList.add("hidden");
+    listContainer.innerHTML = "";
+
+    const data = getPageData();
+    const registeredIds = new Set(data.channels.map((c) => c.channelId));
+
+    const res = await fetch(`/api/guilds/${data.guildId}/channels`);
+    if (loadingEl) loadingEl.classList.add("hidden");
+
+    if (!res.ok) {
+      showToast(
+        data.i18n["dashboard.error"]?.replace(
+          "{message}",
+          "Failed to load channels",
+        ) ?? "Failed to load channels",
+        "error",
+      );
+      return;
+    }
+
+    const allChannels: { id: string; name: string }[] = await res.json();
+    const unregistered = allChannels.filter((ch) => !registeredIds.has(ch.id));
+
+    if (unregistered.length === 0 && allChannels.length === 0) {
+      if (noChannelsEl) noChannelsEl.classList.remove("hidden");
+      return;
+    }
+
+    // Render unregistered channels
+    for (const ch of unregistered) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.setAttribute("data-channel-item", "");
+      btn.setAttribute("data-channel-name", ch.name.toLowerCase());
+      btn.setAttribute("role", "option");
+      btn.setAttribute("aria-selected", "false");
+      btn.className =
+        "flex w-full items-center justify-between rounded-lg px-3 py-3 text-left text-sm transition-colors duration-[--duration-fast] hover:bg-surface-container-highest/30 cursor-pointer";
+      btn.innerHTML = `<span class="flex items-center gap-2"><svg class="h-4 w-4 shrink-0 text-on-surface-variant" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" /></svg><span>${ch.name}</span></span><span class="text-xs font-medium text-vspo-purple">${data.i18n["channel.add.submit"] ?? "Add"}</span>`;
+
+      btn.addEventListener("click", async () => {
+        btn.disabled = true;
+        btn.classList.add("opacity-50");
+
+        const { error } = await actions.addChannel({
+          guildId: data.guildId,
+          channelId: ch.id,
+        });
+
+        if (error) {
+          btn.disabled = false;
+          btn.classList.remove("opacity-50");
+          showToast(error.message, "error");
+          return;
+        }
+
+        closeDialog(dialog);
+        showToast(data.i18n["toast.addSuccess"] ?? "Channel added.");
+        navigate(window.location.pathname, { history: "replace" });
+      });
+
+      listContainer.appendChild(btn);
+    }
+
+    // Render registered channels (disabled)
+    for (const ch of allChannels.filter((c) => registeredIds.has(c.id))) {
+      const div = document.createElement("div");
+      div.setAttribute("data-channel-item", "");
+      div.setAttribute("data-channel-name", ch.name.toLowerCase());
+      div.className =
+        "flex items-center justify-between rounded-lg px-3 py-3 text-sm text-on-surface-variant/50";
+      div.innerHTML = `<span class="flex items-center gap-2"><svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" /></svg><span>${ch.name}</span></span><span class="text-xs">${data.i18n["channel.add.registered"] ?? "Registered"}</span>`;
+      listContainer.appendChild(div);
+    }
+  };
+};
+
+/* ---------- Edit / Config ---------- */
+
+const initEdit = () => {
+  const dialog = document.getElementById(
+    "config-modal",
+  ) as HTMLDialogElement | null;
+  if (!dialog) return;
+
+  const form = dialog.querySelector<HTMLFormElement>("#update-channel-form");
+  const hiddenChannelId = form?.querySelector<HTMLInputElement>(
+    'input[name="channelId"]',
+  );
+
+  // Open handler
+  document.addEventListener("click", (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(
+      "[data-action-edit]",
+    );
+    if (!btn || !dialog) return;
+
+    const data = getPageData();
+    const channelId = btn.dataset.actionEdit;
+    if (!channelId) return;
+    const channel = data.channels.find((c) => c.channelId === channelId);
+    if (!channel) return;
+
+    populateEditForm(dialog, channel, data);
+    openDialog(dialog);
+  });
+
+  // Close handlers
+  dialog.querySelector("[data-modal-close]")?.addEventListener("click", () => {
+    closeDialog(dialog);
+  });
+  dialog.querySelector("[data-modal-cancel]")?.addEventListener("click", () => {
+    closeDialog(dialog);
+  });
+  dialog.addEventListener("click", (e) => {
+    if (e.target === dialog) closeDialog(dialog);
+  });
+  dialog.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeDialog(dialog);
+  });
+
+  // Save handler
+  dialog
+    .querySelector("[data-save-btn]")
+    ?.addEventListener("click", async () => {
+      if (!form || !hiddenChannelId) return;
+
+      const data = getPageData();
+      const formData = new FormData(form);
+      const channelId = hiddenChannelId.value;
+      const language = formData.get("language") as string;
+      const memberType = formData.get("memberType") as
+        | "vspo_jp"
+        | "vspo_en"
+        | "all"
+        | "custom";
+      const customMemberIds = formData.getAll("customMemberIds") as string[];
+
+      const saveBtn =
+        dialog.querySelector<HTMLButtonElement>("[data-save-btn]");
+      if (saveBtn) {
+        saveBtn.disabled = true;
+        saveBtn.classList.add("opacity-50");
+      }
+
+      const { error } = await actions.updateChannel({
+        guildId: data.guildId,
+        channelId,
+        language,
+        memberType,
+        customMemberIds: memberType === "custom" ? customMemberIds : undefined,
+      });
+
+      if (error) {
+        showToast(error.message, "error");
+        if (saveBtn) {
+          saveBtn.disabled = false;
+          saveBtn.classList.remove("opacity-50");
+        }
+        return;
+      }
+
+      closeDialog(dialog);
+      showToast(data.i18n["toast.updateSuccess"] ?? "Updated.");
+      navigate(window.location.pathname, { history: "replace" });
+    });
+
+  // Reset handler
+  dialog
+    .querySelector("[data-reset-btn]")
+    ?.addEventListener("click", async () => {
+      if (!hiddenChannelId) return;
+
+      const data = getPageData();
+      const channelId = hiddenChannelId.value;
+
+      const resetBtn =
+        dialog.querySelector<HTMLButtonElement>("[data-reset-btn]");
+      if (resetBtn) {
+        resetBtn.disabled = true;
+        resetBtn.classList.add("opacity-50");
+      }
+
+      const { error } = await actions.resetChannel({
+        guildId: data.guildId,
+        channelId,
+      });
+
+      if (error) {
+        showToast(error.message, "error");
+        if (resetBtn) {
+          resetBtn.disabled = false;
+          resetBtn.classList.remove("opacity-50");
+        }
+        return;
+      }
+
+      closeDialog(dialog);
+      showToast(data.i18n["toast.resetSuccess"] ?? "Reset to default.");
+      navigate(window.location.pathname, { history: "replace" });
+    });
+};
+
+const populateEditForm = (
+  dialog: HTMLElement,
+  channel: ChannelConfig,
+  data: PageData,
+) => {
+  // Title
+  const heading = dialog.querySelector("[data-config-heading]");
+  if (heading) {
+    heading.textContent =
+      data.i18n["channelConfig.title"]?.replace(
+        "{channelName}",
+        channel.channelName,
+      ) ?? `#${channel.channelName}`;
+  }
+
+  // Hidden channel ID
+  const hiddenId = dialog.querySelector<HTMLInputElement>(
+    'input[name="channelId"]',
+  );
+  if (hiddenId) hiddenId.value = channel.channelId;
+
+  // Language select
+  const langSelect = dialog.querySelector<HTMLSelectElement>("#language");
+  if (langSelect) langSelect.value = channel.language;
+
+  // Member type radios
+  const radios = dialog.querySelectorAll<HTMLInputElement>(
+    'input[name="memberType"]',
+  );
+  for (const radio of radios) {
+    radio.checked = radio.value === channel.memberType;
+    const label = radio.closest<HTMLElement>("[data-radio-label]");
+    if (label) {
+      if (radio.checked) {
+        label.classList.add(
+          "bg-vspo-purple/10",
+          "ring-1",
+          "ring-vspo-purple/30",
+        );
+        label.classList.remove("hover:bg-surface-container-highest/50");
+      } else {
+        label.classList.remove(
+          "bg-vspo-purple/10",
+          "ring-1",
+          "ring-vspo-purple/30",
+        );
+        label.classList.add("hover:bg-surface-container-highest/50");
+      }
+    }
+  }
+
+  // Custom members section visibility
+  const customSection = dialog.querySelector<HTMLElement>(
+    "[data-custom-members]",
+  );
+  const showCustom = channel.memberType === "custom";
+  if (customSection) {
+    customSection.setAttribute("aria-hidden", String(!showCustom));
+    if (showCustom) {
+      customSection.classList.remove("max-h-0", "opacity-0");
+      customSection.classList.add("max-h-[600px]", "opacity-100");
+    } else {
+      customSection.classList.add("max-h-0", "opacity-0");
+      customSection.classList.remove("max-h-[600px]", "opacity-100");
+    }
+  }
+
+  // Custom member checkboxes
+  const customSet = new Set(channel.customMembers ?? []);
+  const checkboxes = dialog.querySelectorAll<HTMLInputElement>(
+    "[data-member-checkbox]",
+  );
+  for (const cb of checkboxes) {
+    cb.checked = customSet.has(cb.value);
+    const label = cb.closest<HTMLElement>("[data-member-item]");
+    if (label) {
+      if (cb.checked) {
+        label.classList.add(
+          "bg-vspo-purple/10",
+          "ring-1",
+          "ring-vspo-purple/20",
+        );
+        label.classList.remove("hover:bg-surface-container-highest/40");
+      } else {
+        label.classList.remove(
+          "bg-vspo-purple/10",
+          "ring-1",
+          "ring-vspo-purple/20",
+        );
+        label.classList.add("hover:bg-surface-container-highest/40");
+      }
+    }
+  }
+
+  // Update selected count
+  updateSelectedCount(dialog, data);
+
+  // Enable save button
+  const saveBtn = dialog.querySelector<HTMLButtonElement>("[data-save-btn]");
+  if (saveBtn) {
+    saveBtn.disabled = false;
+    saveBtn.classList.remove("opacity-50");
+  }
+
+  const resetBtn = dialog.querySelector<HTMLButtonElement>("[data-reset-btn]");
+  if (resetBtn) {
+    resetBtn.disabled = false;
+    resetBtn.classList.remove("opacity-50");
+  }
+};
+
+const updateSelectedCount = (dialog: HTMLElement, data: PageData) => {
+  const countEl = dialog.querySelector<HTMLElement>("[data-selected-count]");
+  if (!countEl) return;
+  const count = dialog.querySelectorAll<HTMLInputElement>(
+    "[data-member-checkbox]:checked",
+  ).length;
+  const template =
+    data.i18n["channelConfig.members.selected"] ?? "{count} selected";
+  countEl.textContent = template.replace("{count}", String(count));
+};
+
+/* ---------- Init ---------- */
+
+/**
+ * Initialize all channel action handlers.
+ * Called on page load and after View Transition swaps.
+ */
+export const initChannelActions = () => {
+  initDelete();
+  initAdd();
+  initEdit();
+};

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -1,13 +1,11 @@
 /**
  * Client-side controller for channel CRUD operations.
- * Manages modal open/close, form submissions via Astro Actions, and DOM updates.
- * Replaces MPA query-param navigation with SPA-like interactions.
+ * Uses optimistic DOM updates instead of full page reloads.
  *
  * @precondition Page must contain #channel-data script with JSON payload
- * @postcondition All modal interactions happen client-side without page reload
+ * @postcondition All modal interactions and data mutations happen client-side
  */
 import { actions } from "astro:actions";
-import { navigate } from "astro:transitions/client";
 
 /* ---------- Types ---------- */
 
@@ -36,10 +34,21 @@ type PageData = {
 
 /* ---------- State ---------- */
 
+let currentData: PageData | null = null;
+let abortController: AbortController | null = null;
+
 const getPageData = (): PageData => {
+  if (currentData) return currentData;
   const el = document.getElementById("channel-data");
   if (!el?.textContent) throw new Error("Missing #channel-data");
-  return JSON.parse(el.textContent);
+  currentData = JSON.parse(el.textContent);
+  return currentData!;
+};
+
+const persistPageData = (data: PageData) => {
+  currentData = data;
+  const el = document.getElementById("channel-data");
+  if (el) el.textContent = JSON.stringify(data);
 };
 
 /* ---------- Toast ---------- */
@@ -85,99 +94,230 @@ const closeDialog = (dialog: HTMLDialogElement) => {
   dialog.close();
 };
 
+/* ---------- DOM update helpers ---------- */
+
+const memberTypeLabel = (mt: string, i18n: Record<string, string>): string =>
+  i18n[`memberType.${mt}`] ?? mt;
+
+const createRowHtml = (
+  ch: ChannelConfig,
+  i18n: Record<string, string>,
+): string => {
+  const langLabel = ch.language.toUpperCase();
+  const mtLabel = memberTypeLabel(ch.memberType, i18n);
+  const statusActive = ch.enabled;
+  const statusLabel = statusActive
+    ? (i18n["channel.status.active"] ?? "Active")
+    : (i18n["channel.status.paused"] ?? "Paused");
+  const editLabel = i18n["channel.edit"] ?? "Edit";
+  const deleteLabel = i18n["channel.delete"] ?? "Delete";
+
+  const statusHtml = statusActive
+    ? `<div class="flex items-center gap-2"><div class="relative flex h-2 w-2"><span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-success opacity-75"></span><span class="relative inline-flex h-2 w-2 rounded-full bg-success shadow-sm shadow-success/50"></span></div><span class="text-[10px] font-bold uppercase tracking-wider text-success">${statusLabel}</span></div>`
+    : `<div class="flex items-center gap-2"><span class="inline-flex h-2 w-2 rounded-full bg-on-surface-variant/40"></span><span class="text-[10px] font-bold uppercase tracking-wider text-on-surface-variant/60">${statusLabel}</span></div>`;
+
+  return `<td class="px-6 py-4 sm:px-8"><div class="flex items-center gap-3"><div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-vspo-purple/10 text-vspo-purple"><svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" /></svg></div><div><p class="text-sm font-semibold text-on-surface">${ch.channelName}</p><p class="text-[10px] text-on-surface-variant/60">${ch.channelId}</p></div></div></td><td class="hidden px-6 py-4 sm:table-cell sm:px-8"><span class="rounded bg-surface-container-highest px-2.5 py-1 text-[10px] font-bold text-on-surface">${langLabel}</span></td><td class="hidden px-6 py-4 text-xs font-medium text-on-surface-variant md:table-cell sm:px-8">${mtLabel}</td><td class="hidden px-6 py-4 lg:table-cell sm:px-8">${statusHtml}</td><td class="px-6 py-4 sm:px-8"><div class="flex items-center justify-end gap-1"><button type="button" data-action-edit="${ch.channelId}" class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-surface-container-highest hover:text-vspo-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vspo-purple/50 cursor-pointer" aria-label="${editLabel} #${ch.channelName}"><svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg></button><button type="button" data-action-delete="${ch.channelId}" class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/50 cursor-pointer" aria-label="${deleteLabel} #${ch.channelName}"><svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg></button></div></td>`;
+};
+
+const restripeRows = () => {
+  const rows = document.querySelectorAll<HTMLElement>("[data-channel-row]");
+  rows.forEach((row, i) => {
+    row.classList.remove("bg-surface", "bg-surface-container-lowest");
+    row.classList.add(
+      i % 2 === 0 ? "bg-surface" : "bg-surface-container-lowest",
+    );
+  });
+};
+
+const updateStats = (data: PageData) => {
+  const total = document.querySelector("[data-stat-total]");
+  if (total) total.textContent = String(data.channels.length);
+
+  const desc = document.querySelector("[data-channels-desc]");
+  if (desc) {
+    const template =
+      data.i18n["dashboard.channelsCount"] ?? "{total} channels registered";
+    desc.textContent = template.replace("{total}", String(data.channels.length));
+  }
+
+  const langContainer = document.querySelector("[data-stat-languages]");
+  if (langContainer) {
+    const langs = [...new Set(data.channels.map((c) => c.language))];
+    if (langs.length === 0) {
+      langContainer.innerHTML =
+        '<span class="text-sm text-on-surface-variant">—</span>';
+    } else {
+      langContainer.innerHTML = langs
+        .map(
+          (lang) =>
+            `<span class="rounded bg-surface-container-highest px-2 py-0.5 text-[10px] font-bold text-vspo-purple">${lang.toUpperCase()}</span>`,
+        )
+        .join("");
+    }
+  }
+
+  const membersContainer = document.querySelector("[data-stat-members]");
+  if (membersContainer) {
+    const types = [...new Set(data.channels.map((c) => c.memberType))];
+    if (types.length === 0) {
+      membersContainer.innerHTML =
+        '<span class="text-sm text-on-surface-variant">—</span>';
+    } else {
+      membersContainer.innerHTML = types
+        .map(
+          (mt) =>
+            `<span class="text-sm font-medium text-on-surface">${memberTypeLabel(mt, data.i18n)}</span>`,
+        )
+        .join("");
+    }
+  }
+};
+
+const updateRowCells = (
+  channelId: string,
+  updates: Partial<ChannelConfig>,
+  i18n: Record<string, string>,
+) => {
+  const row = document.querySelector<HTMLElement>(
+    `[data-channel-row="${channelId}"]`,
+  );
+  if (!row) return;
+
+  if (updates.language !== undefined) {
+    const langCell = row.querySelector("td:nth-child(2) span");
+    if (langCell) langCell.textContent = updates.language.toUpperCase();
+  }
+
+  if (updates.memberType !== undefined) {
+    const mtCell = row.querySelector("td:nth-child(3)");
+    if (mtCell) mtCell.textContent = memberTypeLabel(updates.memberType, i18n);
+  }
+};
+
 /* ---------- Delete ---------- */
 
-const initDelete = () => {
+const initDelete = (signal: AbortSignal) => {
   const dialog = document.getElementById(
     "delete-channel-modal",
   ) as HTMLDialogElement | null;
   if (!dialog) return;
 
-  document.addEventListener("click", (e) => {
-    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(
-      "[data-action-delete]",
-    );
-    if (!btn || !dialog) return;
+  document.addEventListener(
+    "click",
+    (e) => {
+      const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(
+        "[data-action-delete]",
+      );
+      if (!btn || !dialog) return;
 
-    const data = getPageData();
-    const channelId = btn.dataset.actionDelete;
-    if (!channelId) return;
-    const channel = data.channels.find((c) => c.channelId === channelId);
-    if (!channel) return;
+      const data = getPageData();
+      const channelId = btn.dataset.actionDelete;
+      if (!channelId) return;
+      const channel = data.channels.find((c) => c.channelId === channelId);
+      if (!channel) return;
 
-    // Populate dialog
-    const heading = dialog.querySelector("[data-delete-heading]");
-    if (heading)
-      heading.textContent =
-        data.i18n["channel.deleteConfirm"]?.replace(
-          "{channelName}",
-          channel.channelName,
-        ) ?? `Delete #${channel.channelName}?`;
+      const heading = dialog.querySelector("[data-delete-heading]");
+      if (heading)
+        heading.textContent =
+          data.i18n["channel.deleteConfirm"]?.replace(
+            "{channelName}",
+            channel.channelName,
+          ) ?? `Delete #${channel.channelName}?`;
 
-    const hiddenChannelId = dialog.querySelector<HTMLInputElement>(
-      'input[name="channelId"]',
-    );
-    if (hiddenChannelId) hiddenChannelId.value = channelId;
+      const hiddenChannelId = dialog.querySelector<HTMLInputElement>(
+        'input[name="channelId"]',
+      );
+      if (hiddenChannelId) hiddenChannelId.value = channelId;
 
-    openDialog(dialog);
-  });
+      openDialog(dialog);
+    },
+    { signal },
+  );
 
-  // Close handlers
-  dialog.querySelector("[data-modal-cancel]")?.addEventListener("click", () => {
-    closeDialog(dialog);
-  });
+  dialog
+    .querySelector("[data-modal-cancel]")
+    ?.addEventListener("click", () => closeDialog(dialog), { signal });
 
-  dialog.addEventListener("click", (e) => {
-    if (e.target === dialog) closeDialog(dialog);
-  });
+  dialog.addEventListener(
+    "click",
+    (e) => {
+      if (e.target === dialog) closeDialog(dialog);
+    },
+    { signal },
+  );
 
-  dialog.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") closeDialog(dialog);
-  });
+  dialog.addEventListener(
+    "keydown",
+    (e) => {
+      if (e.key === "Escape") closeDialog(dialog);
+    },
+    { signal },
+  );
 
-  // Submit handler
   dialog
     .querySelector("[data-modal-confirm]")
-    ?.addEventListener("click", async () => {
-      const data = getPageData();
-      const channelId = dialog.querySelector<HTMLInputElement>(
-        'input[name="channelId"]',
-      )?.value;
-      if (!channelId) return;
+    ?.addEventListener(
+      "click",
+      async () => {
+        const data = getPageData();
+        const channelId = dialog.querySelector<HTMLInputElement>(
+          'input[name="channelId"]',
+        )?.value;
+        if (!channelId) return;
 
-      const confirmBtn = dialog.querySelector<HTMLButtonElement>(
-        "[data-modal-confirm]",
-      );
-      if (confirmBtn) {
-        confirmBtn.disabled = true;
-        confirmBtn.classList.add("opacity-50");
-      }
+        const confirmBtn = dialog.querySelector<HTMLButtonElement>(
+          "[data-modal-confirm]",
+        );
+        if (confirmBtn) {
+          confirmBtn.disabled = true;
+          confirmBtn.classList.add("opacity-50");
+        }
 
-      const { error } = await actions.deleteChannel({
-        guildId: data.guildId,
-        channelId,
-      });
+        const { error } = await actions.deleteChannel({
+          guildId: data.guildId,
+          channelId,
+        });
 
-      if (error) {
-        closeDialog(dialog);
-        showToast(error.message, "error");
         if (confirmBtn) {
           confirmBtn.disabled = false;
           confirmBtn.classList.remove("opacity-50");
         }
-        return;
-      }
 
-      closeDialog(dialog);
-      showToast(data.i18n["toast.deleteSuccess"] ?? "Deleted.");
-      // Reload page data via View Transitions (soft navigation)
-      navigate(window.location.pathname, { history: "replace" });
-    });
+        if (error) {
+          closeDialog(dialog);
+          showToast(error.message, "error");
+          return;
+        }
+
+        closeDialog(dialog);
+        showToast(data.i18n["toast.deleteSuccess"] ?? "Deleted.");
+
+        // Optimistic DOM update
+        const row = document.querySelector(
+          `[data-channel-row="${channelId}"]`,
+        );
+        if (row) {
+          row.classList.add("opacity-0", "transition-opacity", "duration-200");
+          setTimeout(() => {
+            row.remove();
+            restripeRows();
+          }, 200);
+        }
+
+        const updated: PageData = {
+          ...data,
+          channels: data.channels.filter((c) => c.channelId !== channelId),
+        };
+        persistPageData(updated);
+        updateStats(updated);
+      },
+      { signal },
+    );
 };
 
 /* ---------- Add ---------- */
 
-const initAdd = () => {
+const initAdd = (signal: AbortSignal) => {
   const dialog = document.getElementById(
     "add-channel-modal",
   ) as HTMLDialogElement | null;
@@ -193,60 +333,73 @@ const initAdd = () => {
   const loadingEl = dialog.querySelector<HTMLElement>("[data-loading]");
   const noChannelsEl = dialog.querySelector<HTMLElement>("[data-no-channels]");
 
-  // Open handler
-  document.addEventListener("click", (e) => {
-    const btn = (e.target as HTMLElement).closest<HTMLElement>(
-      "[data-action-add]",
-    );
-    if (!btn || !dialog) return;
+  document.addEventListener(
+    "click",
+    (e) => {
+      const btn = (e.target as HTMLElement).closest<HTMLElement>(
+        "[data-action-add]",
+      );
+      if (!btn || !dialog) return;
 
-    openDialog(dialog);
-    loadChannels();
-  });
+      openDialog(dialog);
+      loadChannels();
+    },
+    { signal },
+  );
 
-  // Close handlers
-  dialog.querySelector("[data-modal-close]")?.addEventListener("click", () => {
-    closeDialog(dialog);
-  });
-  dialog.querySelector("[data-modal-cancel]")?.addEventListener("click", () => {
-    closeDialog(dialog);
-  });
-  dialog.addEventListener("click", (e) => {
-    if (e.target === dialog) closeDialog(dialog);
-  });
-  dialog.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") closeDialog(dialog);
-  });
+  dialog
+    .querySelector("[data-modal-close]")
+    ?.addEventListener("click", () => closeDialog(dialog), { signal });
+  dialog
+    .querySelector("[data-modal-cancel]")
+    ?.addEventListener("click", () => closeDialog(dialog), { signal });
+  dialog.addEventListener(
+    "click",
+    (e) => {
+      if (e.target === dialog) closeDialog(dialog);
+    },
+    { signal },
+  );
+  dialog.addEventListener(
+    "keydown",
+    (e) => {
+      if (e.key === "Escape") closeDialog(dialog);
+    },
+    { signal },
+  );
 
-  // Search filter
   let searchTimer: ReturnType<typeof setTimeout> | undefined;
-  searchInput?.addEventListener("input", () => {
-    clearTimeout(searchTimer);
-    searchTimer = setTimeout(() => {
-      const query = searchInput.value.toLowerCase();
-      const items =
-        listContainer?.querySelectorAll("[data-channel-item]") ?? [];
-      let visibleCount = 0;
-      for (const item of items) {
-        const el = item as HTMLElement;
-        const name = el.dataset.channelName ?? "";
-        const show = name.includes(query);
-        el.style.display = show ? "" : "none";
-        if (show) visibleCount++;
-      }
-      if (emptyMsg) {
-        emptyMsg.classList.toggle("hidden", visibleCount > 0 || !query);
-      }
-    }, 100);
-  });
+  searchInput?.addEventListener(
+    "input",
+    () => {
+      clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => {
+        const query = searchInput.value.toLowerCase();
+        const items =
+          listContainer?.querySelectorAll("[data-channel-item]") ?? [];
+        let visibleCount = 0;
+        for (const item of items) {
+          const el = item as HTMLElement;
+          const name = el.dataset.channelName ?? "";
+          const show = name.includes(query);
+          el.style.display = show ? "" : "none";
+          if (show) visibleCount++;
+        }
+        if (emptyMsg) {
+          emptyMsg.classList.toggle("hidden", visibleCount > 0 || !query);
+        }
+      }, 100);
+    },
+    { signal },
+  );
 
   const loadChannels = async () => {
     if (!listContainer) return;
 
-    // Show loading
     if (loadingEl) loadingEl.classList.remove("hidden");
     if (noChannelsEl) noChannelsEl.classList.add("hidden");
     listContainer.innerHTML = "";
+    if (searchInput) searchInput.value = "";
 
     const data = getPageData();
     const registeredIds = new Set(data.channels.map((c) => c.channelId));
@@ -273,7 +426,6 @@ const initAdd = () => {
       return;
     }
 
-    // Render unregistered channels
     for (const ch of unregistered) {
       const btn = document.createElement("button");
       btn.type = "button";
@@ -289,8 +441,9 @@ const initAdd = () => {
         btn.disabled = true;
         btn.classList.add("opacity-50");
 
+        const latestData = getPageData();
         const { error } = await actions.addChannel({
-          guildId: data.guildId,
+          guildId: latestData.guildId,
           channelId: ch.id,
         });
 
@@ -302,14 +455,45 @@ const initAdd = () => {
         }
 
         closeDialog(dialog);
-        showToast(data.i18n["toast.addSuccess"] ?? "Channel added.");
-        navigate(window.location.pathname, { history: "replace" });
+        showToast(latestData.i18n["toast.addSuccess"] ?? "Channel added.");
+
+        // Optimistic DOM update
+        const newChannel: ChannelConfig = {
+          channelId: ch.id,
+          channelName: ch.name,
+          enabled: true,
+          language: "default",
+          memberType: "all",
+        };
+
+        const updated: PageData = {
+          ...latestData,
+          channels: [...latestData.channels, newChannel],
+        };
+        persistPageData(updated);
+
+        // Remove empty state if present
+        const emptyState = document.querySelector("[data-empty-state]");
+        if (emptyState) emptyState.remove();
+
+        // Add row to table
+        const tbody = document.querySelector("[data-table-body]");
+        if (tbody) {
+          const tr = document.createElement("tr");
+          tr.setAttribute("data-channel-row", ch.id);
+          tr.className =
+            "group transition-colors duration-200 hover:bg-surface-container-highest/30";
+          tr.innerHTML = createRowHtml(newChannel, updated.i18n);
+          tbody.appendChild(tr);
+          restripeRows();
+        }
+
+        updateStats(updated);
       });
 
       listContainer.appendChild(btn);
     }
 
-    // Render registered channels (disabled)
     for (const ch of allChannels.filter((c) => registeredIds.has(c.id))) {
       const div = document.createElement("div");
       div.setAttribute("data-channel-item", "");
@@ -324,7 +508,7 @@ const initAdd = () => {
 
 /* ---------- Edit / Config ---------- */
 
-const initEdit = () => {
+const initEdit = (signal: AbortSignal) => {
   const dialog = document.getElementById(
     "config-modal",
   ) as HTMLDialogElement | null;
@@ -335,117 +519,170 @@ const initEdit = () => {
     'input[name="channelId"]',
   );
 
-  // Open handler
-  document.addEventListener("click", (e) => {
-    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(
-      "[data-action-edit]",
-    );
-    if (!btn || !dialog) return;
+  document.addEventListener(
+    "click",
+    (e) => {
+      const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(
+        "[data-action-edit]",
+      );
+      if (!btn || !dialog) return;
 
-    const data = getPageData();
-    const channelId = btn.dataset.actionEdit;
-    if (!channelId) return;
-    const channel = data.channels.find((c) => c.channelId === channelId);
-    if (!channel) return;
+      const data = getPageData();
+      const channelId = btn.dataset.actionEdit;
+      if (!channelId) return;
+      const channel = data.channels.find((c) => c.channelId === channelId);
+      if (!channel) return;
 
-    populateEditForm(dialog, channel, data);
-    openDialog(dialog);
-  });
+      populateEditForm(dialog, channel, data);
+      openDialog(dialog);
+    },
+    { signal },
+  );
 
-  // Close handlers
-  dialog.querySelector("[data-modal-close]")?.addEventListener("click", () => {
-    closeDialog(dialog);
-  });
-  dialog.querySelector("[data-modal-cancel]")?.addEventListener("click", () => {
-    closeDialog(dialog);
-  });
-  dialog.addEventListener("click", (e) => {
-    if (e.target === dialog) closeDialog(dialog);
-  });
-  dialog.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") closeDialog(dialog);
-  });
+  dialog
+    .querySelector("[data-modal-close]")
+    ?.addEventListener("click", () => closeDialog(dialog), { signal });
+  dialog
+    .querySelector("[data-modal-cancel]")
+    ?.addEventListener("click", () => closeDialog(dialog), { signal });
+  dialog.addEventListener(
+    "click",
+    (e) => {
+      if (e.target === dialog) closeDialog(dialog);
+    },
+    { signal },
+  );
+  dialog.addEventListener(
+    "keydown",
+    (e) => {
+      if (e.key === "Escape") closeDialog(dialog);
+    },
+    { signal },
+  );
 
   // Save handler
   dialog
     .querySelector("[data-save-btn]")
-    ?.addEventListener("click", async () => {
-      if (!form || !hiddenChannelId) return;
+    ?.addEventListener(
+      "click",
+      async () => {
+        if (!form || !hiddenChannelId) return;
 
-      const data = getPageData();
-      const formData = new FormData(form);
-      const channelId = hiddenChannelId.value;
-      const language = formData.get("language") as string;
-      const memberType = formData.get("memberType") as
-        | "vspo_jp"
-        | "vspo_en"
-        | "all"
-        | "custom";
-      const customMemberIds = formData.getAll("customMemberIds") as string[];
+        const data = getPageData();
+        const formData = new FormData(form);
+        const channelId = hiddenChannelId.value;
+        const language = formData.get("language") as string;
+        const memberType = formData.get("memberType") as
+          | "vspo_jp"
+          | "vspo_en"
+          | "all"
+          | "custom";
+        const customMemberIds = formData.getAll("customMemberIds") as string[];
 
-      const saveBtn =
-        dialog.querySelector<HTMLButtonElement>("[data-save-btn]");
-      if (saveBtn) {
-        saveBtn.disabled = true;
-        saveBtn.classList.add("opacity-50");
-      }
+        const saveBtn =
+          dialog.querySelector<HTMLButtonElement>("[data-save-btn]");
+        if (saveBtn) {
+          saveBtn.disabled = true;
+          saveBtn.classList.add("opacity-50");
+        }
 
-      const { error } = await actions.updateChannel({
-        guildId: data.guildId,
-        channelId,
-        language,
-        memberType,
-        customMemberIds: memberType === "custom" ? customMemberIds : undefined,
-      });
+        const { error } = await actions.updateChannel({
+          guildId: data.guildId,
+          channelId,
+          language,
+          memberType,
+          customMemberIds: memberType === "custom" ? customMemberIds : undefined,
+        });
 
-      if (error) {
-        showToast(error.message, "error");
         if (saveBtn) {
           saveBtn.disabled = false;
           saveBtn.classList.remove("opacity-50");
         }
-        return;
-      }
 
-      closeDialog(dialog);
-      showToast(data.i18n["toast.updateSuccess"] ?? "Updated.");
-      navigate(window.location.pathname, { history: "replace" });
-    });
+        if (error) {
+          showToast(error.message, "error");
+          return;
+        }
+
+        closeDialog(dialog);
+        showToast(data.i18n["toast.updateSuccess"] ?? "Updated.");
+
+        // Optimistic DOM update
+        const updates = {
+          language,
+          memberType,
+          customMembers:
+            memberType === "custom" ? customMemberIds : undefined,
+        };
+        updateRowCells(channelId, updates, data.i18n);
+
+        const updated: PageData = {
+          ...data,
+          channels: data.channels.map((c) =>
+            c.channelId === channelId ? { ...c, ...updates } : c,
+          ),
+        };
+        persistPageData(updated);
+        updateStats(updated);
+      },
+      { signal },
+    );
 
   // Reset handler
   dialog
     .querySelector("[data-reset-btn]")
-    ?.addEventListener("click", async () => {
-      if (!hiddenChannelId) return;
+    ?.addEventListener(
+      "click",
+      async () => {
+        if (!hiddenChannelId) return;
 
-      const data = getPageData();
-      const channelId = hiddenChannelId.value;
+        const data = getPageData();
+        const channelId = hiddenChannelId.value;
 
-      const resetBtn =
-        dialog.querySelector<HTMLButtonElement>("[data-reset-btn]");
-      if (resetBtn) {
-        resetBtn.disabled = true;
-        resetBtn.classList.add("opacity-50");
-      }
+        const resetBtn =
+          dialog.querySelector<HTMLButtonElement>("[data-reset-btn]");
+        if (resetBtn) {
+          resetBtn.disabled = true;
+          resetBtn.classList.add("opacity-50");
+        }
 
-      const { error } = await actions.resetChannel({
-        guildId: data.guildId,
-        channelId,
-      });
+        const { error } = await actions.resetChannel({
+          guildId: data.guildId,
+          channelId,
+        });
 
-      if (error) {
-        showToast(error.message, "error");
         if (resetBtn) {
           resetBtn.disabled = false;
           resetBtn.classList.remove("opacity-50");
         }
-        return;
-      }
 
-      closeDialog(dialog);
-      showToast(data.i18n["toast.resetSuccess"] ?? "Reset to default.");
-      navigate(window.location.pathname, { history: "replace" });
-    });
+        if (error) {
+          showToast(error.message, "error");
+          return;
+        }
+
+        closeDialog(dialog);
+        showToast(data.i18n["toast.resetSuccess"] ?? "Reset to default.");
+
+        // Optimistic DOM update
+        const defaults = {
+          language: "default",
+          memberType: "all",
+          customMembers: [] as string[],
+        };
+        updateRowCells(channelId, defaults, data.i18n);
+
+        const updated: PageData = {
+          ...data,
+          channels: data.channels.map((c) =>
+            c.channelId === channelId ? { ...c, ...defaults } : c,
+          ),
+        };
+        persistPageData(updated);
+        updateStats(updated);
+      },
+      { signal },
+    );
 };
 
 const populateEditForm = (
@@ -453,7 +690,6 @@ const populateEditForm = (
   channel: ChannelConfig,
   data: PageData,
 ) => {
-  // Title
   const heading = dialog.querySelector("[data-config-heading]");
   if (heading) {
     heading.textContent =
@@ -463,17 +699,14 @@ const populateEditForm = (
       ) ?? `#${channel.channelName}`;
   }
 
-  // Hidden channel ID
   const hiddenId = dialog.querySelector<HTMLInputElement>(
     'input[name="channelId"]',
   );
   if (hiddenId) hiddenId.value = channel.channelId;
 
-  // Language select
-  const langSelect = dialog.querySelector<HTMLSelectElement>("#language");
+  const langSelect = dialog.querySelector("#language") as HTMLSelectElement | null;
   if (langSelect) langSelect.value = channel.language;
 
-  // Member type radios
   const radios = dialog.querySelectorAll<HTMLInputElement>(
     'input[name="memberType"]',
   );
@@ -499,7 +732,6 @@ const populateEditForm = (
     }
   }
 
-  // Custom members section visibility
   const customSection = dialog.querySelector<HTMLElement>(
     "[data-custom-members]",
   );
@@ -515,7 +747,6 @@ const populateEditForm = (
     }
   }
 
-  // Custom member checkboxes
   const customSet = new Set(channel.customMembers ?? []);
   const checkboxes = dialog.querySelectorAll<HTMLInputElement>(
     "[data-member-checkbox]",
@@ -542,10 +773,8 @@ const populateEditForm = (
     }
   }
 
-  // Update selected count
   updateSelectedCount(dialog, data);
 
-  // Enable save button
   const saveBtn = dialog.querySelector<HTMLButtonElement>("[data-save-btn]");
   if (saveBtn) {
     saveBtn.disabled = false;
@@ -574,10 +803,17 @@ const updateSelectedCount = (dialog: HTMLElement, data: PageData) => {
 
 /**
  * Initialize all channel action handlers.
- * Called on page load and after View Transition swaps.
+ * Uses AbortController to clean up previous listeners on re-init.
  */
 export const initChannelActions = () => {
-  initDelete();
-  initAdd();
-  initEdit();
+  // Clean up previous listeners
+  if (abortController) abortController.abort();
+  abortController = new AbortController();
+  currentData = null;
+
+  const { signal } = abortController;
+
+  initDelete(signal);
+  initAdd(signal);
+  initEdit(signal);
 };

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -137,7 +137,10 @@ const updateStats = (data: PageData) => {
   if (desc) {
     const template =
       data.i18n["dashboard.channelsCount"] ?? "{total} channels registered";
-    desc.textContent = template.replace("{total}", String(data.channels.length));
+    desc.textContent = template.replace(
+      "{total}",
+      String(data.channels.length),
+    );
   }
 
   const langContainer = document.querySelector("[data-stat-languages]");
@@ -254,65 +257,61 @@ const initDelete = (signal: AbortSignal) => {
     { signal },
   );
 
-  dialog
-    .querySelector("[data-modal-confirm]")
-    ?.addEventListener(
-      "click",
-      async () => {
-        const data = getPageData();
-        const channelId = dialog.querySelector<HTMLInputElement>(
-          'input[name="channelId"]',
-        )?.value;
-        if (!channelId) return;
+  dialog.querySelector("[data-modal-confirm]")?.addEventListener(
+    "click",
+    async () => {
+      const data = getPageData();
+      const channelId = dialog.querySelector<HTMLInputElement>(
+        'input[name="channelId"]',
+      )?.value;
+      if (!channelId) return;
 
-        const confirmBtn = dialog.querySelector<HTMLButtonElement>(
-          "[data-modal-confirm]",
-        );
-        if (confirmBtn) {
-          confirmBtn.disabled = true;
-          confirmBtn.classList.add("opacity-50");
-        }
+      const confirmBtn = dialog.querySelector<HTMLButtonElement>(
+        "[data-modal-confirm]",
+      );
+      if (confirmBtn) {
+        confirmBtn.disabled = true;
+        confirmBtn.classList.add("opacity-50");
+      }
 
-        const { error } = await actions.deleteChannel({
-          guildId: data.guildId,
-          channelId,
-        });
+      const { error } = await actions.deleteChannel({
+        guildId: data.guildId,
+        channelId,
+      });
 
-        if (confirmBtn) {
-          confirmBtn.disabled = false;
-          confirmBtn.classList.remove("opacity-50");
-        }
+      if (confirmBtn) {
+        confirmBtn.disabled = false;
+        confirmBtn.classList.remove("opacity-50");
+      }
 
-        if (error) {
-          closeDialog(dialog);
-          showToast(error.message, "error");
-          return;
-        }
-
+      if (error) {
         closeDialog(dialog);
-        showToast(data.i18n["toast.deleteSuccess"] ?? "Deleted.");
+        showToast(error.message, "error");
+        return;
+      }
 
-        // Optimistic DOM update
-        const row = document.querySelector(
-          `[data-channel-row="${channelId}"]`,
-        );
-        if (row) {
-          row.classList.add("opacity-0", "transition-opacity", "duration-200");
-          setTimeout(() => {
-            row.remove();
-            restripeRows();
-          }, 200);
-        }
+      closeDialog(dialog);
+      showToast(data.i18n["toast.deleteSuccess"] ?? "Deleted.");
 
-        const updated: PageData = {
-          ...data,
-          channels: data.channels.filter((c) => c.channelId !== channelId),
-        };
-        persistPageData(updated);
-        updateStats(updated);
-      },
-      { signal },
-    );
+      // Optimistic DOM update
+      const row = document.querySelector(`[data-channel-row="${channelId}"]`);
+      if (row) {
+        row.classList.add("opacity-0", "transition-opacity", "duration-200");
+        setTimeout(() => {
+          row.remove();
+          restripeRows();
+        }, 200);
+      }
+
+      const updated: PageData = {
+        ...data,
+        channels: data.channels.filter((c) => c.channelId !== channelId),
+      };
+      persistPageData(updated);
+      updateStats(updated);
+    },
+    { signal },
+  );
 };
 
 /* ---------- Add ---------- */
@@ -561,128 +560,123 @@ const initEdit = (signal: AbortSignal) => {
   );
 
   // Save handler
-  dialog
-    .querySelector("[data-save-btn]")
-    ?.addEventListener(
-      "click",
-      async () => {
-        if (!form || !hiddenChannelId) return;
+  dialog.querySelector("[data-save-btn]")?.addEventListener(
+    "click",
+    async () => {
+      if (!form || !hiddenChannelId) return;
 
-        const data = getPageData();
-        const formData = new FormData(form);
-        const channelId = hiddenChannelId.value;
-        const language = formData.get("language") as string;
-        const memberType = formData.get("memberType") as
-          | "vspo_jp"
-          | "vspo_en"
-          | "all"
-          | "custom";
-        const customMemberIds = formData.getAll("customMemberIds") as string[];
+      const data = getPageData();
+      const formData = new FormData(form);
+      const channelId = hiddenChannelId.value;
+      const language = formData.get("language") as string;
+      const memberType = formData.get("memberType") as
+        | "vspo_jp"
+        | "vspo_en"
+        | "all"
+        | "custom";
+      const customMemberIds = formData.getAll("customMemberIds") as string[];
 
-        const saveBtn =
-          dialog.querySelector<HTMLButtonElement>("[data-save-btn]");
-        if (saveBtn) {
-          saveBtn.disabled = true;
-          saveBtn.classList.add("opacity-50");
-        }
+      const saveBtn =
+        dialog.querySelector<HTMLButtonElement>("[data-save-btn]");
+      if (saveBtn) {
+        saveBtn.disabled = true;
+        saveBtn.classList.add("opacity-50");
+      }
 
-        const { error } = await actions.updateChannel({
-          guildId: data.guildId,
-          channelId,
-          language,
-          memberType,
-          customMemberIds: memberType === "custom" ? customMemberIds : undefined,
-        });
+      const { error } = await actions.updateChannel({
+        guildId: data.guildId,
+        channelId,
+        language,
+        memberType,
+        customMemberIds: memberType === "custom" ? customMemberIds : undefined,
+      });
 
-        if (saveBtn) {
-          saveBtn.disabled = false;
-          saveBtn.classList.remove("opacity-50");
-        }
+      if (saveBtn) {
+        saveBtn.disabled = false;
+        saveBtn.classList.remove("opacity-50");
+      }
 
-        if (error) {
-          showToast(error.message, "error");
-          return;
-        }
+      if (error) {
+        showToast(error.message, "error");
+        return;
+      }
 
-        closeDialog(dialog);
-        showToast(data.i18n["toast.updateSuccess"] ?? "Updated.");
+      closeDialog(dialog);
+      showToast(data.i18n["toast.updateSuccess"] ?? "Updated.");
 
-        // Optimistic DOM update
-        const updates = {
-          language,
-          memberType,
-          customMembers:
-            memberType === "custom" ? customMemberIds : undefined,
-        };
-        updateRowCells(channelId, updates, data.i18n);
+      // Optimistic DOM update
+      const updates = {
+        language,
+        memberType,
+        customMembers: memberType === "custom" ? customMemberIds : undefined,
+      };
+      updateRowCells(channelId, updates, data.i18n);
 
-        const updated: PageData = {
-          ...data,
-          channels: data.channels.map((c) =>
-            c.channelId === channelId ? { ...c, ...updates } : c,
-          ),
-        };
-        persistPageData(updated);
-        updateStats(updated);
-      },
-      { signal },
-    );
+      const updated: PageData = {
+        ...data,
+        channels: data.channels.map((c) =>
+          c.channelId === channelId ? { ...c, ...updates } : c,
+        ),
+      };
+      persistPageData(updated);
+      updateStats(updated);
+    },
+    { signal },
+  );
 
   // Reset handler
-  dialog
-    .querySelector("[data-reset-btn]")
-    ?.addEventListener(
-      "click",
-      async () => {
-        if (!hiddenChannelId) return;
+  dialog.querySelector("[data-reset-btn]")?.addEventListener(
+    "click",
+    async () => {
+      if (!hiddenChannelId) return;
 
-        const data = getPageData();
-        const channelId = hiddenChannelId.value;
+      const data = getPageData();
+      const channelId = hiddenChannelId.value;
 
-        const resetBtn =
-          dialog.querySelector<HTMLButtonElement>("[data-reset-btn]");
-        if (resetBtn) {
-          resetBtn.disabled = true;
-          resetBtn.classList.add("opacity-50");
-        }
+      const resetBtn =
+        dialog.querySelector<HTMLButtonElement>("[data-reset-btn]");
+      if (resetBtn) {
+        resetBtn.disabled = true;
+        resetBtn.classList.add("opacity-50");
+      }
 
-        const { error } = await actions.resetChannel({
-          guildId: data.guildId,
-          channelId,
-        });
+      const { error } = await actions.resetChannel({
+        guildId: data.guildId,
+        channelId,
+      });
 
-        if (resetBtn) {
-          resetBtn.disabled = false;
-          resetBtn.classList.remove("opacity-50");
-        }
+      if (resetBtn) {
+        resetBtn.disabled = false;
+        resetBtn.classList.remove("opacity-50");
+      }
 
-        if (error) {
-          showToast(error.message, "error");
-          return;
-        }
+      if (error) {
+        showToast(error.message, "error");
+        return;
+      }
 
-        closeDialog(dialog);
-        showToast(data.i18n["toast.resetSuccess"] ?? "Reset to default.");
+      closeDialog(dialog);
+      showToast(data.i18n["toast.resetSuccess"] ?? "Reset to default.");
 
-        // Optimistic DOM update
-        const defaults = {
-          language: "default",
-          memberType: "all",
-          customMembers: [] as string[],
-        };
-        updateRowCells(channelId, defaults, data.i18n);
+      // Optimistic DOM update
+      const defaults = {
+        language: "default",
+        memberType: "all",
+        customMembers: [] as string[],
+      };
+      updateRowCells(channelId, defaults, data.i18n);
 
-        const updated: PageData = {
-          ...data,
-          channels: data.channels.map((c) =>
-            c.channelId === channelId ? { ...c, ...defaults } : c,
-          ),
-        };
-        persistPageData(updated);
-        updateStats(updated);
-      },
-      { signal },
-    );
+      const updated: PageData = {
+        ...data,
+        channels: data.channels.map((c) =>
+          c.channelId === channelId ? { ...c, ...defaults } : c,
+        ),
+      };
+      persistPageData(updated);
+      updateStats(updated);
+    },
+    { signal },
+  );
 };
 
 const populateEditForm = (
@@ -704,7 +698,9 @@ const populateEditForm = (
   );
   if (hiddenId) hiddenId.value = channel.channelId;
 
-  const langSelect = dialog.querySelector("#language") as HTMLSelectElement | null;
+  const langSelect = dialog.querySelector(
+    "#language",
+  ) as HTMLSelectElement | null;
   if (langSelect) langSelect.value = channel.language;
 
   const radios = dialog.querySelectorAll<HTMLInputElement>(

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -75,18 +75,27 @@ const showToast = (message: string, type: "success" | "error" = "success") => {
   }`;
 
   const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  iconSvg.setAttribute("class", `h-5 w-5 shrink-0 ${type === "success" ? "text-vspo-purple" : "text-destructive"}`);
+  iconSvg.setAttribute(
+    "class",
+    `h-5 w-5 shrink-0 ${type === "success" ? "text-vspo-purple" : "text-destructive"}`,
+  );
   iconSvg.setAttribute("fill", "none");
   iconSvg.setAttribute("stroke", "currentColor");
   iconSvg.setAttribute("viewBox", "0 0 24 24");
   iconSvg.setAttribute("aria-hidden", "true");
-  const iconPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  const iconPath = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "path",
+  );
   iconPath.setAttribute("stroke-linecap", "round");
   iconPath.setAttribute("stroke-linejoin", "round");
   iconPath.setAttribute("stroke-width", "2");
-  iconPath.setAttribute("d", type === "success"
-    ? "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-    : "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z");
+  iconPath.setAttribute(
+    "d",
+    type === "success"
+      ? "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+      : "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z",
+  );
   iconSvg.appendChild(iconPath);
 
   const msgSpan = document.createElement("span");
@@ -95,7 +104,8 @@ const showToast = (message: string, type: "success" | "error" = "success") => {
 
   const closeBtn = document.createElement("button");
   closeBtn.type = "button";
-  closeBtn.className = "shrink-0 rounded-lg p-2 text-on-surface-variant hover:text-on-surface cursor-pointer";
+  closeBtn.className =
+    "shrink-0 rounded-lg p-2 text-on-surface-variant hover:text-on-surface cursor-pointer";
   closeBtn.setAttribute("aria-label", "close");
   closeBtn.innerHTML = `<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>`;
   closeBtn.addEventListener("click", () => toast.remove());
@@ -468,13 +478,19 @@ const initAdd = (signal: AbortSignal) => {
         "flex w-full items-center justify-between rounded-lg px-3 py-3 text-left text-sm transition-colors duration-[--duration-fast] hover:bg-surface-container-highest/30 cursor-pointer";
       const content = document.createElement("span");
       content.className = "flex items-center gap-2";
-      const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      const icon = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "svg",
+      );
       icon.setAttribute("class", "h-4 w-4 shrink-0 text-on-surface-variant");
       icon.setAttribute("fill", "none");
       icon.setAttribute("stroke", "currentColor");
       icon.setAttribute("viewBox", "0 0 24 24");
       icon.setAttribute("aria-hidden", "true");
-      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      const path = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "path",
+      );
       path.setAttribute("stroke-linecap", "round");
       path.setAttribute("stroke-linejoin", "round");
       path.setAttribute("stroke-width", "2");
@@ -555,13 +571,19 @@ const initAdd = (signal: AbortSignal) => {
         "flex items-center justify-between rounded-lg px-3 py-3 text-sm text-on-surface-variant/50";
       const regContent = document.createElement("span");
       regContent.className = "flex items-center gap-2";
-      const regIcon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      const regIcon = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "svg",
+      );
       regIcon.setAttribute("class", "h-4 w-4 shrink-0");
       regIcon.setAttribute("fill", "none");
       regIcon.setAttribute("stroke", "currentColor");
       regIcon.setAttribute("viewBox", "0 0 24 24");
       regIcon.setAttribute("aria-hidden", "true");
-      const regPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      const regPath = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "path",
+      );
       regPath.setAttribute("stroke-linecap", "round");
       regPath.setAttribute("stroke-linejoin", "round");
       regPath.setAttribute("stroke-width", "2");
@@ -573,7 +595,8 @@ const initAdd = (signal: AbortSignal) => {
       regContent.appendChild(regName);
       const regLabel = document.createElement("span");
       regLabel.className = "text-xs";
-      regLabel.textContent = data.i18n["channel.add.registered"] ?? "Registered";
+      regLabel.textContent =
+        data.i18n["channel.add.registered"] ?? "Registered";
       div.appendChild(regContent);
       div.appendChild(regLabel);
       listContainer.appendChild(div);

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -125,6 +125,7 @@ const showToast = (message: string, type: "success" | "error" = "success") => {
 /* ---------- Modal helpers ---------- */
 
 const openDialog = (dialog: HTMLDialogElement) => {
+  if (dialog.open) return;
   dialog.showModal();
 };
 
@@ -446,13 +447,24 @@ const initAdd = (signal: AbortSignal) => {
 
     if (loadingEl) loadingEl.classList.remove("hidden");
     if (noChannelsEl) noChannelsEl.classList.add("hidden");
-    listContainer.innerHTML = "";
+    listContainer.textContent = "";
     if (searchInput) searchInput.value = "";
 
     const data = getPageData();
     const registeredIds = new Set(data.channels.map((c) => c.channelId));
 
-    const res = await fetch(`/api/guilds/${data.guildId}/channels`);
+    let res: Response;
+    try {
+      res = await fetch(`/api/guilds/${data.guildId}/channels`);
+    } catch {
+      if (loadingEl) loadingEl.classList.add("hidden");
+      showToast(
+        data.i18n["dashboard.error"]?.replace("{message}", "Network error") ??
+          "Network error",
+        "error",
+      );
+      return;
+    }
     if (loadingEl) loadingEl.classList.add("hidden");
 
     if (!res.ok) {

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -187,33 +187,40 @@ const updateStats = (data: PageData) => {
 
   const langContainer = document.querySelector("[data-stat-languages]");
   if (langContainer) {
+    langContainer.textContent = "";
     const langs = [...new Set(data.channels.map((c) => c.language))];
     if (langs.length === 0) {
-      langContainer.innerHTML =
-        '<span class="text-sm text-on-surface-variant">—</span>';
+      const empty = document.createElement("span");
+      empty.className = "text-sm text-on-surface-variant";
+      empty.textContent = "—";
+      langContainer.appendChild(empty);
     } else {
-      langContainer.innerHTML = langs
-        .map(
-          (lang) =>
-            `<span class="rounded bg-surface-container-highest px-2 py-0.5 text-[10px] font-bold text-vspo-purple">${lang.toUpperCase()}</span>`,
-        )
-        .join("");
+      for (const lang of langs) {
+        const chip = document.createElement("span");
+        chip.className =
+          "rounded bg-surface-container-highest px-2 py-0.5 text-[10px] font-bold text-vspo-purple";
+        chip.textContent = lang.toUpperCase();
+        langContainer.appendChild(chip);
+      }
     }
   }
 
   const membersContainer = document.querySelector("[data-stat-members]");
   if (membersContainer) {
+    membersContainer.textContent = "";
     const types = [...new Set(data.channels.map((c) => c.memberType))];
     if (types.length === 0) {
-      membersContainer.innerHTML =
-        '<span class="text-sm text-on-surface-variant">—</span>';
+      const empty = document.createElement("span");
+      empty.className = "text-sm text-on-surface-variant";
+      empty.textContent = "—";
+      membersContainer.appendChild(empty);
     } else {
-      membersContainer.innerHTML = types
-        .map(
-          (mt) =>
-            `<span class="text-sm font-medium text-on-surface">${memberTypeLabel(mt, data.i18n)}</span>`,
-        )
-        .join("");
+      for (const mt of types) {
+        const chip = document.createElement("span");
+        chip.className = "text-sm font-medium text-on-surface";
+        chip.textContent = memberTypeLabel(mt, data.i18n);
+        membersContainer.appendChild(chip);
+      }
     }
   }
 };

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -51,6 +51,15 @@ const persistPageData = (data: PageData) => {
   if (el) el.textContent = JSON.stringify(data);
 };
 
+/* ---------- Helpers ---------- */
+
+const escapeHtml = (str: string): string =>
+  str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
 /* ---------- Toast ---------- */
 
 const showToast = (message: string, type: "success" | "error" = "success") => {
@@ -65,16 +74,35 @@ const showToast = (message: string, type: "success" | "error" = "success") => {
     type === "success" ? "bg-vspo-purple/10" : "bg-destructive/10"
   }`;
 
-  const icon =
-    type === "success"
-      ? `<svg class="h-5 w-5 shrink-0 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>`
-      : `<svg class="h-5 w-5 shrink-0 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" /></svg>`;
+  const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  iconSvg.setAttribute("class", `h-5 w-5 shrink-0 ${type === "success" ? "text-vspo-purple" : "text-destructive"}`);
+  iconSvg.setAttribute("fill", "none");
+  iconSvg.setAttribute("stroke", "currentColor");
+  iconSvg.setAttribute("viewBox", "0 0 24 24");
+  iconSvg.setAttribute("aria-hidden", "true");
+  const iconPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  iconPath.setAttribute("stroke-linecap", "round");
+  iconPath.setAttribute("stroke-linejoin", "round");
+  iconPath.setAttribute("stroke-width", "2");
+  iconPath.setAttribute("d", type === "success"
+    ? "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+    : "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z");
+  iconSvg.appendChild(iconPath);
 
-  toast.innerHTML = `${icon}<span class="flex-1">${message}</span><button type="button" class="shrink-0 rounded-lg p-2 text-on-surface-variant hover:text-on-surface cursor-pointer" aria-label="close"><svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg></button>`;
+  const msgSpan = document.createElement("span");
+  msgSpan.className = "flex-1";
+  msgSpan.textContent = message;
 
-  toast
-    .querySelector("button")
-    ?.addEventListener("click", () => toast.remove());
+  const closeBtn = document.createElement("button");
+  closeBtn.type = "button";
+  closeBtn.className = "shrink-0 rounded-lg p-2 text-on-surface-variant hover:text-on-surface cursor-pointer";
+  closeBtn.setAttribute("aria-label", "close");
+  closeBtn.innerHTML = `<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>`;
+  closeBtn.addEventListener("click", () => toast.remove());
+
+  toast.appendChild(iconSvg);
+  toast.appendChild(msgSpan);
+  toast.appendChild(closeBtn);
 
   const alertsContainer = document.querySelector("[data-alerts]");
   if (alertsContainer) {
@@ -103,20 +131,24 @@ const createRowHtml = (
   ch: ChannelConfig,
   i18n: Record<string, string>,
 ): string => {
-  const langLabel = ch.language.toUpperCase();
-  const mtLabel = memberTypeLabel(ch.memberType, i18n);
+  const name = escapeHtml(ch.channelName);
+  const id = escapeHtml(ch.channelId);
+  const langLabel = escapeHtml(ch.language.toUpperCase());
+  const mtLabel = escapeHtml(memberTypeLabel(ch.memberType, i18n));
   const statusActive = ch.enabled;
-  const statusLabel = statusActive
-    ? (i18n["channel.status.active"] ?? "Active")
-    : (i18n["channel.status.paused"] ?? "Paused");
-  const editLabel = i18n["channel.edit"] ?? "Edit";
-  const deleteLabel = i18n["channel.delete"] ?? "Delete";
+  const statusLabel = escapeHtml(
+    statusActive
+      ? (i18n["channel.status.active"] ?? "Active")
+      : (i18n["channel.status.paused"] ?? "Paused"),
+  );
+  const editLabel = escapeHtml(i18n["channel.edit"] ?? "Edit");
+  const deleteLabel = escapeHtml(i18n["channel.delete"] ?? "Delete");
 
   const statusHtml = statusActive
     ? `<div class="flex items-center gap-2"><div class="relative flex h-2 w-2"><span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-success opacity-75"></span><span class="relative inline-flex h-2 w-2 rounded-full bg-success shadow-sm shadow-success/50"></span></div><span class="text-[10px] font-bold uppercase tracking-wider text-success">${statusLabel}</span></div>`
     : `<div class="flex items-center gap-2"><span class="inline-flex h-2 w-2 rounded-full bg-on-surface-variant/40"></span><span class="text-[10px] font-bold uppercase tracking-wider text-on-surface-variant/60">${statusLabel}</span></div>`;
 
-  return `<td class="px-6 py-4 sm:px-8"><div class="flex items-center gap-3"><div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-vspo-purple/10 text-vspo-purple"><svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" /></svg></div><div><p class="text-sm font-semibold text-on-surface">${ch.channelName}</p><p class="text-[10px] text-on-surface-variant/60">${ch.channelId}</p></div></div></td><td class="hidden px-6 py-4 sm:table-cell sm:px-8"><span class="rounded bg-surface-container-highest px-2.5 py-1 text-[10px] font-bold text-on-surface">${langLabel}</span></td><td class="hidden px-6 py-4 text-xs font-medium text-on-surface-variant md:table-cell sm:px-8">${mtLabel}</td><td class="hidden px-6 py-4 lg:table-cell sm:px-8">${statusHtml}</td><td class="px-6 py-4 sm:px-8"><div class="flex items-center justify-end gap-1"><button type="button" data-action-edit="${ch.channelId}" class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-surface-container-highest hover:text-vspo-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vspo-purple/50 cursor-pointer" aria-label="${editLabel} #${ch.channelName}"><svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg></button><button type="button" data-action-delete="${ch.channelId}" class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/50 cursor-pointer" aria-label="${deleteLabel} #${ch.channelName}"><svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg></button></div></td>`;
+  return `<td class="px-6 py-4 sm:px-8"><div class="flex items-center gap-3"><div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-vspo-purple/10 text-vspo-purple"><svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" /></svg></div><div><p class="text-sm font-semibold text-on-surface">${name}</p><p class="text-[10px] text-on-surface-variant/60">${id}</p></div></div></td><td class="hidden px-6 py-4 sm:table-cell sm:px-8"><span class="rounded bg-surface-container-highest px-2.5 py-1 text-[10px] font-bold text-on-surface">${langLabel}</span></td><td class="hidden px-6 py-4 text-xs font-medium text-on-surface-variant md:table-cell sm:px-8">${mtLabel}</td><td class="hidden px-6 py-4 lg:table-cell sm:px-8">${statusHtml}</td><td class="px-6 py-4 sm:px-8"><div class="flex items-center justify-end gap-1"><button type="button" data-action-edit="${id}" class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-surface-container-highest hover:text-vspo-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vspo-purple/50 cursor-pointer" aria-label="${editLabel} #${name}"><svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg></button><button type="button" data-action-delete="${id}" class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-on-surface-variant transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/50 cursor-pointer" aria-label="${deleteLabel} #${name}"><svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg></button></div></td>`;
 };
 
 const restripeRows = () => {
@@ -434,7 +466,29 @@ const initAdd = (signal: AbortSignal) => {
       btn.setAttribute("aria-selected", "false");
       btn.className =
         "flex w-full items-center justify-between rounded-lg px-3 py-3 text-left text-sm transition-colors duration-[--duration-fast] hover:bg-surface-container-highest/30 cursor-pointer";
-      btn.innerHTML = `<span class="flex items-center gap-2"><svg class="h-4 w-4 shrink-0 text-on-surface-variant" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" /></svg><span>${ch.name}</span></span><span class="text-xs font-medium text-vspo-purple">${data.i18n["channel.add.submit"] ?? "Add"}</span>`;
+      const content = document.createElement("span");
+      content.className = "flex items-center gap-2";
+      const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      icon.setAttribute("class", "h-4 w-4 shrink-0 text-on-surface-variant");
+      icon.setAttribute("fill", "none");
+      icon.setAttribute("stroke", "currentColor");
+      icon.setAttribute("viewBox", "0 0 24 24");
+      icon.setAttribute("aria-hidden", "true");
+      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      path.setAttribute("stroke-linecap", "round");
+      path.setAttribute("stroke-linejoin", "round");
+      path.setAttribute("stroke-width", "2");
+      path.setAttribute("d", "M7 20l4-16m2 16l4-16M6 9h14M4 15h14");
+      icon.appendChild(path);
+      const channelName = document.createElement("span");
+      channelName.textContent = ch.name;
+      content.appendChild(icon);
+      content.appendChild(channelName);
+      const addLabel = document.createElement("span");
+      addLabel.className = "text-xs font-medium text-vspo-purple";
+      addLabel.textContent = data.i18n["channel.add.submit"] ?? "Add";
+      btn.appendChild(content);
+      btn.appendChild(addLabel);
 
       btn.addEventListener("click", async () => {
         btn.disabled = true;
@@ -499,7 +553,29 @@ const initAdd = (signal: AbortSignal) => {
       div.setAttribute("data-channel-name", ch.name.toLowerCase());
       div.className =
         "flex items-center justify-between rounded-lg px-3 py-3 text-sm text-on-surface-variant/50";
-      div.innerHTML = `<span class="flex items-center gap-2"><svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" /></svg><span>${ch.name}</span></span><span class="text-xs">${data.i18n["channel.add.registered"] ?? "Registered"}</span>`;
+      const regContent = document.createElement("span");
+      regContent.className = "flex items-center gap-2";
+      const regIcon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      regIcon.setAttribute("class", "h-4 w-4 shrink-0");
+      regIcon.setAttribute("fill", "none");
+      regIcon.setAttribute("stroke", "currentColor");
+      regIcon.setAttribute("viewBox", "0 0 24 24");
+      regIcon.setAttribute("aria-hidden", "true");
+      const regPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      regPath.setAttribute("stroke-linecap", "round");
+      regPath.setAttribute("stroke-linejoin", "round");
+      regPath.setAttribute("stroke-width", "2");
+      regPath.setAttribute("d", "M7 20l4-16m2 16l4-16M6 9h14M4 15h14");
+      regIcon.appendChild(regPath);
+      const regName = document.createElement("span");
+      regName.textContent = ch.name;
+      regContent.appendChild(regIcon);
+      regContent.appendChild(regName);
+      const regLabel = document.createElement("span");
+      regLabel.className = "text-xs";
+      regLabel.textContent = data.i18n["channel.add.registered"] ?? "Registered";
+      div.appendChild(regContent);
+      div.appendChild(regLabel);
       listContainer.appendChild(div);
     }
   };

--- a/service/bot-dashboard/src/layouts/Base.astro
+++ b/service/bot-dashboard/src/layouts/Base.astro
@@ -1,5 +1,6 @@
 ---
 import "~/app.css";
+import { ClientRouter } from "astro:transitions";
 import { t } from "~/i18n/dict";
 
 interface Props {
@@ -93,6 +94,7 @@ const altPath = canonicalPath
         rel="stylesheet"
       />
     </noscript>
+    <ClientRouter />
     <title>{pageTitle}</title>
   </head>
   <body class="min-h-screen bg-background text-foreground antialiased">

--- a/service/bot-dashboard/src/pages/api/guilds/[guildId]/channels.ts
+++ b/service/bot-dashboard/src/pages/api/guilds/[guildId]/channels.ts
@@ -1,0 +1,43 @@
+import { env } from "cloudflare:workers";
+import type { APIRoute } from "astro";
+import { VspoChannelApiRepository } from "~/features/channel/repository/vspo-channel-api";
+
+/**
+ * GET /api/guilds/:guildId/channels
+ * Returns all text channels in the Discord guild for the add-channel modal.
+ * @precondition User must be authenticated (middleware enforces this for /api paths under /dashboard context)
+ * @postcondition Returns JSON array of { id, name } pairs
+ * @idempotent true
+ */
+export const GET: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { guildId } = params;
+  if (!guildId) {
+    return new Response(JSON.stringify({ error: "Missing guildId" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const result = await VspoChannelApiRepository.listGuildChannels(
+    env.APP_WORKER,
+    guildId,
+  );
+
+  if (result.err) {
+    return new Response(JSON.stringify({ error: result.err.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(JSON.stringify(result.val), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -56,6 +56,15 @@ const pageData = {
     "channel.add.registered": t(locale, "channel.add.registered"),
     "channelConfig.title": t(locale, "channelConfig.title", { channelName: "{channelName}" }),
     "channelConfig.members.selected": t(locale, "channelConfig.members.selected", { count: "{count}" }),
+    "memberType.all": t(locale, "memberType.all"),
+    "memberType.vspo_jp": t(locale, "memberType.vspo_jp"),
+    "memberType.vspo_en": t(locale, "memberType.vspo_en"),
+    "memberType.custom": t(locale, "memberType.custom"),
+    "channel.status.active": t(locale, "channel.status.active"),
+    "channel.status.paused": t(locale, "channel.status.paused"),
+    "channel.edit": t(locale, "channel.edit"),
+    "channel.delete": t(locale, "channel.delete"),
+    "dashboard.channelsCount": t(locale, "dashboard.channelsCount", { total: "{total}" }),
   },
 };
 ---
@@ -67,7 +76,7 @@ const pageData = {
       <div class="space-y-2">
         <p class="text-xs font-bold uppercase tracking-[0.2em] text-vspo-purple">{t(locale, "nav.channels")}</p>
         <h1 class="font-heading text-3xl font-extrabold text-on-surface sm:text-4xl">{guildName}</h1>
-        <p class="max-w-md text-on-surface-variant">
+        <p data-channels-desc class="max-w-md text-on-surface-variant">
           {t(locale, "dashboard.channelsCount", { total: String(channels.length) })}
         </p>
       </div>
@@ -85,11 +94,11 @@ const pageData = {
     <div class="grid grid-cols-2 gap-4 sm:grid-cols-4 sm:gap-6">
       <div class="rounded-2xl bg-surface-container-low p-6">
         <p class="mb-2 text-xs font-medium text-on-surface-variant">{t(locale, "dashboard.stat.channels")}</p>
-        <span class="font-heading text-3xl font-bold text-on-surface">{channels.length}</span>
+        <span data-stat-total class="font-heading text-3xl font-bold text-on-surface">{channels.length}</span>
       </div>
       <div class="rounded-2xl bg-surface-container-low p-6">
         <p class="mb-2 text-xs font-medium text-on-surface-variant">{t(locale, "channel.language")}</p>
-        <div class="flex gap-2">
+        <div data-stat-languages class="flex gap-2">
           {[...new Set(channels.map(c => c.language))].map(lang => (
             <span class="rounded bg-surface-container-highest px-2 py-0.5 text-[10px] font-bold text-vspo-purple">{lang === "ja" ? "JA" : lang === "en" ? "EN" : lang.toUpperCase()}</span>
           ))}
@@ -98,7 +107,7 @@ const pageData = {
       </div>
       <div class="col-span-2 rounded-2xl bg-surface-container-low p-6">
         <p class="mb-2 text-xs font-medium text-on-surface-variant">{t(locale, "channel.members")}</p>
-        <div class="flex flex-wrap gap-2">
+        <div data-stat-members class="flex flex-wrap gap-2">
           {[...new Set(channels.map(c => c.memberType))].map(mt => (
             <span class="text-sm font-medium text-on-surface">{t(locale, memberTypeKey(mt))}</span>
           ))}

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -138,7 +138,7 @@ const pageData = {
   </div>
 
   {/* Page data for client-side scripts */}
-  <script type="application/json" id="channel-data" set:html={JSON.stringify(pageData)} />
+  <script type="application/json" id="channel-data" set:html={JSON.stringify(pageData).replace(/</g, "\\u003c")} />
 </Dashboard>
 
 <script>

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -1,6 +1,4 @@
 ---
-import { actions } from "astro:actions";
-import { Ok } from "@vspo-lab/error";
 import { env } from "cloudflare:workers";
 import ChannelAddModal from "~/components/channel/ChannelAddModal.astro";
 import ChannelConfigForm from "~/components/channel/ChannelConfigForm.astro";
@@ -25,19 +23,13 @@ if (!accessToken || !user) {
   return Astro.redirect("/");
 }
 
-// Add channel modal state via query param (read early to conditionally fetch channels)
-const showAddModal = Astro.url.searchParams.get("add") === "true";
-
-const [guildsResult, channelsResult, availableChannelsResult, creatorsResult] = await Promise.all([
+const [guildsResult, channelsResult, creatorsResult] = await Promise.all([
   ListGuildsUsecase.execute({
     accessToken,
     userId: user.id,
     appWorker: env.APP_WORKER,
   }),
   VspoChannelApiRepository.getGuildConfig(env.APP_WORKER, guildId),
-  showAddModal
-    ? VspoChannelApiRepository.listGuildChannels(env.APP_WORKER, guildId)
-    : Promise.resolve(Ok([] as { id: string; name: string }[])),
   VspoChannelApiRepository.listCreators(env.APP_WORKER),
 ]);
 
@@ -45,40 +37,27 @@ const allGuilds = guildsResult.err ? [] : [...guildsResult.val.installed, ...gui
 const currentGuild = allGuilds.find((g) => g.id === guildId);
 const guildName = currentGuild?.name ?? guildId;
 const channels = channelsResult.err ? [] : channelsResult.val.channels;
-const availableChannels = availableChannelsResult.err ? [] : availableChannelsResult.val;
 const creators = creatorsResult.err ? { jp: [], en: [] } : creatorsResult.val;
-const fetchError = guildsResult.err ?? channelsResult.err ?? availableChannelsResult.err ?? null;
+const fetchError = guildsResult.err ?? channelsResult.err ?? null;
 
-// Handle action results
-const addResult = Astro.getActionResult(actions.addChannel);
-const updateResult = Astro.getActionResult(actions.updateChannel);
-const deleteResult = Astro.getActionResult(actions.deleteChannel);
-const actionError = addResult?.error ?? updateResult?.error ?? deleteResult?.error;
-const actionSuccess = !actionError && (
-  (addResult?.data != null ? "add" : null) ??
-  (updateResult?.data != null ? "update" : null) ??
-  (deleteResult?.data != null ? "delete" : null)
-);
-const successMessageKey = actionSuccess === "add"
-  ? "toast.addSuccess" as const
-  : actionSuccess === "update"
-    ? "toast.updateSuccess" as const
-    : actionSuccess === "delete"
-      ? "toast.deleteSuccess" as const
-      : null;
-
-// Editing state via query param
-const editChannelId = Astro.url.searchParams.get("edit");
-const editingChannel = editChannelId
-  ? channels.find((c) => c.channelId === editChannelId)
-  : null;
-
-// Deleting state via query param
-const deleteChannelId = Astro.url.searchParams.get("delete");
-const deletingChannel = deleteChannelId
-  ? channels.find((c) => c.channelId === deleteChannelId)
-  : null;
-
+// Prepare data for client-side use (modals, actions)
+const pageData = {
+  guildId,
+  channels,
+  creators: [...creators.jp, ...creators.en],
+  i18n: {
+    "channel.deleteConfirm": t(locale, "channel.deleteConfirm", { channelName: "{channelName}" }),
+    "toast.addSuccess": t(locale, "toast.addSuccess"),
+    "toast.updateSuccess": t(locale, "toast.updateSuccess"),
+    "toast.deleteSuccess": t(locale, "toast.deleteSuccess"),
+    "toast.resetSuccess": t(locale, "toast.resetSuccess"),
+    "dashboard.error": t(locale, "dashboard.error", { message: "{message}" }),
+    "channel.add.submit": t(locale, "channel.add.submit"),
+    "channel.add.registered": t(locale, "channel.add.registered"),
+    "channelConfig.title": t(locale, "channelConfig.title", { channelName: "{channelName}" }),
+    "channelConfig.members.selected": t(locale, "channelConfig.members.selected", { count: "{count}" }),
+  },
+};
 ---
 
 <Dashboard title={guildName} description={t(locale, "meta.guildDetail.description", { guildName })} showSidebar activeGuild={currentGuild ? { id: currentGuild.id, name: currentGuild.name, iconUrl: GuildSummary.iconUrl(currentGuild) } : null}>
@@ -92,13 +71,14 @@ const deletingChannel = deleteChannelId
           {t(locale, "dashboard.channelsCount", { total: String(channels.length) })}
         </p>
       </div>
-      <a
-        href="?add=true"
-        class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-br from-vspo-purple to-vspo-purple-light px-5 py-3 font-heading text-sm font-bold text-white shadow-lg shadow-vspo-purple/20 transition-all hover:scale-[1.03] active:scale-95 sm:hidden"
+      <button
+        type="button"
+        data-action-add
+        class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-br from-vspo-purple to-vspo-purple-light px-5 py-3 font-heading text-sm font-bold text-white shadow-lg shadow-vspo-purple/20 transition-all hover:scale-[1.03] active:scale-95 sm:hidden cursor-pointer"
       >
         <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>
         {t(locale, "channel.add")}
-      </a>
+      </button>
     </div>
 
     {/* Stats Bento Grid */}
@@ -127,70 +107,39 @@ const deletingChannel = deleteChannelId
       </div>
     </div>
 
-    {/* Alerts */}
-    {fetchError && (
-      <ErrorAlert message={t(locale, "dashboard.error", { message: fetchError.message })} retryHref={`/dashboard/${guildId}`} retryLabel={t(locale, "toast.retry")} />
-    )}
-
-    {actionError && (
-      <ErrorAlert message={t(locale, "dashboard.error", { message: actionError.message })} retryHref={`/dashboard/${guildId}`} retryLabel={t(locale, "toast.retry")} />
-    )}
-
-    {
-      successMessageKey && (
-        <div
-          role="status"
-          aria-live="polite"
-          class="toast-success flex items-center gap-3 rounded-xl bg-vspo-purple/10 p-4 text-sm text-on-surface"
-        >
-          <svg class="h-5 w-5 shrink-0 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          <span class="flex-1">{t(locale, successMessageKey)}</span>
-          <button
-            type="button"
-            class="shrink-0 rounded-lg p-2 text-on-surface-variant hover:text-on-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vspo-purple/50"
-            aria-label={t(locale, "toast.dismiss")}
-            onclick="this.closest('.toast-success')?.remove()"
-          >
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-      )
-    }
+    {/* Alerts container */}
+    <div data-alerts class="space-y-4">
+      {fetchError && (
+        <ErrorAlert message={t(locale, "dashboard.error", { message: fetchError.message })} retryHref={`/dashboard/${guildId}`} retryLabel={t(locale, "toast.retry")} />
+      )}
+    </div>
 
     {/* Configuration Matrix */}
     <ChannelTable channels={channels} />
 
-    {
-      editingChannel && (
-        <ChannelConfigForm
-          channel={editingChannel}
-          creators={[...creators.jp, ...creators.en]}
-          guildId={guildId}
-        />
-      )
-    }
+    {/* Hidden modals - opened via client-side JS */}
+    <ChannelConfigForm
+      creators={[...creators.jp, ...creators.en]}
+      guildId={guildId}
+    />
 
-    {
-      deletingChannel && (
-        <DeleteChannelDialog
-          channel={deletingChannel}
-          guildId={guildId}
-        />
-      )
-    }
+    <DeleteChannelDialog guildId={guildId} />
 
-    {
-      showAddModal && (
-        <ChannelAddModal
-          guildId={guildId}
-          registeredChannelIds={new Set(channels.map((c) => c.channelId))}
-          availableChannels={availableChannels}
-        />
-      )
-    }
+    <ChannelAddModal guildId={guildId} />
   </div>
+
+  {/* Page data for client-side scripts */}
+  <script type="application/json" id="channel-data" set:html={JSON.stringify(pageData)} />
 </Dashboard>
+
+<script>
+  import { initChannelActions } from "~/components/channel/channel-actions";
+
+  // Initialize on first load
+  initChannelActions();
+
+  // Re-initialize after View Transition navigations
+  document.addEventListener("astro:after-swap", () => {
+    initChannelActions();
+  });
+</script>

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -147,7 +147,7 @@ const pageData = {
   // Initialize on first load
   initChannelActions();
 
-  // Re-initialize after View Transition navigations
+  // Re-initialize after View Transition swaps
   document.addEventListener("astro:after-swap", () => {
     initChannelActions();
   });


### PR DESCRIPTION
## Summary
- Enable Astro View Transitions (ClientRouter) for SPA-like page navigation across all dashboard pages
- Migrate modals (add/edit/delete) from query-param-driven server rendering to client-side dialog API, eliminating full page reloads on open/close
- Switch form submissions from accept:form (POST+Redirect) to accept:json (Astro Actions client-side calling), eliminating the browser form resubmission popup
- Add JSON API endpoint (/api/guilds/[guildId]/channels) for fetching available channels on demand

## Motivation
Every dashboard interaction (modal open/close, channel add/edit/delete) triggered a full page reload, making the UX feel heavy. The browser Confirm Form Resubmission popup also appeared when navigating back after a form submission.

## Test plan
- [ ] Modal open/close works without page reload
- [ ] Channel add/edit/delete completes without full reload
- [ ] Browser back button does not trigger form resubmission popup
- [ ] Guild-to-guild navigation uses View Transitions smoothly
- [ ] Language selector works correctly
- [ ] Toast notifications appear on success/error