### PR TITLE
fix(bot-dashboard): preserve dark mode across locale switch

### DIFF
--- a/service/bot-dashboard/src/components/ui/ThemeToggle.astro
+++ b/service/bot-dashboard/src/components/ui/ThemeToggle.astro
@@ -46,10 +46,17 @@ const buttonClass = variant === "header"
 </button>
 
 <script>
-  import { registerIcons, toggle } from "~/components/ui/theme";
-  const sun = document.getElementById("theme-icon-sun");
-  const moon = document.getElementById("theme-icon-moon");
-  const btn = document.getElementById("theme-toggle");
-  if (sun && moon) registerIcons(sun, moon);
-  btn?.addEventListener("click", toggle);
+  import { clearIcons, registerIcons, toggle } from "~/components/ui/theme";
+
+  function init() {
+    clearIcons();
+    const sun = document.getElementById("theme-icon-sun");
+    const moon = document.getElementById("theme-icon-moon");
+    const btn = document.getElementById("theme-toggle");
+    if (sun && moon) registerIcons(sun, moon);
+    btn?.addEventListener("click", toggle);
+  }
+
+  init();
+  document.addEventListener("astro:page-load", init);
 </script>

--- a/service/bot-dashboard/src/components/ui/theme.ts
+++ b/service/bot-dashboard/src/components/ui/theme.ts
@@ -8,13 +8,18 @@
 
 type IconPair = { sun: HTMLElement; moon: HTMLElement };
 
-const pairs: IconPair[] = [];
+let pairs: IconPair[] = [];
 
 const applyAll = (isDark: boolean): void => {
   for (const { sun, moon } of pairs) {
     sun.classList.toggle("hidden", !isDark);
     moon.classList.toggle("hidden", isDark);
   }
+};
+
+/** Clear all registered icon pairs (call before re-registering after View Transitions). */
+export const clearIcons = (): void => {
+  pairs = [];
 };
 
 /** Register a sun/moon icon pair to be kept in sync. */

--- a/service/bot-dashboard/src/layouts/Base.astro
+++ b/service/bot-dashboard/src/layouts/Base.astro
@@ -71,13 +71,17 @@ const altPath = canonicalPath
 
     <script is:inline>
       (function () {
-        var stored = localStorage.getItem("theme");
-        var prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches;
-        if (stored === "light" || (!stored && prefersLight)) {
-          /* light mode only when explicitly chosen or OS prefers light */
-        } else {
-          document.documentElement.classList.add("dark");
+        function applyTheme() {
+          var stored = localStorage.getItem("theme");
+          var prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches;
+          if (stored === "light" || (!stored && prefersLight)) {
+            document.documentElement.classList.remove("dark");
+          } else {
+            document.documentElement.classList.add("dark");
+          }
         }
+        applyTheme();
+        document.addEventListener("astro:after-swap", applyTheme);
       })();
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Summary
- Astro `<ClientRouter />` の View Transitions で言語切り替え時に `<html>` の `dark` クラスが消失し、ダークモードがリセットされるバグを修正
- DOM swap 後に `ThemeToggle` のアイコン要素が再登録されず両方 `hidden` になるバグを修正
- `astro:after-swap` でテーマ復元、`astro:page-load` でアイコン再初期化するよう変更

## Changes
- `Base.astro`: インラインテーマスクリプトに `astro:after-swap` ハンドラを追加
- `theme.ts`: `clearIcons()` を追加し、View Transition 後に stale な DOM 参照をリセット可能に
- `ThemeToggle.astro`: `astro:page-load` イベントで毎回アイコンの再登録とイベントリスナーの再設定