### PR TITLE
fix(bot-dashboard): use astro:page-load to prevent modal auto-open on navigation

### DIFF
--- a/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
+++ b/service/bot-dashboard/src/components/channel/ChannelConfigForm.astro
@@ -561,6 +561,7 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
     }, { signal });
   };
 
-  initConfigFormControls();
-  document.addEventListener("astro:after-swap", initConfigFormControls);
+  document.addEventListener("astro:page-load", () => {
+    initConfigFormControls();
+  });
 </script>

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -154,11 +154,14 @@ const pageData = {
 <script>
   import { initChannelActions } from "~/components/channel/channel-actions";
 
-  // Initialize on first load
-  initChannelActions();
+  // Close open dialogs before page transition to prevent stale top-layer state
+  document.addEventListener("astro:before-preparation", () => {
+    const dialogs = document.querySelectorAll("dialog[open]");
+    for (const d of dialogs) (d as HTMLDialogElement).close();
+  });
 
-  // Re-initialize after View Transition swaps
-  document.addEventListener("astro:after-swap", () => {
+  // Initialize on first load and after every client-side navigation
+  document.addEventListener("astro:page-load", () => {
     initChannelActions();
   });
 </script>


### PR DESCRIPTION
## Summary
- View Transition 経由の画面遷移時に「チャンネルを追加」モーダルが自動表示されるバグを修正
- 非推奨の直接呼び出し + `astro:after-swap` パターンを Astro 推奨の `astro:page-load` に統一
- `astro:before-preparation` で遷移前にダイアログをクリーンアップする防御ロジックを追加

## Changes
- `[guildId].astro`: `initChannelActions()` の呼び出しを `astro:page-load` に変更 + `astro:before-preparation` でダイアログ閉鎖
- `ChannelConfigForm.astro`: `initConfigFormControls()` の呼び出しを `astro:page-load` に変更

## Root Cause
Astro の `<ClientRouter />` によるページ遷移時、モジュールスクリプトの直接実行 + `astro:after-swap` の組み合わせでは、View Transition 中のイベント伝播タイミングで document レベルの click ハンドラが意図せず発火していた。`astro:page-load` はすべての遷移処理完了後に発火するため、この問題を根本解決する。