### PR TITLE
feat(bot-dashboard): add CSS animations to landing page

### DIFF
--- a/service/bot-dashboard/src/app.css
+++ b/service/bot-dashboard/src/app.css
@@ -183,6 +183,256 @@ dialog[open] {
 }
 
 /*
+ * === Landing Page Animations ===
+ */
+
+/* Stagger Letter Rise */
+@keyframes letter-rise {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Text Line Reveal */
+@keyframes line-down {
+  from { transform: translateX(-50%) scaleY(0); }
+  to   { transform: translateX(-50%) scaleY(1); }
+}
+@keyframes curtain-round-left {
+  from { border-bottom-right-radius: 0; }
+  to   { border-bottom-right-radius: 100%; }
+}
+@keyframes curtain-open-left {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-101%); }
+}
+@keyframes curtain-round-right {
+  from { border-bottom-left-radius: 0; }
+  to   { border-bottom-left-radius: 100%; }
+}
+@keyframes curtain-open-right {
+  from { transform: translateX(0); }
+  to   { transform: translateX(101%); }
+}
+
+/* Clip-path Reveals */
+@keyframes clip-center {
+  from { clip-path: inset(0 50%); }
+  to   { clip-path: inset(0 0); }
+}
+@keyframes clip-circle {
+  from { clip-path: circle(0% at 50% 50%); }
+  to   { clip-path: circle(100% at 50% 50%); }
+}
+
+/* Digit Roll — uses --dh (digit height) CSS variable for responsive sizing */
+@keyframes digit-roll {
+  from { transform: translateY(calc(var(--dh) * -9)); }
+  to   { transform: translateY(calc(var(--dh) * var(--digit) * -1)); }
+}
+
+/*
+ * === Scroll Reveal System ===
+ * Elements with [data-scroll-reveal] start hidden.
+ * IntersectionObserver adds [data-visible] to trigger animation.
+ */
+[data-scroll-reveal] {
+  opacity: 0;
+}
+
+[data-scroll-reveal][data-visible] {
+  opacity: 1;
+}
+
+/* Fade in up (default scroll reveal) */
+[data-scroll-reveal="fade-in-up"] {
+  transform: translateY(24px);
+}
+[data-scroll-reveal="fade-in-up"][data-visible] {
+  animation: fade-in-up 600ms var(--ease-standard) var(--reveal-delay, 0ms) both;
+}
+
+/* Clip center reveal (with @supports fallback) */
+@supports (clip-path: inset(0 0)) {
+  [data-scroll-reveal="clip-center"] {
+    clip-path: inset(0 50%);
+  }
+  [data-scroll-reveal="clip-center"][data-visible] {
+    animation: clip-center 800ms var(--ease-emphasized) var(--reveal-delay, 0ms) both;
+  }
+}
+
+/* Clip circle reveal (with @supports fallback) */
+@supports (clip-path: circle(50%)) {
+  [data-scroll-reveal="clip-circle"] {
+    clip-path: circle(0% at 50% 50%);
+  }
+  [data-scroll-reveal="clip-circle"][data-visible] {
+    animation: clip-circle 900ms var(--ease-emphasized) var(--reveal-delay, 0ms) both;
+  }
+}
+
+/*
+ * === Stagger Text ===
+ */
+.stagger-text span {
+  display: inline-block;
+  opacity: 0;
+}
+.stagger-text[data-visible] span,
+.stagger-text.is-visible span {
+  animation: letter-rise 0.5s ease-out calc(var(--i) * 60ms + 200ms) forwards;
+}
+
+/*
+ * === Text Line Reveal ===
+ */
+.line-reveal {
+  position: relative;
+  display: inline-block;
+  opacity: 0;
+}
+.line-reveal.is-visible {
+  opacity: 1;
+}
+
+.line-reveal::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 3px;
+  height: 100%;
+  background-color: var(--color-vspo-purple);
+  transform-origin: top;
+  transform: translateX(-50%) scaleY(0);
+}
+.line-reveal.is-visible::before {
+  animation: line-down 0.4s cubic-bezier(0.93, 0, 0.1, 1.01) var(--reveal-delay, 0ms) both;
+}
+
+.line-reveal-inner {
+  position: relative;
+  overflow: hidden;
+  display: inline-block;
+  padding: 4px 16px;
+}
+.line-reveal-inner::before,
+.line-reveal-inner::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  width: 50.5%;
+  height: 100%;
+  background: var(--color-surface, #fafafa);
+  z-index: 1;
+}
+.dark .line-reveal-inner::before,
+.dark .line-reveal-inner::after {
+  background: var(--sem-surface, #121317);
+}
+.line-reveal-inner::before { left: -1px; }
+.line-reveal-inner::after { right: -1px; }
+
+.line-reveal.is-visible .line-reveal-inner::before {
+  animation:
+    curtain-round-left 0.45s ease-out calc(var(--reveal-delay, 0ms) + 400ms) both,
+    curtain-open-left 0.9s ease-in-out calc(var(--reveal-delay, 0ms) + 500ms) forwards;
+}
+.line-reveal.is-visible .line-reveal-inner::after {
+  animation:
+    curtain-round-right 0.45s ease-out calc(var(--reveal-delay, 0ms) + 400ms) both,
+    curtain-open-right 0.9s ease-in-out calc(var(--reveal-delay, 0ms) + 500ms) forwards;
+}
+
+/*
+ * === Digit Roll ===
+ * --dh controls digit height for responsive sizing.
+ */
+.digit-roll {
+  --dh: 40px;
+  display: flex;
+  align-items: center;
+}
+@media (min-width: 640px) {
+  .digit-roll { --dh: 48px; }
+}
+
+.digit-slot {
+  width: calc(var(--dh) * 0.8);
+  height: var(--dh);
+  overflow: hidden;
+  position: relative;
+}
+.digit-strip {
+  display: flex;
+  flex-direction: column;
+  transform: translateY(calc(var(--dh) * -9));
+}
+.digit-strip span {
+  width: calc(var(--dh) * 0.8);
+  height: var(--dh);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Animated only when parent has [data-visible] */
+[data-visible] .digit-strip {
+  animation: digit-roll 1.2s cubic-bezier(0.22, 1, 0.36, 1) var(--digit-delay, 0s) both;
+}
+
+/* Separator (comma, period) */
+.digit-sep {
+  width: calc(var(--dh) * 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+}
+[data-visible] .digit-sep {
+  animation: fade-in-up 400ms var(--ease-standard) 0.8s both;
+}
+
+/*
+ * === Feature Card Hover Enhancement ===
+ */
+@media (hover: hover) and (prefers-reduced-motion: no-preference) {
+  .feature-card {
+    transition: transform var(--duration-medium) var(--ease-standard),
+                box-shadow var(--duration-medium) var(--ease-standard);
+  }
+  .feature-card:hover {
+    transform: translateY(-6px);
+    box-shadow: var(--shadow-hover);
+  }
+  .feature-card:hover .feature-icon {
+    transform: scale(1.1);
+    transition: transform var(--duration-medium) cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+}
+
+/*
+ * === Hero Sequence (page-load animations) ===
+ */
+.hero-badge {
+  opacity: 0;
+  animation: fade-in-up 500ms var(--ease-standard) 300ms both;
+}
+.hero-description {
+  opacity: 0;
+  animation: fade-in-up 500ms var(--ease-standard) 500ms both;
+}
+.hero-stats {
+  opacity: 0;
+  animation: fade-in-up 500ms var(--ease-standard) 600ms both;
+}
+.hero-cta {
+  opacity: 0;
+  animation: fade-in-up 500ms var(--ease-standard) 700ms both;
+}
+
+/*
  * === Reduced motion ===
  */
 @media (prefers-reduced-motion: reduce) {

--- a/service/bot-dashboard/src/components/landing/DigitRoll.astro
+++ b/service/bot-dashboard/src/components/landing/DigitRoll.astro
@@ -1,0 +1,67 @@
+---
+/**
+ * DigitRoll — Animated number counter that rolls digits into place.
+ *
+ * @precondition .digit-roll CSS rules and digit-roll keyframe must be in app.css.
+ * @postcondition Each digit displays a 0-9 strip that scrolls to the target digit.
+ *
+ * Decomposes a number into individual digits, inserts locale-appropriate separators,
+ * and animates each digit with a staggered delay. Animation triggers via [data-visible]
+ * from ScrollReveal parent.
+ *
+ * @example
+ * <DigitRoll value={1234} class="text-2xl font-bold" />
+ */
+type Props = {
+  /** Number to display */
+  value: number;
+  /** Additional CSS classes applied to digit text */
+  class?: string;
+};
+
+const { value, class: className = "" } = Astro.props;
+
+const DIGITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+
+/** Format number with comma separators and split into tokens */
+function toTokens(n: number): Array<{ type: "digit"; value: number; index: number } | { type: "sep"; char: string }> {
+  const formatted = n.toLocaleString("en-US");
+  const tokens: Array<{ type: "digit"; value: number; index: number } | { type: "sep"; char: string }> = [];
+  let digitIndex = 0;
+  for (const char of formatted) {
+    if (char >= "0" && char <= "9") {
+      tokens.push({ type: "digit", value: Number.parseInt(char, 10), index: digitIndex });
+      digitIndex++;
+    } else {
+      tokens.push({ type: "sep", char });
+    }
+  }
+  return tokens;
+}
+
+const tokens = toTokens(value);
+---
+
+<span class:list={["digit-roll", className]}>
+  {/* Screen reader accessible text */}
+  <span class="sr-only">{value.toLocaleString("en-US")}</span>
+  {/* Visual animated digits (hidden from AT) */}
+  <span aria-hidden="true" class="contents">
+    {tokens.map((token) =>
+      token.type === "digit" ? (
+        <span class="digit-slot">
+          <span
+            class="digit-strip"
+            style={`--digit: ${token.value}; --digit-delay: ${token.index * 80}ms`}
+          >
+            {DIGITS.map((d) => (
+              <span>{d}</span>
+            ))}
+          </span>
+        </span>
+      ) : (
+        <span class="digit-sep">{token.char}</span>
+      )
+    )}
+  </span>
+</span>

--- a/service/bot-dashboard/src/components/landing/ScrollReveal.astro
+++ b/service/bot-dashboard/src/components/landing/ScrollReveal.astro
@@ -1,0 +1,76 @@
+---
+/**
+ * ScrollReveal — IntersectionObserver wrapper for scroll-triggered animations.
+ *
+ * @precondition Animation keyframes must be defined in app.css.
+ * @postcondition Element receives [data-visible] when scrolled into view (one-shot).
+ *
+ * @example
+ * <ScrollReveal animation="fade-in-up">
+ *   <p>This fades in on scroll</p>
+ * </ScrollReveal>
+ *
+ * @example
+ * <ScrollReveal animation="clip-center" delay={200} tag="section">
+ *   <div>Revealed from center</div>
+ * </ScrollReveal>
+ */
+type Props = {
+  /** Animation type matching [data-scroll-reveal] CSS selectors */
+  animation: "fade-in-up" | "clip-center" | "clip-circle";
+  /** Delay in ms before animation starts */
+  delay?: number;
+  /** HTML tag to render */
+  tag?: string;
+  /** Additional CSS classes */
+  class?: string;
+};
+
+const {
+  animation,
+  delay = 0,
+  tag = "div",
+  class: className = "",
+} = Astro.props;
+
+const Tag = tag;
+---
+
+<Tag
+  data-scroll-reveal={animation}
+  style={delay > 0 ? `--reveal-delay: ${delay}ms` : undefined}
+  class={className}
+>
+  <slot />
+</Tag>
+
+<script>
+  function initScrollReveal(): void {
+    const elements = document.querySelectorAll<HTMLElement>(
+      "[data-scroll-reveal]:not([data-visible])"
+    );
+    if (elements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.setAttribute("data-visible", "");
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: 0.15, rootMargin: "0px 0px -50px 0px" }
+    );
+
+    for (const el of elements) {
+      observer.observe(el);
+    }
+  }
+
+  // Initial load
+  initScrollReveal();
+
+  // Re-initialize after Astro ClientRouter navigation
+  document.addEventListener("astro:page-load", initScrollReveal);
+</script>

--- a/service/bot-dashboard/src/components/landing/StaggerText.astro
+++ b/service/bot-dashboard/src/components/landing/StaggerText.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * StaggerText — Splits text into per-character spans with CSS variable --i for stagger delay.
+ *
+ * @precondition .stagger-text CSS rules and letter-rise keyframe must be in app.css.
+ * @postcondition Each character is wrapped in a <span style="--i: N"> for staggered animation.
+ *
+ * Uses Array.from() for proper Unicode handling (ja/en safe).
+ * Animation triggers on page load via .is-visible class (hero) or [data-visible] (scroll).
+ *
+ * @example
+ * <StaggerText text="Hello World" tag="h1" class="text-4xl font-bold" autoPlay />
+ */
+type Props = {
+  /** Text to animate character by character */
+  text: string;
+  /** HTML tag to render */
+  tag?: string;
+  /** Additional CSS classes */
+  class?: string;
+  /** Auto-play animation on page load (no scroll trigger needed) */
+  autoPlay?: boolean;
+};
+
+const {
+  text,
+  tag = "span",
+  class: className = "",
+  autoPlay = false,
+} = Astro.props;
+
+const Tag = tag;
+const chars = Array.from(text);
+---
+
+<Tag
+  class:list={["stagger-text", { "is-visible": autoPlay }, className]}
+>
+  {/* Screen reader accessible text */}
+  <span class="sr-only">{text}</span>
+  {/* Visual animated characters (hidden from AT) */}
+  <span aria-hidden="true" class="contents">
+    {chars.map((char, i) =>
+      char === " " ? (
+        <span class="inline-block" style={`--i: ${i}`}>&nbsp;</span>
+      ) : char === "\n" ? (
+        <br />
+      ) : (
+        <span style={`--i: ${i}`}>{char}</span>
+      )
+    )}
+  </span>
+</Tag>

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -4,6 +4,9 @@ import Base from "~/layouts/Base.astro";
 import Button from "~/components/ui/Button.astro";
 import LanguageSelector from "~/components/ui/LanguageSelector.astro";
 import ThemeToggle from "~/components/ui/ThemeToggle.astro";
+import ScrollReveal from "~/components/landing/ScrollReveal.astro";
+import StaggerText from "~/components/landing/StaggerText.astro";
+import DigitRoll from "~/components/landing/DigitRoll.astro";
 import { t } from "~/i18n/dict";
 import { buildBotInviteUrl } from "~/features/guild/domain/guild";
 import { VspoGuildApiRepository } from "~/features/guild/repository/vspo-guild-api";
@@ -45,27 +48,32 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
       {/* Hero Section */}
       <section class="px-6 pb-16 pt-16 sm:pb-24 sm:pt-24">
         <div class="mx-auto flex max-w-3xl flex-col items-center text-center">
-          {/* Badge */}
-          <div class="mb-8 inline-flex items-center gap-2 rounded-full bg-surface-container-highest px-3 py-1">
-            <div class="h-2 w-2 rounded-full bg-success"></div>
-            <span class="text-xs font-medium tracking-wide text-vspo-purple">{t(locale, "app.name")}</span>
+          {/* Badge — line reveal animation */}
+          <div class="hero-badge line-reveal is-visible mb-8" style="--reveal-delay: 0ms">
+            <span class="line-reveal-inner inline-flex items-center gap-2 rounded-full bg-surface-container-highest px-3 py-1">
+              <span class="h-2 w-2 rounded-full bg-success"></span>
+              <span class="text-xs font-medium tracking-wide text-vspo-purple">{t(locale, "app.name")}</span>
+            </span>
           </div>
 
-          {/* Headline */}
-          <h1 class="mb-6 whitespace-pre-line font-heading text-4xl font-extrabold tracking-tight text-on-surface sm:text-5xl md:text-6xl">
-            {t(locale, "login.headline")}
-          </h1>
+          {/* Headline — stagger letter rise */}
+          <StaggerText
+            text={t(locale, "login.headline")}
+            tag="h1"
+            class="mb-6 whitespace-pre-line font-heading text-4xl font-extrabold tracking-tight text-on-surface sm:text-5xl md:text-6xl"
+            autoPlay
+          />
 
-          <p class="mb-8 max-w-xl text-balance text-base leading-relaxed text-on-surface-variant sm:text-lg">
+          <p class="hero-description mb-8 max-w-xl text-balance text-base leading-relaxed text-on-surface-variant sm:text-lg">
             {t(locale, "login.description")}
           </p>
 
-          {/* Stats */}
+          {/* Stats — digit roll counter */}
           {stats && (
-            <div class="mb-10 flex items-center justify-center gap-6">
+            <div class="hero-stats mb-10 flex items-center justify-center gap-6">
               <div class="text-center">
-                <div class="text-2xl font-extrabold tabular-nums text-on-surface sm:text-3xl">
-                  {stats.guildCount.toLocaleString()}
+                <div class="text-2xl font-extrabold text-on-surface sm:text-3xl">
+                  <DigitRoll value={stats.guildCount} />
                 </div>
                 <div class="text-xs font-medium tracking-wide text-on-surface-variant">
                   {t(locale, "login.stat.servers")}
@@ -73,8 +81,8 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
               </div>
               <div class="h-8 w-px bg-border/50" aria-hidden="true"></div>
               <div class="text-center">
-                <div class="text-2xl font-extrabold tabular-nums text-on-surface sm:text-3xl">
-                  {stats.totalMemberCount.toLocaleString()}
+                <div class="text-2xl font-extrabold text-on-surface sm:text-3xl">
+                  <DigitRoll value={stats.totalMemberCount} />
                 </div>
                 <div class="text-xs font-medium tracking-wide text-on-surface-variant">
                   {t(locale, "login.stat.users")}
@@ -103,7 +111,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
           )}
 
           {/* CTA Buttons */}
-          <div class="flex flex-col items-center gap-3 sm:flex-row">
+          <div class="hero-cta flex flex-col items-center gap-3 sm:flex-row">
             <Button
               as="a"
               href={botInviteUrl}
@@ -134,9 +142,11 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
       {/* Discord notification preview */}
       <section class="px-6 pb-8 sm:pb-16">
         <div class="mx-auto max-w-5xl">
-          <p class="mb-8 text-center text-xs font-bold uppercase tracking-[0.2em] text-vspo-purple">{t(locale, "login.previewCaption")}</p>
+          <ScrollReveal animation="fade-in-up">
+            <p class="mb-8 text-center text-xs font-bold uppercase tracking-[0.2em] text-vspo-purple">{t(locale, "login.previewCaption")}</p>
+          </ScrollReveal>
           <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
-            <div class="aspect-[3/5] overflow-hidden rounded-xl shadow-card">
+            <ScrollReveal animation="clip-center" class="aspect-[3/5] overflow-hidden rounded-xl shadow-card">
               <picture>
                 <source srcset="/discord-preview-1.webp" type="image/webp" />
                 <img
@@ -148,8 +158,8 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
                   height="1024"
                 />
               </picture>
-            </div>
-            <div class="aspect-[3/5] overflow-hidden rounded-xl shadow-card">
+            </ScrollReveal>
+            <ScrollReveal animation="clip-center" delay={200} class="aspect-[3/5] overflow-hidden rounded-xl shadow-card">
               <picture>
                 <source srcset="/discord-preview-2.webp" type="image/webp" />
                 <img
@@ -161,7 +171,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
                   height="1024"
                 />
               </picture>
-            </div>
+            </ScrollReveal>
           </div>
         </div>
       </section>
@@ -169,59 +179,67 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
       {/* Features */}
       <section class="bg-surface-container-lowest px-6 py-16 sm:py-24">
         <div class="mx-auto max-w-4xl">
-          <div class="mb-12 text-left">
+          <ScrollReveal animation="fade-in-up" class="mb-12 text-left">
             <h2 class="mb-3 font-heading text-2xl font-extrabold tracking-tight text-on-surface sm:text-3xl">{t(locale, "login.features")}</h2>
             <p class="max-w-xl text-on-surface-variant">{t(locale, "login.features.desc")}</p>
-          </div>
+          </ScrollReveal>
 
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <div class="rounded-xl bg-surface-container p-6 transition-colors hover:bg-surface-container-high">
-              <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
-                <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
-                </svg>
+            <ScrollReveal animation="fade-in-up" delay={0}>
+              <div class="feature-card rounded-xl bg-surface-container p-6">
+                <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
+                  <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+                  </svg>
+                </div>
+                <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.list")}</h3>
+                <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.list.desc")}</p>
               </div>
-              <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.list")}</h3>
-              <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.list.desc")}</p>
-            </div>
+            </ScrollReveal>
 
-            <div class="rounded-xl bg-surface-container p-6 transition-colors hover:bg-surface-container-high">
-              <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-tertiary/10">
-                <svg class="h-5 w-5 text-tertiary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
-                </svg>
+            <ScrollReveal animation="fade-in-up" delay={100}>
+              <div class="feature-card rounded-xl bg-surface-container p-6">
+                <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-tertiary/10">
+                  <svg class="h-5 w-5 text-tertiary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                  </svg>
+                </div>
+                <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.filter")}</h3>
+                <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.filter.desc")}</p>
               </div>
-              <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.filter")}</h3>
-              <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.filter.desc")}</p>
-            </div>
+            </ScrollReveal>
 
-            <div class="rounded-xl bg-surface-container p-6 transition-colors hover:bg-surface-container-high">
-              <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
-                <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-                </svg>
+            <ScrollReveal animation="fade-in-up" delay={200}>
+              <div class="feature-card rounded-xl bg-surface-container p-6">
+                <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
+                  <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                </div>
+                <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.realtime")}</h3>
+                <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.realtime.desc")}</p>
               </div>
-              <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.realtime")}</h3>
-              <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.realtime.desc")}</p>
-            </div>
+            </ScrollReveal>
 
-            <div class="rounded-xl bg-surface-container p-6 transition-colors hover:bg-surface-container-high">
-              <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
-                <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
+            <ScrollReveal animation="fade-in-up" delay={300}>
+              <div class="feature-card rounded-xl bg-surface-container p-6">
+                <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
+                  <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                </div>
+                <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.settings")}</h3>
+                <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.settings.desc")}</p>
               </div>
-              <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.settings")}</h3>
-              <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.settings.desc")}</p>
-            </div>
+            </ScrollReveal>
           </div>
         </div>
       </section>
 
       {/* CTA Section */}
       <section class="px-6 py-16 sm:py-24">
-        <div class="mx-auto max-w-3xl rounded-2xl border border-border bg-surface-container-low p-10 text-center sm:p-16">
+        <ScrollReveal animation="clip-circle" class="mx-auto max-w-3xl rounded-2xl border border-border bg-surface-container-low p-10 text-center sm:p-16">
           <h2 class="mb-4 font-heading text-3xl font-extrabold text-on-surface sm:text-4xl">{t(locale, "login.cta.headline")}</h2>
           <p class="mx-auto mb-8 max-w-lg text-on-surface-variant">{t(locale, "login.cta.description")}</p>
           <div class="flex flex-col justify-center gap-3 sm:flex-row">
@@ -249,11 +267,12 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
               {t(locale, "login.button")}
             </Button>
           </div>
-        </div>
+        </ScrollReveal>
       </section>
 
       {/* Footer */}
       <footer class="border-t border-border/50 px-6 py-8">
+        <ScrollReveal animation="fade-in-up">
         <div class="mx-auto flex max-w-7xl flex-col items-center gap-4 sm:flex-row sm:justify-between">
           <div class="flex items-center gap-2">
             <span class="font-heading text-lg font-bold tracking-tight text-vspo-purple">{t(locale, "app.name")}</span>
@@ -286,6 +305,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
             </a>
           </nav>
         </div>
+        </ScrollReveal>
       </footer>
     </main>
   </div>


### PR DESCRIPTION
## Summary

- ランディングページ全セクションにCSSアニメーションを追加（Hero: stagger letter rise + line reveal, Stats: digit roll counter, Preview: clip-path center reveal, Features: fade-in-up + hover強化, CTA: clip-circle reveal, Footer: fade-in-up）
- 新規コンポーネント3つ: `ScrollReveal.astro`（IntersectionObserver）、`StaggerText.astro`（文字分割アニメーション）、`DigitRoll.astro`（数値ロールカウンター）
- アクセシビリティ: `sr-only` + `aria-hidden` パターン、`@supports` clip-path フォールバック、`prefers-reduced-motion` 対応済み

## Changes

| ファイル | 変更 |
|---|---|
| `src/app.css` | +250行: キーフレーム、scroll-reveal CSS、digit-roll、feature-card hover、hero sequence |
| `src/pages/index.astro` | 各セクションにアニメーションコンポーネント適用 |
| `src/components/landing/ScrollReveal.astro` | 新規: IntersectionObserver ラッパー |
| `src/components/landing/StaggerText.astro` | 新規: 文字ごとスタガーアニメーション |
| `src/components/landing/DigitRoll.astro` | 新規: 数値ロールカウンター |

## Technical Details

- 純CSS + IntersectionObserver（外部ライブラリなし）
- GPU加速プロパティ中心: transform, opacity, clip-path
- Astro ClientRouter 対応（`astro:page-load` で再初期化）
- ダークモード対応（line-reveal カーテン背景切替）
- 参考: `/Users/suga-cat/dev/poc-schedule/sample/css/` の CSS Motion Trace コレクション

## Test Plan

- [x] `pnpm --filter bot-dashboard build` 成功
- [x] `pnpm astro check` 新規ファイルに型エラーなし
- [x] Playwright でビジュアル確認（Hero, Features, CTA, Footer）
- [x] Codex レビュー実施・指摘修正済み
- [ ] ダークモードでの表示確認
- [ ] ja/en 両ロケールでの StaggerText 動作確認