### PR TITLE
fix(bot-dashboard): improve UI and enable dev mock by default

### DIFF
--- a/service/bot-dashboard/src/app.css
+++ b/service/bot-dashboard/src/app.css
@@ -233,7 +233,7 @@ dialog[open] {
 }
 
 .digit-slot {
-  width: calc(var(--dh) * 0.8);
+  width: calc(var(--dh) * 0.6);
   height: var(--dh);
   overflow: hidden;
   position: relative;
@@ -243,7 +243,7 @@ dialog[open] {
   flex-direction: column;
 }
 .digit-strip span {
-  width: calc(var(--dh) * 0.8);
+  width: calc(var(--dh) * 0.6);
   height: var(--dh);
   display: flex;
   align-items: center;

--- a/service/bot-dashboard/src/components/ui/LanguageSelector.astro
+++ b/service/bot-dashboard/src/components/ui/LanguageSelector.astro
@@ -5,22 +5,21 @@ import { t } from "~/i18n/dict";
 interface Props {
   currentLocale: Locale;
   returnTo: string;
-  /** "header" renders a compact icon button; "dropdown" renders text buttons for menus. */
+  /** "header" renders a compact icon button with popup; "dropdown" renders text buttons for menus. */
   variant?: "header" | "dropdown";
 }
 
 const { currentLocale, returnTo, variant = "header" } = Astro.props;
-const nextLocale: Locale = currentLocale === "ja" ? "en" : "ja";
 ---
 
 {variant === "header" ? (
-  <form method="post" action="/api/change-locale">
-    <input type="hidden" name="_returnTo" value={returnTo} />
-    <input type="hidden" name="locale" value={nextLocale} />
+  <div class="lang-popup-wrapper relative">
     <button
-      type="submit"
+      type="button"
       aria-label={t(currentLocale, "settings.language")}
-      class="relative flex h-9 w-9 items-center justify-center rounded-[--radius-sm] text-on-surface-variant transition-colors duration-[--duration-fast] ease-[--ease-standard] hover:bg-surface-container-highest hover:text-on-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vspo-purple/50 cursor-pointer"
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="lang-popup-trigger relative flex h-9 w-9 items-center justify-center rounded-[--radius-sm] text-on-surface-variant transition-colors duration-[--duration-fast] ease-[--ease-standard] hover:bg-surface-container-highest hover:text-on-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vspo-purple/50 cursor-pointer"
     >
       <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
         <circle cx="12" cy="12" r="10" />
@@ -30,7 +29,57 @@ const nextLocale: Locale = currentLocale === "ja" ? "en" : "ja";
         {currentLocale.toUpperCase()}
       </span>
     </button>
-  </form>
+    <div class="lang-popup absolute right-0 top-full z-50 mt-2 hidden min-w-[140px] overflow-hidden rounded-lg border border-outline-variant bg-surface-container shadow-lg" role="menu">
+      {(["ja", "en"] as const).map((lang) => (
+        <form method="post" action="/api/change-locale">
+          <input type="hidden" name="_returnTo" value={returnTo} />
+          <input type="hidden" name="locale" value={lang} />
+          <button
+            type="submit"
+            role="menuitem"
+            class={`flex w-full items-center gap-2 px-3 py-2.5 text-sm transition-colors cursor-pointer ${
+              currentLocale === lang
+                ? "bg-vspo-purple/10 text-vspo-purple font-semibold"
+                : "text-on-surface hover:bg-surface-container-highest"
+            }`}
+          >
+            {t(currentLocale, `settings.language.${lang}` as keyof typeof import("~/i18n/dict").ja)}
+            {currentLocale === lang && (
+              <svg class="ml-auto h-4 w-4 text-vspo-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            )}
+          </button>
+        </form>
+      ))}
+    </div>
+  </div>
+  <script>
+    document.addEventListener("click", (e) => {
+      const wrapper = (e.target as Element)?.closest(".lang-popup-wrapper");
+      document.querySelectorAll(".lang-popup-wrapper").forEach((w) => {
+        if (w !== wrapper) {
+          w.querySelector(".lang-popup")?.classList.add("hidden");
+          w.querySelector(".lang-popup-trigger")?.setAttribute("aria-expanded", "false");
+        }
+      });
+      if (!wrapper) return;
+      const trigger = wrapper.querySelector(".lang-popup-trigger");
+      const popup = wrapper.querySelector(".lang-popup");
+      if (!trigger || !popup) return;
+      if ((e.target as Element)?.closest(".lang-popup-trigger")) {
+        const isOpen = !popup.classList.contains("hidden");
+        popup.classList.toggle("hidden");
+        trigger.setAttribute("aria-expanded", isOpen ? "false" : "true");
+      }
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        document.querySelectorAll(".lang-popup").forEach((p) => p.classList.add("hidden"));
+        document.querySelectorAll(".lang-popup-trigger").forEach((t) => t.setAttribute("aria-expanded", "false"));
+      }
+    });
+  </script>
 ) : (
   <form method="post" action="/api/change-locale" class="flex items-center gap-1">
     <input type="hidden" name="_returnTo" value={returnTo} />

--- a/service/bot-dashboard/src/features/auth/repository/discord-api.ts
+++ b/service/bot-dashboard/src/features/auth/repository/discord-api.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 import { parseResult } from "~/features/shared/lib/parse";
 
 const isDevMock = () =>
-  (env as unknown as Record<string, unknown>).DEV_MOCK_AUTH === "true" &&
-  import.meta.env.DEV;
+  import.meta.env.DEV &&
+  (env as unknown as Record<string, unknown>).DEV_MOCK_AUTH !== "false";
 
 const DiscordTokenResponseSchema = z.object({
   access_token: z.string(),

--- a/service/bot-dashboard/src/features/shared/dev-mock.ts
+++ b/service/bot-dashboard/src/features/shared/dev-mock.ts
@@ -7,11 +7,15 @@ import type { ApplicationService } from "~/types/api";
  * APP_WORKER の RPC が利用不可（ローカル開発）かを判定する。
  * DEV_MOCK_AUTH=true かつ開発モードの場合、または APP_WORKER に RPC メソッドがない場合に true。
  */
-export const isRpcUnavailable = (appWorker: ApplicationService): boolean =>
-  ((env as unknown as Record<string, unknown>).DEV_MOCK_AUTH === "true" &&
-    import.meta.env.DEV) ||
-  !appWorker ||
-  typeof appWorker.newDiscordUsecase !== "function";
+export const isRpcUnavailable = (appWorker: ApplicationService): boolean => {
+  // In dev mode, use mocks by default. Set DEV_MOCK_AUTH=false to use real backend.
+  if (import.meta.env.DEV) {
+    const flag = (env as unknown as Record<string, unknown>).DEV_MOCK_AUTH;
+    return flag !== "false";
+  }
+  if (!appWorker) return true;
+  return typeof appWorker.newDiscordUsecase !== "function";
+};
 
 const DEV_GUILD_ID = "111111111111111111";
 

--- a/service/bot-dashboard/src/features/shared/dev-mock.ts
+++ b/service/bot-dashboard/src/features/shared/dev-mock.ts
@@ -4,8 +4,12 @@ import type { CreatorType } from "~/features/shared/domain/creator";
 import type { ApplicationService } from "~/types/api";
 
 /**
- * APP_WORKER の RPC が利用不可（ローカル開発）かを判定する。
- * DEV_MOCK_AUTH=true かつ開発モードの場合、または APP_WORKER に RPC メソッドがない場合に true。
+ * APP_WORKER の RPC を使わず開発用モックにフォールバックすべきかを判定する。
+ *
+ * @precondition appWorker は ApplicationService を想定するが、未設定の場合も許容する。
+ * @postcondition dev モードでは DEV_MOCK_AUTH="false" のときのみ false を返す。
+ *   非 dev モードでは appWorker が未設定または newDiscordUsecase が関数でない場合に true を返す。
+ * @idempotent true
  */
 export const isRpcUnavailable = (appWorker: ApplicationService): boolean => {
   // In dev mode, use mocks by default. Set DEV_MOCK_AUTH=false to use real backend.

--- a/service/bot-dashboard/src/middleware.ts
+++ b/service/bot-dashboard/src/middleware.ts
@@ -22,7 +22,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   }
 
   const devMockAuth = (env as unknown as Record<string, unknown>).DEV_MOCK_AUTH;
-  if (devMockAuth === "true" && import.meta.env.DEV) {
+  if (import.meta.env.DEV && devMockAuth !== "false") {
     context.locals.user = MOCK_USER;
     context.locals.accessToken = "mock-access-token";
     return next();

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -160,6 +160,12 @@ const pageData = {
     for (const d of dialogs) (d as HTMLDialogElement).close();
   });
 
+  // Also close dialogs after DOM swap to prevent stale top-layer state
+  document.addEventListener("astro:after-swap", () => {
+    const dialogs = document.querySelectorAll("dialog[open]");
+    for (const d of dialogs) (d as HTMLDialogElement).close();
+  });
+
   // Initialize on first load and after every client-side navigation
   document.addEventListener("astro:page-load", () => {
     initChannelActions();

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -138,9 +138,6 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
       {/* Discord notification preview */}
       <section class="px-6 pb-8 sm:pb-16">
         <div class="mx-auto max-w-5xl">
-          <ScrollReveal animation="fade-in-up">
-            <p class="mb-8 text-center text-xs font-bold uppercase tracking-[0.2em] text-vspo-purple">{t(locale, "login.previewCaption")}</p>
-          </ScrollReveal>
           <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <ScrollReveal animation="fade-in-up" class="aspect-[3/5] overflow-hidden rounded-xl shadow-card">
               <picture>


### PR DESCRIPTION
## Summary

- DigitRoll の桁幅を縮小し、数字間の余白を改善
- 言語切替をトグル式からポップアップ選択式に変更（日本語/English、チェックマーク付き）
- ランディングページの不要な「通知イメージ」キャプションを削除
- View Transitions 時のダイアログ残存を防止（`astro:after-swap` でクローズ）
- dev モードでデフォルトモックデータを使用するよう変更（`DEV_MOCK_AUTH=false` でオプトアウト可能）

## Changes

| File | Change |
|------|--------|
| `app.css` | digit-slot 幅 0.8 → 0.6 |
| `LanguageSelector.astro` | トグル → ポップアップメニュー |
| `index.astro` | previewCaption 削除 |
| `[guildId].astro` | `astro:after-swap` ダイアログクローズ追加 |
| `dev-mock.ts` | dev モードでデフォルトモック有効 |
| `discord-api.ts` | `isDevMock` を同じロジックに統一 |
| `middleware.ts` | auth モックを同じロジックに統一 |

## Test plan

- [ ] ランディングページの数字表示が詰まって表示されること
- [ ] 言語ボタンクリックでポップアップが開き、選択肢が表示されること
- [ ] 「通知イメージ」テキストが表示されないこと
- [ ] 「設定を管理」クリック後にチャンネル追加モーダルが自動表示されないこと
- [ ] バックエンド未起動のローカル環境でモックデータで動作すること
- [ ] `DEV_MOCK_AUTH=false` 設定時にモックが無効になること
- [ ] 本番環境では従来通りの動作であること