### PR TITLE
refactor(api): replace axios with native fetch

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -20,8 +20,6 @@ const response = await apiClient.someEndpoint();
 ## Dependencies
 
 - @vspo-lab/error: workspace package
-- axios: ^1.9.0
-- axios-retry: ^4.5.0
 
 ## Development
 

--- a/packages/api/orval.config.ts
+++ b/packages/api/orval.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     input: "../../service/server/docs/openapi.json",
     output: {
       target: "./src/gen/openapi.ts",
-      httpClient: "axios",
+      httpClient: "fetch",
     },
   },
 });

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -21,7 +21,6 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@vspo-lab/error": "workspace:^",
-    "axios": "^1.13.6"
+    "@vspo-lab/error": "workspace:^"
   }
 }

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -1,6 +1,4 @@
 import { AppError, Err, Ok, type Result } from "@vspo-lab/error";
-import type { AxiosRequestConfig } from "axios";
-import axios from "axios";
 import type * as apiGen from "./gen/openapi";
 import { isLocalEnv, MockHandler } from "./mock";
 
@@ -12,7 +10,6 @@ type ApiErrorResponse = {
   };
 };
 
-// Define a simpler approach without using type assertions
 function isValidAppErrorCode(code: string): code is AppError["code"] {
   return [
     "BAD_REQUEST",
@@ -29,6 +26,19 @@ function isValidAppErrorCode(code: string): code is AppError["code"] {
     "METHOD_NOT_ALLOWED",
   ].includes(code);
 }
+
+export type RequestOptions = {
+  signal?: AbortSignal;
+};
+
+type RequestConfig = {
+  method: string;
+  url: string;
+  params?: Record<string, string | string[] | undefined>;
+  data?: unknown;
+  headers?: Record<string, string>;
+  signal?: AbortSignal | undefined;
+};
 
 export type VSPOApiOptions = {
   apiKey?: string;
@@ -93,96 +103,114 @@ export class VSPOApi {
     return headers;
   }
 
-  private async request<TData>(
-    config: AxiosRequestConfig,
-  ): Promise<Result<TData, AppError>> {
-    let err: Error | null = null;
+  /** Build a URL with query parameters appended. */
+  private buildUrl(
+    base: string,
+    params?: Record<string, string | string[] | undefined>,
+  ): string {
+    if (!params) return base;
 
-    const requestConfig = {
-      ...config,
-      headers: {
-        ...config.headers,
-        ...this.getHeaders(),
-      },
-    };
-
-    for (let i = 0; i <= this.retry.attempts; i++) {
-      try {
-        const response = await axios.request<TData>(requestConfig);
-        return Ok(response.data);
-      } catch (error) {
-        // Initialize with default values satisfying AppError structure
-        let errorMessage = "An unexpected error occurred.";
-        // Use a default code that is definitely in the AppError['code'] union
-        let determinedCode: AppError["code"] = "INTERNAL_SERVER_ERROR";
-        // AppError['status'] expects number, not number | undefined. Use 0 for non-HTTP errors.
-        let errorStatus = 0;
-        // Ensure cause is Error | undefined
-        const errorCause: Error | undefined =
-          error instanceof Error ? error : undefined;
-
-        if (axios.isAxiosError<ApiErrorResponse>(error)) {
-          // Axios error handling
-          if (error.response) {
-            // Error response from server
-            const apiError = error.response.data?.error;
-            errorStatus = error.response.status; // Assign actual HTTP status
-            errorMessage = apiError?.message || `API Error: ${errorStatus}`;
-            // Use the specific error code from the API if available and valid
-            if (apiError?.code) {
-              if (isValidAppErrorCode(apiError.code)) {
-                determinedCode = apiError.code;
-              } else {
-                // If code from API is not a valid AppError code, use default
-                determinedCode = "INTERNAL_SERVER_ERROR";
-              }
-            } else {
-              // If no specific code from API, keep default ('INTERNAL_SERVER_ERROR')
-              determinedCode = "INTERNAL_SERVER_ERROR";
-            }
-
-            // Client errors (4xx) are usually not recoverable with retries
-            if (errorStatus >= 400 && errorStatus < 500) {
-              err = error;
-              break;
-            }
-          } else if (error.request) {
-            // Request made but no response received
-            errorMessage = "No response received from the server.";
-            determinedCode = "INTERNAL_SERVER_ERROR";
-            errorStatus = 0;
-          } else {
-            // Setup error before request was sent
-            errorMessage = error.message;
-            determinedCode = "INTERNAL_SERVER_ERROR";
-            errorStatus = 0;
-          }
-        } else {
-          // Handle non-Axios errors
-          errorMessage = error instanceof Error ? error.message : String(error);
-          determinedCode = "INTERNAL_SERVER_ERROR";
-          errorStatus = 0;
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined) continue;
+      if (Array.isArray(value)) {
+        for (const v of value) {
+          searchParams.append(key, v);
         }
-
-        err = new AppError({
-          message: errorMessage,
-          code: determinedCode,
-          cause: errorCause,
-        });
-
-        // If this is not the last attempt, wait before retrying
-        if (i < this.retry.attempts) {
-          const backoff = this.retry.backoff(i);
-          console.debug(
-            `Attempt ${i + 1} of ${this.retry.attempts + 1} failed, retrying in ${backoff}ms: ${errorMessage}`,
-          );
-          await new Promise((r) => setTimeout(r, backoff));
-        }
+      } else {
+        searchParams.append(key, value);
       }
     }
 
-    // If we get here, all retries failed
-    // type-safe: err is always AppError assigned in the retry loop
+    const qs = searchParams.toString();
+    return qs ? `${base}?${qs}` : base;
+  }
+
+  private async request<TData>(
+    config: RequestConfig,
+  ): Promise<Result<TData, AppError>> {
+    let err: Error | null = null;
+
+    for (let i = 0; i <= this.retry.attempts; i++) {
+      const url = this.buildUrl(config.url, config.params);
+      const init: RequestInit = {
+        method: config.method,
+        headers: {
+          ...this.getHeaders(),
+          ...config.headers,
+        },
+        ...(config.signal != null ? { signal: config.signal } : {}),
+      };
+
+      if (config.data !== undefined) {
+        init.body = JSON.stringify(config.data);
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(url, init);
+      } catch (error) {
+        const errorCause = error instanceof Error ? error : undefined;
+        err = new AppError({
+          message:
+            error instanceof Error
+              ? error.message
+              : "No response received from the server.",
+          code: "INTERNAL_SERVER_ERROR",
+          cause: errorCause,
+        });
+
+        if (i < this.retry.attempts) {
+          const backoff = this.retry.backoff(i);
+          console.debug(
+            `Attempt ${i + 1} of ${this.retry.attempts + 1} failed, retrying in ${backoff}ms: ${err.message}`,
+          );
+          await new Promise((r) => setTimeout(r, backoff));
+        }
+        continue;
+      }
+
+      if (response.ok) {
+        const data = (await response.json()) as TData;
+        return Ok(data);
+      }
+
+      // Error response from server
+      let errorMessage = `API Error: ${response.status}`;
+      let determinedCode: AppError["code"] = "INTERNAL_SERVER_ERROR";
+
+      try {
+        const body = (await response.json()) as ApiErrorResponse;
+        const apiError = body?.error;
+        if (apiError?.message) {
+          errorMessage = apiError.message;
+        }
+        if (apiError?.code && isValidAppErrorCode(apiError.code)) {
+          determinedCode = apiError.code;
+        }
+      } catch {
+        // Could not parse error body — keep defaults
+      }
+
+      err = new AppError({
+        message: errorMessage,
+        code: determinedCode,
+      });
+
+      // Client errors (4xx) are usually not recoverable with retries
+      if (response.status >= 400 && response.status < 500) {
+        break;
+      }
+
+      if (i < this.retry.attempts) {
+        const backoff = this.retry.backoff(i);
+        console.debug(
+          `Attempt ${i + 1} of ${this.retry.attempts + 1} failed, retrying in ${backoff}ms: ${errorMessage}`,
+        );
+        await new Promise((r) => setTimeout(r, backoff));
+      }
+    }
+
     return Err(err as AppError);
   }
 
@@ -190,37 +218,35 @@ export class VSPOApi {
     return {
       list: (
         params: apiGen.ListStreamsParams,
-        options?: AxiosRequestConfig,
+        options?: RequestOptions,
       ): Promise<Result<apiGen.ListStreams200, AppError>> => {
-        // Use mock data if in local environment
         if (isLocalEnv({ baseUrl: this.baseUrl })) {
           const mockData = MockHandler.getStreams(params);
           return Promise.resolve(Ok(mockData));
         }
 
         return this.request<apiGen.ListStreams200>({
-          ...options,
           method: "GET",
           url: `${this.baseUrl}/streams`,
           params,
+          signal: options?.signal,
         });
       },
 
       search: (
         body: apiGen.PostStreamBody,
-        options?: AxiosRequestConfig,
+        options?: RequestOptions,
       ): Promise<Result<apiGen.PostStream200, AppError>> => {
-        // Use mock data if in local environment
         if (isLocalEnv({ baseUrl: this.baseUrl })) {
           const mockData = MockHandler.searchStreams(body);
           return Promise.resolve(Ok(mockData));
         }
 
         return this.request<apiGen.PostStream200>({
-          ...options,
           method: "POST",
           url: `${this.baseUrl}/streams/search`,
           data: body,
+          signal: options?.signal,
         });
       },
     };
@@ -230,19 +256,18 @@ export class VSPOApi {
     return {
       list: (
         params: apiGen.ListCreatorsParams,
-        options?: AxiosRequestConfig,
+        options?: RequestOptions,
       ): Promise<Result<apiGen.ListCreators200, AppError>> => {
-        // Use mock data if in local environment
         if (isLocalEnv({ baseUrl: this.baseUrl })) {
           const mockData = MockHandler.getCreators(params);
           return Promise.resolve(Ok(mockData));
         }
 
         return this.request<apiGen.ListCreators200>({
-          ...options,
           method: "GET",
           url: `${this.baseUrl}/creators`,
           params,
+          signal: options?.signal,
         });
       },
     };
@@ -252,19 +277,18 @@ export class VSPOApi {
     return {
       list: (
         params: apiGen.ListClipsParams,
-        options?: AxiosRequestConfig,
+        options?: RequestOptions,
       ): Promise<Result<apiGen.ListClips200, AppError>> => {
-        // Use mock data if in local environment
         if (isLocalEnv({ baseUrl: this.baseUrl })) {
           const mockData = MockHandler.getClips(params);
           return Promise.resolve(Ok(mockData));
         }
 
         return this.request<apiGen.ListClips200>({
-          ...options,
           method: "GET",
           url: `${this.baseUrl}/clips`,
           params,
+          signal: options?.signal,
         });
       },
     };
@@ -274,47 +298,42 @@ export class VSPOApi {
     return {
       list: (
         params: apiGen.ListEventsParams,
-        options?: AxiosRequestConfig,
+        options?: RequestOptions,
       ): Promise<Result<apiGen.ListEvents200, AppError>> => {
-        // Use mock data if in local environment
         if (isLocalEnv({ baseUrl: this.baseUrl })) {
           const mockData = MockHandler.getEvents(params);
           return Promise.resolve(Ok(mockData));
         }
 
         return this.request<apiGen.ListEvents200>({
-          ...options,
           method: "GET",
           url: `${this.baseUrl}/events`,
           params,
+          signal: options?.signal,
         });
       },
 
       create: (
         body: apiGen.CreateEventBody,
-        options?: AxiosRequestConfig,
+        options?: RequestOptions,
       ): Promise<Result<apiGen.CreateEvent201, AppError>> => {
-        // Note: For creation endpoints, we still make the API call
-        // as mocking creation would require storing state
         return this.request<apiGen.CreateEvent201>({
-          ...options,
           method: "POST",
           url: `${this.baseUrl}/events`,
           data: body,
+          signal: options?.signal,
         });
       },
 
       get: (
         id: string,
-        options?: AxiosRequestConfig,
+        options?: RequestOptions,
       ): Promise<Result<apiGen.GetEvent200, AppError>> => {
-        // Use mock data if in local environment
         if (isLocalEnv({ baseUrl: this.baseUrl })) {
           try {
             const mockData = MockHandler.getEvent(id);
             return Promise.resolve(Ok(mockData));
           } catch (_error) {
-            // If event not found, return a NOT_FOUND error
             return Promise.resolve(
               Err(
                 new AppError({
@@ -327,9 +346,9 @@ export class VSPOApi {
         }
 
         return this.request<apiGen.GetEvent200>({
-          ...options,
           method: "GET",
           url: `${this.baseUrl}/events/${id}`,
+          signal: options?.signal,
         });
       },
     };
@@ -339,19 +358,18 @@ export class VSPOApi {
     return {
       list: (
         params: apiGen.ListFreechatsParams,
-        options?: AxiosRequestConfig,
+        options?: RequestOptions,
       ): Promise<Result<apiGen.ListFreechats200, AppError>> => {
-        // Use mock data if in local environment
         if (isLocalEnv({ baseUrl: this.baseUrl })) {
           const mockData = MockHandler.getFreechats(params);
           return Promise.resolve(Ok(mockData));
         }
 
         return this.request<apiGen.ListFreechats200>({
-          ...options,
           method: "GET",
           url: `${this.baseUrl}/freechats`,
           params,
+          signal: options?.signal,
         });
       },
     };

--- a/packages/api/src/gen/openapi.ts
+++ b/packages/api/src/gen/openapi.ts
@@ -5,11 +5,6 @@
  * API
  * OpenAPI spec version: 1.0.0
  */
-import axios from 'axios';
-import type {
-  AxiosRequestConfig,
-  AxiosResponse
-} from 'axios';
 
 /**
  * A machine readable error code.
@@ -936,87 +931,3 @@ export type ListFreechats200 = {
   pagination: ListFreechats200Pagination;
 };
 
-export const listStreams = <TData = AxiosResponse<ListStreams200>>(
-    params: ListStreamsParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/streams`,{
-    ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
-
-export const listCreators = <TData = AxiosResponse<ListCreators200>>(
-    params: ListCreatorsParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/creators`,{
-    ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
-
-export const postStream = <TData = AxiosResponse<PostStream200>>(
-    postStreamBody: PostStreamBody, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/streams/search`,
-      postStreamBody,options
-    );
-  }
-
-export const listClips = <TData = AxiosResponse<ListClips200>>(
-    params: ListClipsParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/clips`,{
-    ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
-
-export const listEvents = <TData = AxiosResponse<ListEvents200>>(
-    params: ListEventsParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/events`,{
-    ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
-
-export const createEvent = <TData = AxiosResponse<CreateEvent201>>(
-    createEventBody: CreateEventBody, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/events`,
-      createEventBody,options
-    );
-  }
-
-export const getEvent = <TData = AxiosResponse<GetEvent200>>(
-    id: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/events/${id}`,options
-    );
-  }
-
-export const listFreechats = <TData = AxiosResponse<ListFreechats200>>(
-    params: ListFreechatsParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/freechats`,{
-    ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
-
-export type ListStreamsResult = AxiosResponse<ListStreams200>
-export type ListCreatorsResult = AxiosResponse<ListCreators200>
-export type PostStreamResult = AxiosResponse<PostStream200>
-export type ListClipsResult = AxiosResponse<ListClips200>
-export type ListEventsResult = AxiosResponse<ListEvents200>
-export type CreateEventResult = AxiosResponse<CreateEvent201>
-export type GetEventResult = AxiosResponse<GetEvent200>
-export type ListFreechatsResult = AxiosResponse<ListFreechats200>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,9 +85,6 @@ importers:
       '@vspo-lab/error':
         specifier: workspace:^
         version: link:../errors
-      axios:
-        specifier: ^1.13.6
-        version: 1.13.6
     devDependencies:
       orval:
         specifier: ^8.0.0
@@ -4775,9 +4772,6 @@ packages:
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
-
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -5925,15 +5919,6 @@ packages:
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
-
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   fontace@0.4.1:
     resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
@@ -7826,9 +7811,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
@@ -14794,14 +14776,6 @@ snapshots:
 
   aws4fetch@1.0.20: {}
 
-  axios@1.13.6:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axobject-query@4.1.0: {}
 
   babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.105.4):
@@ -16205,8 +16179,6 @@ snapshots:
   flatted@3.4.1: {}
 
   flattie@1.1.1: {}
-
-  follow-redirects@1.15.11: {}
 
   fontace@0.4.1:
     dependencies:
@@ -18565,8 +18537,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@1.1.0: {}
 
   public-encrypt@4.0.3:
     dependencies:


### PR DESCRIPTION
## Summary
- Remove `axios` dependency from `@vspo-lab/api` to reduce supply chain attack surface
- Replace all HTTP calls in `VSPOApi.request()` with native `fetch` API
- Remove unused orval-generated axios functions from `openapi.ts` (only type exports were consumed)
- Update orval config to use `fetch` httpClient for future code generation

## Test plan
- [x] `@vspo-lab/api` builds successfully (`pnpm --filter @vspo-lab/api build`)
- [x] `vspo-schedule-v2-web` consumer builds successfully
- [x] No remaining axios references in source code
- [ ] Verify API calls work correctly in staging environment