### PR TITLE
fix(bot-dashboard): distinguish custom member type from all and show avatars

### DIFF
--- a/service/bot-dashboard/src/features/channel/components/ChannelConfigForm.astro
+++ b/service/bot-dashboard/src/features/channel/components/ChannelConfigForm.astro
@@ -107,7 +107,10 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
 
         {/* Dropdown multi-select */}
         <div class="relative" data-member-dropdown>
-          {/* Trigger: chips area + dropdown button */}
+          {/* Selected chips */}
+          <div class="mb-1.5 flex hidden flex-wrap gap-1.5" data-selected-chips></div>
+
+          {/* Trigger: dropdown button */}
           <button
             type="button"
             class="flex w-full cursor-pointer flex-wrap items-center gap-1.5 rounded-lg border border-outline-variant/20 bg-surface-container-low px-3 py-2 text-left text-sm transition-colors hover:border-vspo-purple/40 focus:border-vspo-purple focus:outline-none focus:ring-1 focus:ring-vspo-purple"
@@ -117,9 +120,6 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
           >
             <span class="text-on-surface-variant/60" data-dropdown-placeholder>{t(locale, "channelConfig.members.search")}</span>
           </button>
-
-          {/* Selected chips (shown above trigger when members are selected) */}
-          <div class="mb-1.5 flex hidden flex-wrap gap-1.5" data-selected-chips></div>
 
           {/* Dropdown panel */}
           <div
@@ -467,7 +467,6 @@ const enCreators = Creator.filterByType(creators, "vspo_en");
       }
       const hasChips = checked.length > 0;
       chipsContainer.classList.toggle("hidden", !hasChips);
