### PR TITLE
feat(bot-dashboard): localize language display and add dropdown multi-select

### DIFF
--- a/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
@@ -102,128 +102,155 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
           </span>
         </div>
 
-        {/* Search bar */}
-        <label for="member-search" class="sr-only">{t(locale, "channelConfig.members.search")}</label>
-        <div class="relative">
-          <svg class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-on-surface-variant/60" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-          <input
-            id="member-search"
-            type="search"
-            placeholder={t(locale, "channelConfig.members.search")}
-            class="w-full rounded-lg border border-outline-variant/20 bg-surface-container-low py-2 pl-9 pr-3 text-sm text-on-surface placeholder:text-on-surface-variant/60 focus:border-vspo-purple focus:outline-none focus:ring-1 focus:ring-vspo-purple"
-            data-member-search
-          />
-        </div>
+        {/* Dropdown multi-select */}
+        <div class="relative" data-member-dropdown>
+          {/* Trigger: chips area + dropdown button */}
+          <button
+            type="button"
+            class="flex w-full cursor-pointer flex-wrap items-center gap-1.5 rounded-lg border border-outline-variant/20 bg-surface-container-low px-3 py-2 text-left text-sm transition-colors hover:border-vspo-purple/40 focus:border-vspo-purple focus:outline-none focus:ring-1 focus:ring-vspo-purple"
+            data-dropdown-trigger
+            aria-expanded="false"
+            aria-haspopup="listbox"
+          >
+            <span class="text-on-surface-variant/60" data-dropdown-placeholder>{t(locale, "channelConfig.members.search")}</span>
+          </button>
 
-        <div class="max-h-48 space-y-3 overflow-y-auto rounded-lg border border-outline-variant/20 p-3 sm:max-h-56">
-          {/* JP Group */}
-          {jpCreators.length > 0 && (
-            <div data-member-group="vspo_jp">
-              <div class="mb-1.5 flex items-center justify-between">
-                <h4 class="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
-                  {t(locale, "channelConfig.members.jpGroup")}
-                </h4>
-                <button
-                  type="button"
-                  class="cursor-pointer text-xs font-medium text-vspo-purple transition-colors hover:text-vspo-purple/80"
-                  data-toggle-group="vspo_jp"
-                  data-label-select={t(locale, "channelConfig.members.selectAll")}
-                  data-label-deselect={t(locale, "channelConfig.members.deselectAll")}
-                >
-                  {t(locale, "channelConfig.members.selectAll")}
-                </button>
-              </div>
-              <div class="space-y-0.5">
-                {jpCreators.map((creator) => (
-                  <label
-                    class="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-all hover:bg-surface-container-highest/40"
-                    data-member-item
-                    data-member-name={creator.name.toLowerCase()}
-                    data-member-group-item="vspo_jp"
-                  >
-                    <input
-                      type="checkbox"
-                      name="customMemberIds"
-                      value={creator.id}
-                      class="shrink-0 accent-vspo-purple"
-                      data-member-checkbox
-                    />
-                    {creator.thumbnailUrl ? (
-                      <img
-                        src={creator.thumbnailUrl}
-                        alt=""
-                        class="h-6 w-6 shrink-0 rounded-full object-cover"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-surface-container-highest text-xs font-medium text-on-surface-variant">
-                        {creator.name.charAt(0)}
-                      </span>
-                    )}
-                    <span class="truncate text-sm">{creator.name}</span>
-                  </label>
-                ))}
+          {/* Selected chips (shown above trigger when members are selected) */}
+          <div class="mb-1.5 flex hidden flex-wrap gap-1.5" data-selected-chips></div>
+
+          {/* Dropdown panel */}
+          <div
+            class="absolute left-0 z-10 mt-1 hidden w-full rounded-lg border border-outline-variant/20 bg-surface-container-high shadow-lg"
+            data-dropdown-panel
+            role="listbox"
+            aria-multiselectable="true"
+          >
+            {/* Search bar */}
+            <div class="border-b border-outline-variant/10 p-2">
+              <label for="member-search" class="sr-only">{t(locale, "channelConfig.members.search")}</label>
+              <div class="relative">
+                <svg class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-on-surface-variant/60" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+                <input
+                  id="member-search"
+                  type="search"
+                  placeholder={t(locale, "channelConfig.members.search")}
+                  class="w-full rounded-md border border-outline-variant/20 bg-surface-container-low py-1.5 pl-9 pr-3 text-sm text-on-surface placeholder:text-on-surface-variant/60 focus:border-vspo-purple focus:outline-none focus:ring-1 focus:ring-vspo-purple"
+                  data-member-search
+                />
               </div>
             </div>
-          )}
 
