### PR TITLE
perf(bot-dashboard): optimize MPA page transition speed

### DIFF
--- a/service/bot-dashboard/astro.config.ts
+++ b/service/bot-dashboard/astro.config.ts
@@ -6,6 +6,9 @@ import { defineConfig } from "astro/config";
 export default defineConfig({
   site: "https://discord.vspo-schedule.com",
   output: "server",
+  prefetch: {
+    defaultStrategy: "viewport",
+  },
   i18n: {
     defaultLocale: "ja",
     locales: ["ja", "en"],

--- a/service/bot-dashboard/src/env.d.ts
+++ b/service/bot-dashboard/src/env.d.ts
@@ -25,6 +25,13 @@ declare namespace App {
     expiresAt: number;
     oauth_state: string;
     locale: import("~/i18n/dict").Locale;
+    /** Cached guild summaries to avoid re-fetching on guild detail pages */
+    guildSummaries: Array<{
+      id: string;
+      name: string;
+      icon: string | null;
+      botInstalled: boolean;
+    }>;
   }
   interface Locals {
     user: SessionData["user"] | null;

--- a/service/bot-dashboard/src/env.d.ts
+++ b/service/bot-dashboard/src/env.d.ts
@@ -30,6 +30,7 @@ declare namespace App {
       id: string;
       name: string;
       icon: string | null;
+      isAdmin: boolean;
       botInstalled: boolean;
     }>;
   }

--- a/service/bot-dashboard/src/features/announcement/data/announcements.ts
+++ b/service/bot-dashboard/src/features/announcement/data/announcements.ts
@@ -24,19 +24,6 @@ const announcements: readonly AnnouncementType[] = [
     date: "2026-04-01T00:00:00Z",
     type: "update",
   },
-  {
-    id: "2026-03-01-launch",
-    title: {
-      ja: "すぽじゅーる Bot サービス開始",
-      en: "Spodule Bot Service Launch",
-    },
-    body: {
-      ja: "ぶいすぽっ!メンバーの配信予定をDiscordに届けるBotを公開しました。",
-      en: "The bot now sends VSPO stream schedules to Discord.",
-    },
-    date: "2026-03-01T00:00:00Z",
-    type: "info",
-  },
 ] as const;
 
 export { type AnnouncementType, announcements };

--- a/service/bot-dashboard/src/features/guild/usecase/list-guilds.test.ts
+++ b/service/bot-dashboard/src/features/guild/usecase/list-guilds.test.ts
@@ -138,6 +138,30 @@ describe("ListGuildsUsecase", () => {
       ]);
     });
 