-      if (placeholder) placeholder.classList.toggle("hidden", hasChips);
     };
 
     const updateSelectedState = () => {

--- a/service/bot-dashboard/src/features/channel/components/ChannelTable.astro
+++ b/service/bot-dashboard/src/features/channel/components/ChannelTable.astro
@@ -79,10 +79,12 @@ const resolveCustomCreators = (customMembers?: string[]): CreatorType[] => {
               </td>
               <td class="hidden px-6 py-4 text-xs font-medium text-on-surface-variant md:table-cell sm:px-8">
                 {ch.memberType === "custom" ? (() => {
+                  const resolved = resolveCustomCreators(ch.customMembers);
+                  if (resolved.length === 0) return t(locale, memberTypeKey(ch.memberType));
                   const overflow = (ch.customMembers?.length ?? 0) - MAX_AVATARS;
                   return (
                     <div class="flex items-center -space-x-2">
-                      {resolveCustomCreators(ch.customMembers).slice(0, MAX_AVATARS).map((creator) => (
+                      {resolved.slice(0, MAX_AVATARS).map((creator) => (
                         <div class="relative h-7 w-7 shrink-0 rounded-full ring-2 ring-surface" title={creator.name}>
                           {creator.thumbnailUrl ? (
                             <img
@@ -92,7 +94,7 @@ const resolveCustomCreators = (customMembers?: string[]): CreatorType[] => {
                               loading="lazy"
                             />
                           ) : (
-                            <div class="flex h-7 w-7 items-center justify-center rounded-full bg-vspo-purple/20 text-[10px] font-bold text-vspo-purple">
+                            <div class="flex h-7 w-7 items-center justify-center rounded-full bg-vspo-purple/20 text-[10px] font-bold text-vspo-purple" role="img" aria-label={creator.name}>
                               {creator.name.charAt(0)}
                             </div>
                           )}

--- a/service/bot-dashboard/src/features/channel/components/ChannelTable.astro
+++ b/service/bot-dashboard/src/features/channel/components/ChannelTable.astro
@@ -1,18 +1,30 @@
 ---
 import type { ChannelConfigType } from "~/features/channel/domain/channel-config";
+import type { CreatorType } from "~/features/shared/domain/creator";
+import { Creator } from "~/features/shared/domain/creator";
 import Button from "~/features/shared/components/Button.astro";
 import IconButton from "~/features/shared/components/IconButton.astro";
 import { t, memberTypeKey, languageDisplayKey } from "~/i18n/dict";
 
 interface Props {
   channels: ChannelConfigType[];
+  creators?: CreatorType[];
 }
 
-const { channels } = Astro.props;
+const { channels, creators = [] } = Astro.props;
 const { locale } = Astro.locals;
 
 /** Language code to localized chip label */
 const langChipLabel = (lang: string) => t(locale, languageDisplayKey(lang));
+
+/** Max number of avatars to display before showing "+N" */
+const MAX_AVATARS = 5;
+
+/** Resolve creators for a channel's custom members */
+const resolveCustomCreators = (customMembers?: string[]): CreatorType[] => {
+  if (!customMembers || customMembers.length === 0) return [];
+  return Creator.filterByIds(creators, new Set(customMembers));
+};
 ---
 
 {/* Configuration Matrix */}
@@ -68,7 +80,35 @@ const langChipLabel = (lang: string) => t(locale, languageDisplayKey(lang));
                 </span>
               </td>
               <td class="hidden px-6 py-4 text-xs font-medium text-on-surface-variant md:table-cell sm:px-8">
-                {t(locale, memberTypeKey(ch.memberType))}
+                {ch.memberType === "custom" ? (
+                  <div class="flex items-center gap-2">
+                    <div class="flex items-center -space-x-2">
+                      {resolveCustomCreators(ch.customMembers).slice(0, MAX_AVATARS).map((creator) => (
+                        <div class="relative h-7 w-7 shrink-0 rounded-full ring-2 ring-surface" title={creator.name}>
+                          {creator.thumbnailUrl ? (
+                            <img
+                              src={creator.thumbnailUrl}
+                              alt={creator.name}
+                              class="h-7 w-7 rounded-full object-cover"
+                              loading="lazy"
+                            />
+                          ) : (
+                            <div class="flex h-7 w-7 items-center justify-center rounded-full bg-vspo-purple/20 text-[10px] font-bold text-vspo-purple">
+                              {creator.name.charAt(0)}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                      {(ch.customMembers?.length ?? 0) > MAX_AVATARS && (
+                        <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-surface-container-highest text-[10px] font-bold text-on-surface-variant ring-2 ring-surface">
+                          +{(ch.customMembers?.length ?? 0) - MAX_AVATARS}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  t(locale, memberTypeKey(ch.memberType))
+                )}
               </td>
               <td class="hidden px-6 py-4 lg:table-cell sm:px-8">
                 {ch.enabled ? (

--- a/service/bot-dashboard/src/features/channel/components/ChannelTable.astro
+++ b/service/bot-dashboard/src/features/channel/components/ChannelTable.astro
@@ -17,10 +17,8 @@ const { locale } = Astro.locals;
 /** Language code to localized chip label */
 const langChipLabel = (lang: string) => t(locale, languageDisplayKey(lang));
 
-/** Max number of avatars to display before showing "+N" */
 const MAX_AVATARS = 5;
 
-/** Resolve creators for a channel's custom members */
 const resolveCustomCreators = (customMembers?: string[]): CreatorType[] => {
   if (!customMembers || customMembers.length === 0) return [];
   return Creator.filterByIds(creators, new Set(customMembers));
@@ -80,8 +78,9 @@ const resolveCustomCreators = (customMembers?: string[]): CreatorType[] => {
                 </span>
               </td>
               <td class="hidden px-6 py-4 text-xs font-medium text-on-surface-variant md:table-cell sm:px-8">
-                {ch.memberType === "custom" ? (
-                  <div class="flex items-center gap-2">
+                {ch.memberType === "custom" ? (() => {
+                  const overflow = (ch.customMembers?.length ?? 0) - MAX_AVATARS;
+                  return (
                     <div class="flex items-center -space-x-2">
                       {resolveCustomCreators(ch.customMembers).slice(0, MAX_AVATARS).map((creator) => (
                         <div class="relative h-7 w-7 shrink-0 rounded-full ring-2 ring-surface" title={creator.name}>
@@ -99,14 +98,14 @@ const resolveCustomCreators = (customMembers?: string[]): CreatorType[] => {
                           )}
                         </div>
                       ))}
-                      {(ch.customMembers?.length ?? 0) > MAX_AVATARS && (
+                      {overflow > 0 && (
                         <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-surface-container-highest text-[10px] font-bold text-on-surface-variant ring-2 ring-surface">
-                          +{(ch.customMembers?.length ?? 0) - MAX_AVATARS}
+                          +{overflow}
                         </div>
                       )}
                     </div>
-                  </div>
-                ) : (
+                  );
+                })() : (
                   t(locale, memberTypeKey(ch.memberType))
                 )}
               </td>

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -25,6 +25,7 @@ const toFrontendMemberType = (
     | "vspo_all"
     | "general"
     | undefined,
+  selectedMemberIds?: string[],
 ): MemberTypeValue => {
   switch (serverMemberType) {
     case "vspo_jp":
@@ -32,6 +33,9 @@ const toFrontendMemberType = (
     case "vspo_en":
       return "vspo_en";
     case "vspo_all":
+      return selectedMemberIds && selectedMemberIds.length > 0
+        ? "custom"
+        : "all";
     case "general":
     case undefined:
       return "all";
@@ -122,8 +126,8 @@ const VspoChannelApiRepository = {
         channelName: ch.name,
         enabled: true,
         language: ch.languageCode,
-        memberType: toFrontendMemberType(ch.memberType),
-        customMembers: undefined,
+        memberType: toFrontendMemberType(ch.memberType, ch.selectedMemberIds),
+        customMembers: ch.selectedMemberIds,
       })),
     });
   },

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -171,7 +171,7 @@ const VspoChannelApiRepository = {
       memberType: data.memberType
         ? toServerMemberType(data.memberType)
         : undefined,
-      selectedMemberIds: data.customMembers,
+      selectedMemberIds: data.memberType === "custom" ? data.customMembers : [],
     });
   },
 

--- a/service/bot-dashboard/src/features/shared/dev-mock.ts
+++ b/service/bot-dashboard/src/features/shared/dev-mock.ts
@@ -57,6 +57,18 @@ export const devMock = {
               memberType: "vspo_jp" as const,
               customMembers: undefined,
             },
+            {
+              channelId: "ch-004",
+              channelName: "custom-picks",
+              enabled: true,
+              language: "ja",
+              memberType: "custom" as const,
+              customMembers: [
+                "creator-jp-001",
+                "creator-jp-003",
+                "creator-en-002",
+              ],
+            },
           ]
         : [],
   }),
@@ -67,6 +79,7 @@ export const devMock = {
           { id: "ch-001", name: "vspo-notifications" },
           { id: "ch-002", name: "schedule-en" },
           { id: "ch-003", name: "archives" },
+          { id: "ch-004", name: "custom-picks" },
           { id: "ch-mock-1", name: "general" },
           { id: "ch-mock-2", name: "random" },
         ]

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -142,7 +142,7 @@ const fetchError = channelsResult.err ?? creatorsResult.err ?? null;
     </div>
 
     {/* Configuration Matrix */}
-    <ChannelTable channels={channels} />
+    <ChannelTable channels={channels} creators={[...creators.jp, ...creators.en]} />
 
     {/* Hidden modals */}
     <ChannelConfigForm

--- a/service/vspo-schedule/v2/web/src/features/shared/types/api.d.ts
+++ b/service/vspo-schedule/v2/web/src/features/shared/types/api.d.ts
@@ -2425,6 +2425,7 @@ declare class DiscordService extends RpcTarget {
             | "vspo_all"
             | "general"
             | undefined;
+          selectedMemberIds?: string[] | undefined;
           isInitialAdd?: boolean | undefined;
         }[];
       },
@@ -2455,6 +2456,7 @@ declare class DiscordService extends RpcTarget {
             | "vspo_all"
             | "general"
             | undefined;
+          selectedMemberIds?: string[] | undefined;
           isInitialAdd?: boolean | undefined;
         }[];
       },


### PR DESCRIPTION
## Summary
- Fix `toFrontendMemberType` to check `selectedMemberIds` when server returns `vspo_all` — returns `"custom"` when members are individually selected, `"all"` otherwise
- Pass `selectedMemberIds` from RPC response through to `customMembers` field (was previously hardcoded to `undefined`)
- Show overlapping member avatars in ChannelTable for custom member type with `+N` overflow badge
- Add `selectedMemberIds` to DiscordService RPC type definition (`api.d.ts`)
- Add custom member mock data for dev testing