-          {/* EN Group */}
-          {enCreators.length > 0 && (
-            <div data-member-group="vspo_en">
-              <div class="mb-1.5 flex items-center justify-between">
-                <h4 class="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
-                  {t(locale, "channelConfig.members.enGroup")}
-                </h4>
-                <button
-                  type="button"
-                  class="cursor-pointer text-xs font-medium text-vspo-purple transition-colors hover:text-vspo-purple/80"
-                  data-toggle-group="vspo_en"
-                  data-label-select={t(locale, "channelConfig.members.selectAll")}
-                  data-label-deselect={t(locale, "channelConfig.members.deselectAll")}
-                >
-                  {t(locale, "channelConfig.members.selectAll")}
-                </button>
-              </div>
-              <div class="space-y-0.5">
-                {enCreators.map((creator) => (
-                  <label
-                    class="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-all hover:bg-surface-container-highest/40"
-                    data-member-item
-                    data-member-name={creator.name.toLowerCase()}
-                    data-member-group-item="vspo_en"
-                  >
-                    <input
-                      type="checkbox"
-                      name="customMemberIds"
-                      value={creator.id}
-                      class="shrink-0 accent-vspo-purple"
-                      data-member-checkbox
-                    />
-                    {creator.thumbnailUrl ? (
-                      <img
-                        src={creator.thumbnailUrl}
-                        alt=""
-                        class="h-6 w-6 shrink-0 rounded-full object-cover"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-surface-container-highest text-xs font-medium text-on-surface-variant">
-                        {creator.name.charAt(0)}
-                      </span>
-                    )}
-                    <span class="truncate text-sm">{creator.name}</span>
-                  </label>
-                ))}
-              </div>
+            <div class="max-h-48 space-y-3 overflow-y-auto p-3 sm:max-h-56">
+              {/* JP Group */}
+              {jpCreators.length > 0 && (
+                <div data-member-group="vspo_jp">
+                  <div class="mb-1.5 flex items-center justify-between">
+                    <h4 class="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+                      {t(locale, "channelConfig.members.jpGroup")}
+                    </h4>
+                    <button
+                      type="button"
+                      class="cursor-pointer text-xs font-medium text-vspo-purple transition-colors hover:text-vspo-purple/80"
+                      data-toggle-group="vspo_jp"
+                      data-label-select={t(locale, "channelConfig.members.selectAll")}
+                      data-label-deselect={t(locale, "channelConfig.members.deselectAll")}
+                    >
+                      {t(locale, "channelConfig.members.selectAll")}
+                    </button>
+                  </div>
+                  <div class="space-y-0.5">
+                    {jpCreators.map((creator) => (
+                      <label
+                        class="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-all hover:bg-surface-container-highest/40"
+                        data-member-item
+                        data-member-name={creator.name.toLowerCase()}
+                        data-member-group-item="vspo_jp"
+                      >
+                        <input
+                          type="checkbox"
+                          name="customMemberIds"
+                          value={creator.id}
+                          class="shrink-0 accent-vspo-purple"
+                          data-member-checkbox
+                        />
+                        {creator.thumbnailUrl ? (
+                          <img
+                            src={creator.thumbnailUrl}
+                            alt=""
+                            class="h-6 w-6 shrink-0 rounded-full object-cover"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-surface-container-highest text-xs font-medium text-on-surface-variant">
+                            {creator.name.charAt(0)}
+                          </span>
+                        )}
+                        <span class="truncate text-sm">{creator.name}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* EN Group */}
+              {enCreators.length > 0 && (
+                <div data-member-group="vspo_en">
+                  <div class="mb-1.5 flex items-center justify-between">
+                    <h4 class="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+                      {t(locale, "channelConfig.members.enGroup")}
+                    </h4>
+                    <button
+                      type="button"
+                      class="cursor-pointer text-xs font-medium text-vspo-purple transition-colors hover:text-vspo-purple/80"
+                      data-toggle-group="vspo_en"
+                      data-label-select={t(locale, "channelConfig.members.selectAll")}
+                      data-label-deselect={t(locale, "channelConfig.members.deselectAll")}
+                    >
+                      {t(locale, "channelConfig.members.selectAll")}
+                    </button>
+                  </div>
+                  <div class="space-y-0.5">
+                    {enCreators.map((creator) => (
+                      <label
+                        class="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-all hover:bg-surface-container-highest/40"
+                        data-member-item
+                        data-member-name={creator.name.toLowerCase()}
+                        data-member-group-item="vspo_en"
+                      >
+                        <input
+                          type="checkbox"
+                          name="customMemberIds"
+                          value={creator.id}
+                          class="shrink-0 accent-vspo-purple"
+                          data-member-checkbox
+                        />
+                        {creator.thumbnailUrl ? (
+                          <img
+                            src={creator.thumbnailUrl}
+                            alt=""
+                            class="h-6 w-6 shrink-0 rounded-full object-cover"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-surface-container-highest text-xs font-medium text-on-surface-variant">
+                            {creator.name.charAt(0)}
+                          </span>
+                        )}
+                        <span class="truncate text-sm">{creator.name}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Empty search state */}
+              <p class="hidden py-4 text-center text-sm text-on-surface-variant" data-member-search-empty aria-live="polite">
+                {t(locale, "channel.add.empty")}
+              </p>
             </div>
-          )}
-
-          {/* Empty search state */}
-          <p class="hidden py-4 text-center text-sm text-on-surface-variant" data-member-search-empty aria-live="polite">
-            {t(locale, "channel.add.empty")}
-          </p>
+          </div>
         </div>
       </div>
 
@@ -242,10 +269,20 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
 
 <script>
   /**
-   * Edit modal interactive controls: radio highlights, custom member toggles, search filter.
+   * Edit modal interactive controls: radio highlights, dropdown multi-select, search filter.
    * Uses AbortController to prevent duplicate listeners on view transition swaps.
    */
   let configFormAbort: AbortController | null = null;
+
+  type CreatorInfo = { id: string; name: string; thumbnailUrl: string | null };
+
+  const getCreatorsMap = (): Map<string, CreatorInfo> => {
+    const el = document.getElementById("channel-data");
+    if (!el?.textContent) return new Map();
+    const data = JSON.parse(el.textContent);
+    const creators: CreatorInfo[] = data.creators ?? [];
+    return new Map(creators.map((c) => [c.id, c]));
+  };
 
   const initConfigFormControls = () => {
     if (configFormAbort) configFormAbort.abort();
@@ -262,6 +299,12 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
     const emptyMsg = dialog.querySelector<HTMLElement>("[data-member-search-empty]");
     const saveBtn = dialog.querySelector<HTMLButtonElement>("[data-save-btn]");
     const memberTypeRadios = dialog.querySelectorAll<HTMLInputElement>('input[name="memberType"]');
+    const dropdownTrigger = dialog.querySelector<HTMLButtonElement>("[data-dropdown-trigger]");
+    const dropdownPanel = dialog.querySelector<HTMLElement>("[data-dropdown-panel]");
+    const chipsContainer = dialog.querySelector<HTMLElement>("[data-selected-chips]");
+    const placeholder = dialog.querySelector<HTMLElement>("[data-dropdown-placeholder]");
+
+    const creatorsMap = getCreatorsMap();
 
     const toggleHighlight = (
       el: HTMLElement,
@@ -276,6 +319,59 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
         el.classList.remove("bg-vspo-purple/10", "ring-1", ring);
         el.classList.add(hoverClass);
       }
+    };
+
+    /* -- Chip management -- */
+
+    const createChip = (creator: CreatorInfo): HTMLSpanElement => {
+      const chip = document.createElement("span");
+      chip.setAttribute("data-chip", creator.id);
+      chip.className =
+        "inline-flex items-center gap-1 rounded-full bg-vspo-purple/10 py-0.5 pl-1 pr-1.5 text-xs text-on-surface";
+
+      if (creator.thumbnailUrl) {
+        const img = document.createElement("img");
+        img.src = creator.thumbnailUrl;
+        img.alt = "";
+        img.className = "h-4 w-4 rounded-full object-cover";
+        chip.appendChild(img);
+      } else {
+        const fallback = document.createElement("span");
+        fallback.className =
+          "flex h-4 w-4 items-center justify-center rounded-full bg-surface-container-highest text-[8px] font-medium text-on-surface-variant";
+        fallback.textContent = creator.name.charAt(0);
+        chip.appendChild(fallback);
+      }
+
+      const nameSpan = document.createElement("span");
+      nameSpan.className = "max-w-[80px] truncate";
+      nameSpan.textContent = creator.name;
+      chip.appendChild(nameSpan);
+
+      const removeBtn = document.createElement("button");
+      removeBtn.type = "button";
+      removeBtn.className =
+        "ml-0.5 inline-flex h-3.5 w-3.5 cursor-pointer items-center justify-center rounded-full text-on-surface-variant/60 transition-colors hover:bg-vspo-purple/20 hover:text-on-surface";
+      removeBtn.setAttribute("data-remove-chip", creator.id);
+      removeBtn.setAttribute("aria-label", `Remove ${creator.name}`);
+      removeBtn.innerHTML =
+        '<svg class="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M6 18L18 6M6 6l12 12"/></svg>';
+      chip.appendChild(removeBtn);
+
+      return chip;
+    };
+
+    const syncChips = () => {
+      if (!chipsContainer) return;
+      chipsContainer.textContent = "";
+      const checked = dialog.querySelectorAll<HTMLInputElement>("[data-member-checkbox]:checked");
+      for (const cb of checked) {
+        const creator = creatorsMap.get(cb.value);
+        if (creator) chipsContainer.appendChild(createChip(creator));
+      }
+      const hasChips = checked.length > 0;
+      chipsContainer.classList.toggle("hidden", !hasChips);
+      if (placeholder) placeholder.classList.toggle("hidden", hasChips);
     };
 
     const updateSelectedState = () => {
@@ -293,6 +389,8 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
         saveBtn.classList.toggle("opacity-50", count === 0);
         saveBtn.classList.toggle("pointer-events-none", count === 0);
       }
+
+      syncChips();
     };
 
     const updateToggleLabel = (groupName: string) => {
@@ -306,6 +404,65 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
         ? (toggleBtn.dataset.labelDeselect ?? "Deselect All")
         : (toggleBtn.dataset.labelSelect ?? "Select All");
     };
+
+    /* -- Dropdown open/close -- */
+
+    const openDropdown = () => {
+      if (!dropdownPanel || !dropdownTrigger) return;
+      dropdownPanel.classList.remove("hidden");
+      dropdownTrigger.setAttribute("aria-expanded", "true");
+      searchInput?.focus();
+    };
+
+    const closeDropdown = () => {
+      if (!dropdownPanel || !dropdownTrigger) return;
+      dropdownPanel.classList.add("hidden");
+      dropdownTrigger.setAttribute("aria-expanded", "false");
+    };
+
+    dropdownTrigger?.addEventListener("click", (e) => {
+      e.preventDefault();
+      const isOpen = dropdownTrigger.getAttribute("aria-expanded") === "true";
+      if (isOpen) {
+        closeDropdown();
+      } else {
+        openDropdown();
+      }
+    }, { signal });
+
+    // Close on click outside
+    document.addEventListener("click", (e) => {
+      const dropdown = dialog.querySelector<HTMLElement>("[data-member-dropdown]");
+      if (!dropdown) return;
+      if (!dropdown.contains(e.target as Node)) {
+        closeDropdown();
+      }
+    }, { signal });
+
+    // Close on Escape within dropdown
+    dialog.querySelector("[data-member-dropdown]")?.addEventListener("keydown", (e) => {
+      if ((e as KeyboardEvent).key === "Escape") {
+        e.stopPropagation();
+        closeDropdown();
+      }
+    }, { signal });
+
+    // Chip removal via event delegation on chips container
+    chipsContainer?.addEventListener("click", (e) => {
+      const removeBtn = (e.target as HTMLElement).closest<HTMLElement>("[data-remove-chip]");
+      if (!removeBtn) return;
+      const creatorId = removeBtn.dataset.removeChip;
+      if (!creatorId) return;
+      const cb = dialog.querySelector<HTMLInputElement>(`[data-member-checkbox][value="${creatorId}"]`);
+      if (cb) {
+        cb.checked = false;
+        const label = cb.closest<HTMLElement>("[data-member-item]");
+        if (label) toggleHighlight(label, false, "ring-vspo-purple/20", "hover:bg-surface-container-highest/40");
+        const groupName = cb.closest<HTMLElement>("[data-member-group-item]")?.dataset.memberGroupItem;
+        if (groupName) updateToggleLabel(groupName);
+      }
+      updateSelectedState();
+    }, { signal });
 
     // Search filtering
     let searchTimer: ReturnType<typeof setTimeout> | undefined;
@@ -379,6 +536,7 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
       } else {
         customSection.classList.add("max-h-0", "opacity-0");
         customSection.classList.remove("max-h-[600px]", "opacity-100");
+        closeDropdown();
       }
     };
 
@@ -396,6 +554,13 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
         }
       }, { signal });
     }
+
+    // Listen for members-updated event from channel-actions.ts (populateEditForm)
+    dialog.addEventListener("members-updated", () => {
+      syncChips();
+      updateSelectedState();
+      for (const groupName of ["vspo_jp", "vspo_en"]) updateToggleLabel(groupName);
+    }, { signal });
   };
 
   initConfigFormControls();