+    it("does not fetch channel summaries when includeChannelSummary is false", async () => {
+      vi.mocked(DiscordApiRepository.getUserGuilds).mockResolvedValue(
+        Ok([ownerGuild]),
+      );
+      vi.mocked(VspoGuildApiRepository.getBotGuildIds).mockResolvedValue(
+        Ok(new Set(["1"])),
+      );
+      vi.mocked(VspoGuildApiRepository.checkUserGuildAdmin).mockResolvedValue(
+        Ok({ "1": true }),
+      );
+
+      const result = await ListGuildsUsecase.execute({
+        accessToken: "token",
+        userId: "user-1",
+        appWorker,
+        includeChannelSummary: false,
+      });
+
+      expect(result.err).toBeUndefined();
+      expect(VspoChannelApiRepository.getGuildConfig).not.toHaveBeenCalled();
+      if (result.err) return;
+      expect(result.val.installed[0].channelSummary).toBeUndefined();
+    });
+
     it("returns Err when getUserGuilds fails", async () => {
       const error = new AppError({
         message: "guild fetch failed",

--- a/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
+++ b/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
@@ -11,6 +11,7 @@ type ListGuildsParams = {
   accessToken: string;
   userId: string;
   appWorker: ApplicationService;
+  includeChannelSummary?: boolean;
 };
 
 type ListGuildsResult = {
@@ -31,6 +32,7 @@ type ListGuildsResult = {
 const execute = async (
   params: ListGuildsParams,
 ): Promise<Result<ListGuildsResult, AppError>> => {
+  const { includeChannelSummary = true } = params;
   const [guildsResult, botGuildIdsResult] = await Promise.all([
     DiscordApiRepository.getUserGuilds(params.accessToken),
     VspoGuildApiRepository.getBotGuildIds(params.appWorker),
@@ -69,18 +71,23 @@ const execute = async (
   const manageable = GuildSummary.filterManageable(resolvedGuilds);
   const { installed, notInstalled } = GuildSummary.partition(manageable);
 
-  // Fetch channel configs for all installed guilds in parallel.
+  // Fetch channel configs for all installed guilds in parallel if requested.
   // Per-guild failures are swallowed so a single bad guild does not block the page.
-  const installedWithSummaries = await Promise.all(
-    installed.map(async (guild) => {
-      const channelResult = await VspoChannelApiRepository.getGuildConfig(
-        params.appWorker,
-        guild.id,
-      );
-      if (channelResult.err) return guild;
-      return GuildSummary.withChannelSummary(guild, channelResult.val.channels);
-    }),
-  );
+  const installedWithSummaries = includeChannelSummary
+    ? await Promise.all(
+        installed.map(async (guild) => {
+          const channelResult = await VspoChannelApiRepository.getGuildConfig(
+            params.appWorker,
+            guild.id,
+          );
+          if (channelResult.err) return guild;
+          return GuildSummary.withChannelSummary(
+            guild,
+            channelResult.val.channels,
+          );
+        }),
+      )
+    : installed;
 
   return Ok({
     installed: installedWithSummaries,

--- a/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
+++ b/service/bot-dashboard/src/features/guild/usecase/list-guilds.ts
@@ -23,7 +23,7 @@ type ListGuildsResult = {
 /**
  * Retrieves the guilds the current user can manage and categorizes them for the dashboard.
  *
- * @param params - Discord access token, user ID, and app worker binding
+ * @param params - Discord access token, user ID, app worker binding, and optional includeChannelSummary (default true; when false, skips per-guild channel config fetches)
  * @returns Installed guilds, not-installed guilds, and sidebar guild metadata, or an AppError
  * @precondition params.accessToken !== "" && params.userId !== "" && params.appWorker is configured
  * @postcondition On Ok, installed guilds have botInstalled === true and isAdmin === true

--- a/service/bot-dashboard/src/layouts/Base.astro
+++ b/service/bot-dashboard/src/layouts/Base.astro
@@ -92,12 +92,12 @@ const altPath = canonicalPath
     <link
       rel="preload"
       as="style"
-      href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800&family=Noto+Sans+JP:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap"
       onload="this.rel='stylesheet'"
     />
     <noscript>
       <link
-        href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800&family=Noto+Sans+JP:wght@400;500;600;700&display=swap"
+        href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap"
         rel="stylesheet"
       />
     </noscript>

--- a/service/bot-dashboard/src/middleware.ts
+++ b/service/bot-dashboard/src/middleware.ts
@@ -58,24 +58,31 @@ const securityHeaders = defineMiddleware(async (_context, next) => {
  * destructive operations, so explicit CSRF protection is not required for it.
  */
 const auth = defineMiddleware(async (context, next) => {
-  const sessionLocale = await context.session?.get("locale");
+  const devMockAuth =
+    "DEV_MOCK_AUTH" in env
+      ? (env as Record<string, unknown>).DEV_MOCK_AUTH
+      : undefined;
+  if (import.meta.env.DEV && devMockAuth !== "false") {
+    context.locals.locale = "ja";
+    context.locals.user = MOCK_USER;
+    context.locals.accessToken = "mock-access-token";
+    return next();
+  }
+
+  // Read session values in parallel to reduce KV round-trips
+  const [sessionLocale, user, expiresAt, accessToken] = await Promise.all([
+    context.session?.get("locale"),
+    context.session?.get("user"),
+    context.session?.get("expiresAt"),
+    context.session?.get("accessToken"),
+  ]);
+
   const locale = sessionLocale ?? "ja";
   context.locals.locale = locale;
   if (!sessionLocale) {
     context.session?.set("locale", locale);
   }
 
-  const devMockAuth =
-    "DEV_MOCK_AUTH" in env
-      ? (env as Record<string, unknown>).DEV_MOCK_AUTH
-      : undefined;
-  if (import.meta.env.DEV && devMockAuth !== "false") {
-    context.locals.user = MOCK_USER;
-    context.locals.accessToken = "mock-access-token";
-    return next();
-  }
-
-  const user = await context.session?.get("user");
   context.locals.user = user ?? null;
 
   if (!user) {
@@ -87,10 +94,9 @@ const auth = defineMiddleware(async (context, next) => {
   }
 
   // Check token expiry and refresh if needed
-  const expiresAt = (await context.session?.get("expiresAt")) ?? 0;
   const now = getCurrentUTCDate().getTime();
 
-  if (now >= expiresAt - REFRESH_BUFFER_MS) {
+  if (now >= (expiresAt ?? 0) - REFRESH_BUFFER_MS) {
     const refreshToken = await context.session?.get("refreshToken");
     if (!refreshToken) {
       context.session?.destroy();
@@ -115,8 +121,7 @@ const auth = defineMiddleware(async (context, next) => {
     context.session?.set("expiresAt", newExpiresAt);
     context.locals.accessToken = tokens.access_token;
   } else {
-    context.locals.accessToken =
-      (await context.session?.get("accessToken")) ?? null;
+    context.locals.accessToken = accessToken ?? null;
   }
 
   return next();

--- a/service/bot-dashboard/src/middleware.ts
+++ b/service/bot-dashboard/src/middleware.ts
@@ -63,7 +63,8 @@ const auth = defineMiddleware(async (context, next) => {
       ? (env as Record<string, unknown>).DEV_MOCK_AUTH
       : undefined;
   if (import.meta.env.DEV && devMockAuth !== "false") {
-    context.locals.locale = "ja";
+    const devLocale = (await context.session?.get("locale")) ?? "ja";
+    context.locals.locale = devLocale;
     context.locals.user = MOCK_USER;
     context.locals.accessToken = "mock-access-token";
     return next();

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -65,7 +65,7 @@ const [guildsResult, channelsResult, creatorsResult] = await Promise.all([
 ]);
 
 const currentGuild = cachedGuild
-  ? { id: cachedGuild.id, name: cachedGuild.name, icon: cachedGuild.icon, isAdmin: true, botInstalled: cachedGuild.botInstalled }
+  ? { id: cachedGuild.id, name: cachedGuild.name, icon: cachedGuild.icon, isAdmin: cachedGuild.isAdmin, botInstalled: cachedGuild.botInstalled }
   : (() => {
       const all = guildsResult?.err ? [] : [...(guildsResult?.val.installed ?? []), ...(guildsResult?.val.notInstalled ?? [])];
       return all.find((g) => g.id === guildId) ?? null;

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -50,18 +50,26 @@ const flashMessages: Record<string, string> = {
 // Get action error if any
 const actionError = addResult?.error ?? updateResult?.error ?? deleteResult?.error ?? resetResult?.error ?? null;
 
+// Use cached guild summaries from session (set by /dashboard) to avoid the heavy
+// ListGuildsUsecase call on every guild detail navigation.
+// Falls back to the full fetch only on direct navigation (e.g. bookmark).
+const cachedGuilds = await Astro.session?.get("guildSummaries");
+const cachedGuild = cachedGuilds?.find((g) => g.id === guildId);
+
 const [guildsResult, channelsResult, creatorsResult] = await Promise.all([
-  ListGuildsUsecase.execute({
-    accessToken,
-    userId: user.id,
-    appWorker: env.APP_WORKER,
-  }),
+  cachedGuild
+    ? Promise.resolve(null)
+    : ListGuildsUsecase.execute({ accessToken, userId: user.id, appWorker: env.APP_WORKER, includeChannelSummary: false }),
   VspoChannelApiRepository.getGuildConfig(env.APP_WORKER, guildId),
   VspoChannelApiRepository.listCreators(env.APP_WORKER),
 ]);
 
-const allGuilds = guildsResult.err ? [] : [...guildsResult.val.installed, ...guildsResult.val.notInstalled];
-const currentGuild = allGuilds.find((g) => g.id === guildId);
+const currentGuild = cachedGuild
+  ? { id: cachedGuild.id, name: cachedGuild.name, icon: cachedGuild.icon, isAdmin: true, botInstalled: cachedGuild.botInstalled }
+  : (() => {
+      const all = guildsResult?.err ? [] : [...(guildsResult?.val.installed ?? []), ...(guildsResult?.val.notInstalled ?? [])];
+      return all.find((g) => g.id === guildId) ?? null;
+    })();
 const guildName = currentGuild?.name ?? guildId;
 const channels = channelsResult.err ? [] : channelsResult.val.channels;
 const creators = creatorsResult.err ? { jp: [], en: [] } : creatorsResult.val;

--- a/service/bot-dashboard/src/pages/dashboard/[guildId]/announcements.astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId]/announcements.astro
@@ -19,6 +19,7 @@ const guildsResult = await ListGuildsUsecase.execute({
   accessToken,
   userId: user.id,
   appWorker: env.APP_WORKER,
+  includeChannelSummary: false,
 });
 
 const allGuilds = guildsResult.err

--- a/service/bot-dashboard/src/pages/dashboard/index.astro
+++ b/service/bot-dashboard/src/pages/dashboard/index.astro
@@ -23,6 +23,15 @@ const fetchError = result.err ?? null;
 const installed = result.err ? [] : result.val.installed;
 const notInstalled = result.err ? [] : result.val.notInstalled;
 const botClientId = env.DISCORD_BOT_CLIENT_ID;
+
+// Cache guild summaries in session for fast access on guild detail pages
+if (!result.err) {
+  const allGuilds = [...result.val.installed, ...result.val.notInstalled];
+  Astro.session?.set(
+    "guildSummaries",
+    allGuilds.map((g) => ({ id: g.id, name: g.name, icon: g.icon, botInstalled: g.botInstalled })),
+  );
+}
 ---
 
 <Dashboard title={t(locale, "dashboard.servers")} description={t(locale, "meta.dashboard.description")} showSidebar>

--- a/service/bot-dashboard/src/pages/dashboard/index.astro
+++ b/service/bot-dashboard/src/pages/dashboard/index.astro
@@ -29,7 +29,7 @@ if (!result.err) {
   const allGuilds = [...result.val.installed, ...result.val.notInstalled];
   Astro.session?.set(
     "guildSummaries",
-    allGuilds.map((g) => ({ id: g.id, name: g.name, icon: g.icon, botInstalled: g.botInstalled })),
+    allGuilds.map((g) => ({ id: g.id, name: g.name, icon: g.icon, isAdmin: g.isAdmin, botInstalled: g.botInstalled })),
   );
 }
 ---

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -95,7 +95,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
               </svg>
               <div class="flex-1">
                 <p>{t(locale, errorKey)}</p>
-                <a href="/auth/discord" class="mt-1 inline-block font-medium text-vspo-purple underline hover:no-underline">
+                <a href="/auth/discord" data-astro-prefetch="false" class="mt-1 inline-block font-medium text-vspo-purple underline hover:no-underline">
                   {t(locale, "login.button")}
                 </a>
               </div>
@@ -128,6 +128,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
               rel="noopener"
               variant="outline"
               size="lg"
+              data-astro-prefetch="false"
             >
               {t(locale, "login.button")}
             </Button>
@@ -256,6 +257,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
               rel="noopener"
               variant="outline"
               size="lg"
+              data-astro-prefetch="false"
             >
               {t(locale, "login.button")}
             </Button>


### PR DESCRIPTION
## Summary
- ギルド詳細ページでセッションキャッシュからギルド情報を取得し、ListGuildsUsecase の冗長な API コール (Discord API + Bot API ×N) をスキップ
- `includeChannelSummary` フラグを追加し、ギルド詳細ページでの N+1 チャンネル設定フェッチを除去
- middleware のセッション読み取りを `Promise.all` で並列化し、KV ラウンドトリップを削減
- Astro prefetch 戦略を `viewport` に設定し、ビューポート内リンクを事前フェッチ
- Google Fonts のウェイトを 7→5 に削減 (M PLUS Rounded 1c 500, Noto Sans JP 600 を除去)
- 不要になったローンチお知らせを削除