--- a/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
@@ -110,7 +110,7 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
             class="flex w-full cursor-pointer flex-wrap items-center gap-1.5 rounded-lg border border-outline-variant/20 bg-surface-container-low px-3 py-2 text-left text-sm transition-colors hover:border-vspo-purple/40 focus:border-vspo-purple focus:outline-none focus:ring-1 focus:ring-vspo-purple"
             data-dropdown-trigger
             aria-expanded="false"
-            aria-haspopup="listbox"
+            aria-haspopup="dialog"
           >
             <span class="text-on-surface-variant/60" data-dropdown-placeholder>{t(locale, "channelConfig.members.search")}</span>
           </button>
@@ -122,8 +122,6 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
           <div
             class="absolute left-0 z-10 mt-1 hidden w-full rounded-lg border border-outline-variant/20 bg-surface-container-high shadow-lg"
             data-dropdown-panel
-            role="listbox"
-            aria-multiselectable="true"
           >
             {/* Search bar */}
             <div class="border-b border-outline-variant/10 p-2">

--- a/service/bot-dashboard/src/components/channel/ChannelConfigForm.stories.ts
+++ b/service/bot-dashboard/src/components/channel/ChannelConfigForm.stories.ts
@@ -81,6 +81,21 @@ const meta: Meta<ChannelConfigFormArgs> = {
 
     const selectedCount = customMemberSet.size;
 
+    const chipHtml = (creator: Creator) => `
+      <span data-chip="${creator.id}" class="inline-flex items-center gap-1 rounded-full bg-vspo-purple/10 py-0.5 pl-1 pr-1.5 text-xs text-on-surface">
+        ${creator.thumbnailUrl ? `<img src="${creator.thumbnailUrl}" alt="" class="h-4 w-4 rounded-full object-cover" />` : `<span class="flex h-4 w-4 items-center justify-center rounded-full bg-surface-container-highest text-[8px] font-medium text-on-surface-variant">${creator.name.charAt(0)}</span>`}
+        <span class="max-w-[80px] truncate">${creator.name}</span>
+        <button type="button" class="ml-0.5 inline-flex h-3.5 w-3.5 cursor-pointer items-center justify-center rounded-full text-on-surface-variant/60 hover:bg-vspo-purple/20 hover:text-on-surface" data-remove-chip="${creator.id}" aria-label="Remove ${creator.name}">
+          <svg class="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M6 18L18 6M6 6l12 12"/></svg>
+        </button>
+      </span>`;
+
+    const selectedChips = args.creators
+      .filter((c) => customMemberSet.has(c.id))
+      .map(chipHtml)
+      .join("");
+    const hasChips = selectedCount > 0;
+
     return `
       <dialog open class="fixed inset-0 z-50 flex items-center justify-center" id="config-modal" aria-labelledby="config-modal-heading" aria-modal="true" style="background: rgba(0,0,0,0.6);">
         <div class="glass mx-4 w-full max-w-lg rounded-xl bg-surface-container-high/90 p-6 text-on-surface shadow-hover">
@@ -96,6 +111,7 @@ const meta: Meta<ChannelConfigFormArgs> = {
               <select id="language" name="language" class="w-full rounded-md border border-outline-variant/20 bg-surface-container-low px-3 py-2 text-sm text-on-surface">
                 <option value="ja" ${args.channel.language === "ja" ? "selected" : ""}>Japanese</option>
                 <option value="en" ${args.channel.language === "en" ? "selected" : ""}>English</option>
+                <option value="default" ${args.channel.language === "default" ? "selected" : ""}>Default</option>
               </select>
             </div>
             <fieldset class="space-y-2">
@@ -107,8 +123,22 @@ const meta: Meta<ChannelConfigFormArgs> = {
                 <span class="text-sm font-medium">Custom Members</span>
                 <span class="rounded-full bg-vspo-purple/10 px-2.5 py-0.5 text-xs font-medium text-vspo-purple" data-selected-count>${selectedCount} selected</span>
               </div>
-              <div class="max-h-56 space-y-3 overflow-y-auto rounded-lg border border-outline-variant/20 p-3">
-                ${args.creators.map(memberRow).join("")}
+              <div class="relative" data-member-dropdown>
+                <button type="button" class="flex w-full cursor-pointer flex-wrap items-center gap-1.5 rounded-lg border border-outline-variant/20 bg-surface-container-low px-3 py-2 text-left text-sm transition-colors hover:border-vspo-purple/40" data-dropdown-trigger aria-expanded="${showCustomMembers}" aria-haspopup="listbox">
+                  ${hasChips ? "" : '<span class="text-on-surface-variant/60" data-dropdown-placeholder>Search members...</span>'}
+                </button>
+                <div class="mb-1.5 flex ${hasChips ? "" : "hidden"} flex-wrap gap-1.5" data-selected-chips>${selectedChips}</div>
+                <div class="${showCustomMembers ? "" : "hidden"} absolute left-0 z-10 mt-1 w-full rounded-lg border border-outline-variant/20 bg-surface-container-high shadow-lg" data-dropdown-panel role="listbox" aria-multiselectable="true">
+                  <div class="border-b border-outline-variant/10 p-2">
+                    <div class="relative">
+                      <svg class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-on-surface-variant/60" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+                      <input type="search" placeholder="Search members..." class="w-full rounded-md border border-outline-variant/20 bg-surface-container-low py-1.5 pl-9 pr-3 text-sm text-on-surface placeholder:text-on-surface-variant/60" data-member-search />
+                    </div>
+                  </div>
+                  <div class="max-h-48 space-y-3 overflow-y-auto p-3 sm:max-h-56">
+                    ${args.creators.map(memberRow).join("")}
+                  </div>
+                </div>
               </div>
             </div>
             <div class="flex justify-end gap-2 pt-2">

--- a/service/bot-dashboard/src/components/channel/ChannelConfigForm.stories.ts
+++ b/service/bot-dashboard/src/components/channel/ChannelConfigForm.stories.ts
@@ -128,7 +128,7 @@ const meta: Meta<ChannelConfigFormArgs> = {
                   ${hasChips ? "" : '<span class="text-on-surface-variant/60" data-dropdown-placeholder>Search members...</span>'}
                 </button>
                 <div class="mb-1.5 flex ${hasChips ? "" : "hidden"} flex-wrap gap-1.5" data-selected-chips>${selectedChips}</div>
-                <div class="${showCustomMembers ? "" : "hidden"} absolute left-0 z-10 mt-1 w-full rounded-lg border border-outline-variant/20 bg-surface-container-high shadow-lg" data-dropdown-panel role="listbox" aria-multiselectable="true">
+                <div class="${showCustomMembers ? "" : "hidden"} absolute left-0 z-10 mt-1 w-full rounded-lg border border-outline-variant/20 bg-surface-container-high shadow-lg" data-dropdown-panel>
                   <div class="border-b border-outline-variant/10 p-2">
                     <div class="relative">
                       <svg class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-on-surface-variant/60" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>

--- a/service/bot-dashboard/src/components/channel/ChannelTable.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelTable.astro
@@ -1,6 +1,6 @@
 ---
 import type { ChannelConfigType } from "~/features/channel/domain/channel-config";
-import { t, memberTypeKey } from "~/i18n/dict";
+import { t, memberTypeKey, languageDisplayKey } from "~/i18n/dict";
 
 interface Props {
   channels: ChannelConfigType[];
@@ -9,8 +9,8 @@ interface Props {
 const { channels } = Astro.props;
 const { locale } = Astro.locals;
 
-/** Language code to chip label — uppercases any language code */
-const langChipLabel = (lang: string) => lang.toUpperCase();
+/** Language code to localized chip label */
+const langChipLabel = (lang: string) => t(locale, languageDisplayKey(lang));
 ---
 
 {/* Configuration Matrix */}

--- a/service/bot-dashboard/src/components/channel/ChannelTable.stories.ts
+++ b/service/bot-dashboard/src/components/channel/ChannelTable.stories.ts
@@ -33,7 +33,8 @@ const langDisplayLabels: Record<string, string> = {
   default: "Default",
 };
 
-const langChipLabel = (lang: string) => langDisplayLabels[lang] ?? lang.toUpperCase();
+const langChipLabel = (lang: string) =>
+  langDisplayLabels[lang] ?? lang.toUpperCase();
 
 const memberTypeLabel: Record<string, string> = {
   vspo_jp: "VSPO! JP",

--- a/service/bot-dashboard/src/components/channel/ChannelTable.stories.ts
+++ b/service/bot-dashboard/src/components/channel/ChannelTable.stories.ts
@@ -21,8 +21,19 @@ const deleteIcon = `<svg class="h-5 w-5" fill="none" stroke="currentColor" viewB
 
 const addIcon = `<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>`;
 
-const langChipLabel = (lang: string) =>
-  lang === "ja" ? "JA" : lang === "en" ? "EN" : lang.toUpperCase();
+const langDisplayLabels: Record<string, string> = {
+  ja: "Japanese",
+  en: "English",
+  fr: "French",
+  de: "German",
+  es: "Spanish",
+  cn: "Simplified Chinese",
+  tw: "Traditional Chinese",
+  ko: "Korean",
+  default: "Default",
+};
+
+const langChipLabel = (lang: string) => langDisplayLabels[lang] ?? lang.toUpperCase();
 
 const memberTypeLabel: Record<string, string> = {
   vspo_jp: "VSPO! JP",
@@ -134,6 +145,13 @@ export const WithChannels: Story = {
         enabled: false,
         language: "en",
         memberType: "vspo_jp",
+      },
+      {
+        channelId: "ch-6",
+        channelName: "default-lang",
+        enabled: true,
+        language: "default",
+        memberType: "all",
       },
     ],
   },

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -56,7 +56,9 @@ const persistPageData = (data: PageData) => {
 const languageLabel = (lang: string, i18n: Record<string, string>): string => {
   const key = lang.trim().toLowerCase();
   if (!key) return i18n["language.unknown"] ?? "";
-  return i18n[`language.${key}`] ?? i18n["language.unknown"] ?? key.toUpperCase();
+  return (
+    i18n[`language.${key}`] ?? i18n["language.unknown"] ?? key.toUpperCase()
+  );
 };
 
 const escapeHtml = (str: string): string =>

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -41,8 +41,9 @@ const getPageData = (): PageData => {
   if (currentData) return currentData;
   const el = document.getElementById("channel-data");
   if (!el?.textContent) throw new Error("Missing #channel-data");
-  currentData = JSON.parse(el.textContent);
-  return currentData!;
+  const parsed: PageData = JSON.parse(el.textContent);
+  currentData = parsed;
+  return parsed;
 };
 
 const persistPageData = (data: PageData) => {

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -53,6 +53,9 @@ const persistPageData = (data: PageData) => {
 
 /* ---------- Helpers ---------- */
 
+const languageLabel = (lang: string, i18n: Record<string, string>): string =>
+  i18n[`language.${lang}`] ?? lang.toUpperCase();
+
 const escapeHtml = (str: string): string =>
   str
     .replace(/&/g, "&amp;")
@@ -144,7 +147,7 @@ const createRowHtml = (
 ): string => {
   const name = escapeHtml(ch.channelName);
   const id = escapeHtml(ch.channelId);
-  const langLabel = escapeHtml(ch.language.toUpperCase());
+  const langLabel = escapeHtml(languageLabel(ch.language, i18n));
   const mtLabel = escapeHtml(memberTypeLabel(ch.memberType, i18n));
   const statusActive = ch.enabled;
   const statusLabel = escapeHtml(
@@ -200,7 +203,7 @@ const updateStats = (data: PageData) => {
         const chip = document.createElement("span");
         chip.className =
           "rounded bg-surface-container-highest px-2 py-0.5 text-[10px] font-bold text-vspo-purple";
-        chip.textContent = lang.toUpperCase();
+        chip.textContent = languageLabel(lang, data.i18n);
         langContainer.appendChild(chip);
       }
     }
@@ -238,7 +241,7 @@ const updateRowCells = (
 
   if (updates.language !== undefined) {
     const langCell = row.querySelector("td:nth-child(2) span");
-    if (langCell) langCell.textContent = updates.language.toUpperCase();
+    if (langCell) langCell.textContent = languageLabel(updates.language, i18n);
   }
 
   if (updates.memberType !== undefined) {
@@ -888,6 +891,9 @@ const populateEditForm = (
   }
 
   updateSelectedCount(dialog, data);
+
+  // Notify ChannelConfigForm script to sync chips
+  dialog.dispatchEvent(new CustomEvent("members-updated"));
 
   const saveBtn = dialog.querySelector<HTMLButtonElement>("[data-save-btn]");
   if (saveBtn) {

--- a/service/bot-dashboard/src/components/channel/channel-actions.ts
+++ b/service/bot-dashboard/src/components/channel/channel-actions.ts
@@ -53,8 +53,11 @@ const persistPageData = (data: PageData) => {
 
 /* ---------- Helpers ---------- */
 
-const languageLabel = (lang: string, i18n: Record<string, string>): string =>
-  i18n[`language.${lang}`] ?? lang.toUpperCase();
+const languageLabel = (lang: string, i18n: Record<string, string>): string => {
+  const key = lang.trim().toLowerCase();
+  if (!key) return i18n["language.unknown"] ?? "";
+  return i18n[`language.${key}`] ?? i18n["language.unknown"] ?? key.toUpperCase();
+};
 
 const escapeHtml = (str: string): string =>
   str

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -9,7 +9,7 @@ import Dashboard from "~/layouts/Dashboard.astro";
 import { VspoChannelApiRepository } from "~/features/channel/repository/vspo-channel-api";
 import { GuildSummary } from "~/features/guild/domain/guild";
 import { ListGuildsUsecase } from "~/features/guild/usecase/list-guilds";
-import { t, memberTypeKey } from "~/i18n/dict";
+import { t, memberTypeKey, languageDisplayKey } from "~/i18n/dict";
 
 const locale = Astro.locals.locale;
 const { guildId } = Astro.params;
@@ -65,6 +65,15 @@ const pageData = {
     "channel.edit": t(locale, "channel.edit"),
     "channel.delete": t(locale, "channel.delete"),
     "dashboard.channelsCount": t(locale, "dashboard.channelsCount", { total: "{total}" }),
+    "language.ja": t(locale, "channelConfig.language.ja"),
+    "language.en": t(locale, "channelConfig.language.en"),
+    "language.fr": t(locale, "channelConfig.language.fr"),
+    "language.de": t(locale, "channelConfig.language.de"),
+    "language.es": t(locale, "channelConfig.language.es"),
+    "language.cn": t(locale, "channelConfig.language.cn"),
+    "language.tw": t(locale, "channelConfig.language.tw"),
+    "language.ko": t(locale, "channelConfig.language.ko"),
+    "language.default": t(locale, "channelConfig.language.default"),
   },
 };
 ---
@@ -100,7 +109,7 @@ const pageData = {
         <p class="mb-2 text-xs font-medium text-on-surface-variant">{t(locale, "channel.language")}</p>
         <div data-stat-languages class="flex gap-2">
           {[...new Set(channels.map(c => c.language))].map(lang => (
-            <span class="rounded bg-surface-container-highest px-2 py-0.5 text-[10px] font-bold text-vspo-purple">{lang === "ja" ? "JA" : lang === "en" ? "EN" : lang.toUpperCase()}</span>
+            <span class="rounded bg-surface-container-highest px-2 py-0.5 text-[10px] font-bold text-vspo-purple">{t(locale, languageDisplayKey(lang))}</span>
           ))}
           {channels.length === 0 && <span class="text-sm text-on-surface-variant">—</span>}
         </div>

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -74,6 +74,7 @@ const pageData = {
     "language.tw": t(locale, "channelConfig.language.tw"),
     "language.ko": t(locale, "channelConfig.language.ko"),
     "language.default": t(locale, "channelConfig.language.default"),
+    "language.unknown": t(locale, "channelConfig.language.unknown"),
   },
 };
 ---


### PR DESCRIPTION
## Summary
- 言語チップ表示を `toUpperCase()` から i18n ローカライズに変更（"DEFAULT" → "デフォルト"/"Default"）
- カスタムメンバー選択UIをチェックボックスリストからドロップダウン型マルチセレクト（チップ表示付き）に変更
- ChannelTable、stats bento grid、クライアントサイド楽観更新の全3箇所で言語ラベルをローカライズ

## Changes
- `ChannelTable.astro`: `langChipLabel` を `t(locale, languageDisplayKey(lang))` に変更
- `[guildId].astro`: stats言語チップ i18n化 + `pageData.i18n` に言語ラベル9件追加
- `channel-actions.ts`: `languageLabel()` helper追加、`toUpperCase` 3箇所置換、`members-updated` イベント dispatch
- `ChannelConfigForm.astro`: ドロップダウントリガー + 選択済みチップ + ドロップダウンパネル構造に再構成
- Stories: 新UI構造に合わせて更新