### PR TITLE
feat(bot-dashboard): polish landing page UI and unify 404 button

### DIFF
--- a/service/bot-dashboard/src/features/landing/components/FeaturePopup.astro
+++ b/service/bot-dashboard/src/features/landing/components/FeaturePopup.astro
@@ -4,18 +4,22 @@ interface Props {
   title: string;
   description: string;
   closeLabel: string;
+  imagePlaceholder: string;
 }
 
-const { id, title, description, closeLabel } = Astro.props;
+const { id, title, description, closeLabel, imagePlaceholder } = Astro.props;
+const titleId = `${id}-title`;
 ---
 
 <dialog
   id={id}
+  aria-modal="true"
+  aria-labelledby={titleId}
   class="feature-popup m-auto max-w-lg rounded-2xl border border-border bg-surface p-0 text-on-surface shadow-xl backdrop:bg-black/50"
 >
   <div class="flex flex-col gap-4 p-6">
     <div class="flex items-start justify-between">
-      <h3 class="font-heading text-xl font-bold">{title}</h3>
+      <h3 id={titleId} class="font-heading text-xl font-bold">{title}</h3>
       <button
         type="button"
         class="feature-popup-close -mr-2 -mt-2 cursor-pointer rounded-lg p-2 text-on-surface-variant transition-colors hover:bg-accent hover:text-on-surface"
@@ -34,7 +38,7 @@ const { id, title, description, closeLabel } = Astro.props;
           <svg class="mr-2 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
           </svg>
-          Coming soon
+          {imagePlaceholder}
         </div>
       </slot>
     </div>

--- a/service/bot-dashboard/src/features/landing/components/FeaturePopup.astro
+++ b/service/bot-dashboard/src/features/landing/components/FeaturePopup.astro
@@ -1,0 +1,44 @@
+---
+interface Props {
+  id: string;
+  title: string;
+  description: string;
+  closeLabel: string;
+}
+
+const { id, title, description, closeLabel } = Astro.props;
+---
+
+<dialog
+  id={id}
+  class="feature-popup m-auto max-w-lg rounded-2xl border border-border bg-surface p-0 text-on-surface shadow-xl backdrop:bg-black/50"
+>
+  <div class="flex flex-col gap-4 p-6">
+    <div class="flex items-start justify-between">
+      <h3 class="font-heading text-xl font-bold">{title}</h3>
+      <button
+        type="button"
+        class="feature-popup-close -mr-2 -mt-2 cursor-pointer rounded-lg p-2 text-on-surface-variant transition-colors hover:bg-accent hover:text-on-surface"
+        aria-label={closeLabel}
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    {/* Image placeholder — replace src when screenshots are ready */}
+    <div class="aspect-video w-full overflow-hidden rounded-lg bg-surface-container">
+      <slot name="image">
+        <div class="flex h-full items-center justify-center text-sm text-on-surface-variant">
+          <svg class="mr-2 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          Coming soon
+        </div>
+      </slot>
+    </div>
+
+    <p class="text-sm leading-relaxed text-on-surface-variant">{description}</p>
+  </div>
+</dialog>

--- a/service/bot-dashboard/src/i18n/dict.ts
+++ b/service/bot-dashboard/src/i18n/dict.ts
@@ -5,10 +5,9 @@ const ja = {
 
   // Login page
   "login.title": "ログイン",
-  "login.headline": "ぶいすぽっ!の配信予定を\nDiscord に届ける",
-  "login.description":
-    "ぶいすぽっ!メンバーの配信予定を Discord に自動で届けます",
-  "login.button": "Discord でログイン",
+  "login.headline": "ぶいすぽっ!の配信予定を\nDiscordへ",
+  "login.description": "",
+  "login.button": "Discordで管理画面へログイン",
   "login.addBot": "サーバーに追加する",
   "login.previewCaption": "通知イメージ",
   "login.previewAlt1": "ぶいすぽっ!公式メンバーの配信通知例",
@@ -34,6 +33,7 @@ const ja = {
   "login.feature.settings": "Webで設定管理",
   "login.feature.settings.desc":
     "ダッシュボードから通知チャンネルや対象メンバーを変更",
+  "login.feature.close": "閉じる",
 
   // Dashboard
   "dashboard.servers": "サーバー一覧",
@@ -176,10 +176,9 @@ const en: Record<keyof typeof ja, string> = {
 
   // Login page
   "login.title": "Login",
-  "login.headline": "VSPO stream schedules,\nright in Discord",
-  "login.description":
-    "Automatic Discord notifications for VSPO member streams",
-  "login.button": "Login with Discord",
+  "login.headline": "VSPO stream schedules,\nto Discord",
+  "login.description": "",
+  "login.button": "Log in to Dashboard with Discord",
   "login.addBot": "Add to Server",
   "login.previewCaption": "Preview",
   "login.previewAlt1": "Example notification for official VSPO member streams",
@@ -208,6 +207,7 @@ const en: Record<keyof typeof ja, string> = {
   "login.feature.settings": "Settings from the web",
   "login.feature.settings.desc":
     "Change notification channels and target members from the dashboard",
+  "login.feature.close": "Close",
 
   // Dashboard
   "dashboard.servers": "Servers",

--- a/service/bot-dashboard/src/i18n/dict.ts
+++ b/service/bot-dashboard/src/i18n/dict.ts
@@ -34,6 +34,7 @@ const ja = {
   "login.feature.settings.desc":
     "ダッシュボードから通知チャンネルや対象メンバーを変更",
   "login.feature.close": "閉じる",
+  "login.feature.imagePlaceholder": "準備中",
 
   // Dashboard
   "dashboard.servers": "サーバー一覧",
@@ -208,6 +209,7 @@ const en: Record<keyof typeof ja, string> = {
   "login.feature.settings.desc":
     "Change notification channels and target members from the dashboard",
   "login.feature.close": "Close",
+  "login.feature.imagePlaceholder": "Coming soon",
 
   // Dashboard
   "dashboard.servers": "Servers",

--- a/service/bot-dashboard/src/pages/404.astro
+++ b/service/bot-dashboard/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
 import Base from "~/layouts/Base.astro";
+import Button from "~/features/shared/components/Button.astro";
 import { t } from "~/i18n/dict";
 
 const { locale } = Astro.locals;
@@ -11,12 +12,9 @@ const { locale } = Astro.locals;
     <p class="mt-4 text-lg text-on-surface-variant">
       {t(locale, "error.notFound.title")}
     </p>
-    <a
-      href="/"
-      class="mt-8 inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-vspo-purple to-vspo-purple-light px-6 py-3 font-heading text-sm font-bold text-white shadow-lg shadow-vspo-purple/20 transition-all hover:scale-[1.02] active:scale-95"
-    >
+    <Button as="a" href="/" variant="primary" size="lg" class="mt-8 gap-2">
       <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1" /></svg>
       {t(locale, "error.notFound.back")}
-    </a>
+    </Button>
   </main>
 </Base>

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -177,7 +177,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
 
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <ScrollReveal animation="fade-in-up" delay={0}>
-              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-list">
+              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-list" aria-haspopup="dialog" aria-controls="feature-list">
                 <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
                   <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
@@ -189,7 +189,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
             </ScrollReveal>
 
             <ScrollReveal animation="fade-in-up" delay={100}>
-              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-filter">
+              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-filter" aria-haspopup="dialog" aria-controls="feature-filter">
                 <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-tertiary/10">
                   <svg class="h-5 w-5 text-tertiary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
@@ -201,7 +201,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
             </ScrollReveal>
 
             <ScrollReveal animation="fade-in-up" delay={200}>
-              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-realtime">
+              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-realtime" aria-haspopup="dialog" aria-controls="feature-realtime">
                 <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
                   <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
@@ -213,7 +213,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
             </ScrollReveal>
 
             <ScrollReveal animation="fade-in-up" delay={300}>
-              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-settings">
+              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-settings" aria-haspopup="dialog" aria-controls="feature-settings">
                 <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
                   <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
@@ -227,10 +227,10 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
           </div>
 
           {/* Feature Popups */}
-          <FeaturePopup id="feature-list" title={t(locale, "login.feature.list")} description={t(locale, "login.feature.list.desc")} closeLabel={t(locale, "login.feature.close")} />
-          <FeaturePopup id="feature-filter" title={t(locale, "login.feature.filter")} description={t(locale, "login.feature.filter.desc")} closeLabel={t(locale, "login.feature.close")} />
-          <FeaturePopup id="feature-realtime" title={t(locale, "login.feature.realtime")} description={t(locale, "login.feature.realtime.desc")} closeLabel={t(locale, "login.feature.close")} />
-          <FeaturePopup id="feature-settings" title={t(locale, "login.feature.settings")} description={t(locale, "login.feature.settings.desc")} closeLabel={t(locale, "login.feature.close")} />
+          <FeaturePopup id="feature-list" title={t(locale, "login.feature.list")} description={t(locale, "login.feature.list.desc")} closeLabel={t(locale, "login.feature.close")} imagePlaceholder={t(locale, "login.feature.imagePlaceholder")} />
+          <FeaturePopup id="feature-filter" title={t(locale, "login.feature.filter")} description={t(locale, "login.feature.filter.desc")} closeLabel={t(locale, "login.feature.close")} imagePlaceholder={t(locale, "login.feature.imagePlaceholder")} />
+          <FeaturePopup id="feature-realtime" title={t(locale, "login.feature.realtime")} description={t(locale, "login.feature.realtime.desc")} closeLabel={t(locale, "login.feature.close")} imagePlaceholder={t(locale, "login.feature.imagePlaceholder")} />
+          <FeaturePopup id="feature-settings" title={t(locale, "login.feature.settings")} description={t(locale, "login.feature.settings.desc")} closeLabel={t(locale, "login.feature.close")} imagePlaceholder={t(locale, "login.feature.imagePlaceholder")} />
         </div>
       </section>
 
@@ -310,21 +310,32 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
 </Base>
 
 <script>
-  document.querySelectorAll<HTMLButtonElement>(".feature-card-trigger").forEach((btn) => {
-    btn.addEventListener("click", () => {
-      const id = btn.dataset.feature;
-      if (id) {
-        const dialog = document.getElementById(id) as HTMLDialogElement | null;
-        dialog?.showModal();
-      }
-    });
-  });
+  let ac = new AbortController();
 
-  document.querySelectorAll<HTMLDialogElement>(".feature-popup").forEach((dialog) => {
-    const closeBtn = dialog.querySelector(".feature-popup-close");
-    closeBtn?.addEventListener("click", () => dialog.close());
-    dialog.addEventListener("click", (e) => {
-      if (e.target === dialog) dialog.close();
+  function initFeaturePopups() {
+    ac.abort();
+    ac = new AbortController();
+    const { signal } = ac;
+
+    document.querySelectorAll<HTMLButtonElement>(".feature-card-trigger").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const id = btn.dataset.feature;
+        if (id) {
+          const dialog = document.getElementById(id) as HTMLDialogElement | null;
+          if (dialog && !dialog.open) dialog.showModal();
+        }
+      }, { signal });
     });
-  });
+
+    document.querySelectorAll<HTMLDialogElement>(".feature-popup").forEach((dialog) => {
+      const closeBtn = dialog.querySelector(".feature-popup-close");
+      closeBtn?.addEventListener("click", () => dialog.close(), { signal });
+      dialog.addEventListener("click", (e) => {
+        if (e.target === dialog) dialog.close();
+      }, { signal });
+    });
+  }
+
+  initFeaturePopups();
+  document.addEventListener("astro:page-load", initFeaturePopups);
 </script>

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -6,6 +6,7 @@ import LanguageSelector from "~/features/shared/components/LanguageSelector.astr
 import ThemeToggle from "~/features/shared/components/ThemeToggle.astro";
 import ScrollReveal from "~/features/landing/components/ScrollReveal.astro";
 import DigitRoll from "~/features/landing/components/DigitRoll.astro";
+import FeaturePopup from "~/features/landing/components/FeaturePopup.astro";
 import { t } from "~/i18n/dict";
 import { buildBotInviteUrl } from "~/features/guild/domain/guild";
 import { VspoGuildApiRepository } from "~/features/guild/repository/vspo-guild-api";
@@ -57,12 +58,8 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
 
           {/* Headline */}
           <h1
-            class="hero-headline mb-6 whitespace-pre-line font-heading text-4xl font-extrabold tracking-tight text-on-surface sm:text-5xl md:text-6xl"
+            class="hero-headline mb-8 whitespace-pre-line font-heading text-4xl font-extrabold tracking-tight text-on-surface sm:text-5xl md:text-6xl"
           >{t(locale, "login.headline")}</h1>
-
-          <p class="hero-description mb-8 max-w-xl text-balance text-base leading-relaxed text-on-surface-variant sm:text-lg">
-            {t(locale, "login.description")}
-          </p>
 
           {/* Stats — digit roll counter */}
           {stats && (
@@ -180,7 +177,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
 
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <ScrollReveal animation="fade-in-up" delay={0}>
-              <div class="feature-card rounded-xl bg-surface-container p-6">
+              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-list">
                 <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
                   <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
@@ -188,11 +185,11 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
                 </div>
                 <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.list")}</h3>
                 <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.list.desc")}</p>
-              </div>
+              </button>
             </ScrollReveal>
 
             <ScrollReveal animation="fade-in-up" delay={100}>
-              <div class="feature-card rounded-xl bg-surface-container p-6">
+              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-filter">
                 <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-tertiary/10">
                   <svg class="h-5 w-5 text-tertiary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
@@ -200,11 +197,11 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
                 </div>
                 <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.filter")}</h3>
                 <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.filter.desc")}</p>
-              </div>
+              </button>
             </ScrollReveal>
 
             <ScrollReveal animation="fade-in-up" delay={200}>
-              <div class="feature-card rounded-xl bg-surface-container p-6">
+              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-realtime">
                 <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
                   <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
@@ -212,11 +209,11 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
                 </div>
                 <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.realtime")}</h3>
                 <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.realtime.desc")}</p>
-              </div>
+              </button>
             </ScrollReveal>
 
             <ScrollReveal animation="fade-in-up" delay={300}>
-              <div class="feature-card rounded-xl bg-surface-container p-6">
+              <button type="button" class="feature-card-trigger w-full cursor-pointer rounded-xl bg-surface-container p-6 text-left transition-shadow hover:shadow-card" data-feature="feature-settings">
                 <div class="feature-icon mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-vspo-purple/10">
                   <svg class="h-5 w-5 text-vspo-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
@@ -225,9 +222,15 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
                 </div>
                 <h3 class="mb-1 font-heading text-lg font-bold text-on-surface">{t(locale, "login.feature.settings")}</h3>
                 <p class="text-sm leading-relaxed text-on-surface-variant">{t(locale, "login.feature.settings.desc")}</p>
-              </div>
+              </button>
             </ScrollReveal>
           </div>
+
+          {/* Feature Popups */}
+          <FeaturePopup id="feature-list" title={t(locale, "login.feature.list")} description={t(locale, "login.feature.list.desc")} closeLabel={t(locale, "login.feature.close")} />
+          <FeaturePopup id="feature-filter" title={t(locale, "login.feature.filter")} description={t(locale, "login.feature.filter.desc")} closeLabel={t(locale, "login.feature.close")} />
+          <FeaturePopup id="feature-realtime" title={t(locale, "login.feature.realtime")} description={t(locale, "login.feature.realtime.desc")} closeLabel={t(locale, "login.feature.close")} />
+          <FeaturePopup id="feature-settings" title={t(locale, "login.feature.settings")} description={t(locale, "login.feature.settings.desc")} closeLabel={t(locale, "login.feature.close")} />
         </div>
       </section>
 
@@ -305,3 +308,23 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
     </main>
   </div>
 </Base>
+
+<script>
+  document.querySelectorAll<HTMLButtonElement>(".feature-card-trigger").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const id = btn.dataset.feature;
+      if (id) {
+        const dialog = document.getElementById(id) as HTMLDialogElement | null;
+        dialog?.showModal();
+      }
+    });
+  });
+
+  document.querySelectorAll<HTMLDialogElement>(".feature-popup").forEach((dialog) => {
+    const closeBtn = dialog.querySelector(".feature-popup-close");
+    closeBtn?.addEventListener("click", () => dialog.close());
+    dialog.addEventListener("click", (e) => {
+      if (e.target === dialog) dialog.close();
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary
- ヘッドライン変更: 「ぶいすぽっ!の配信予定を Discordへ」に短縮
- サブタイトル (description) を削除
- ログインボタン文言: 「Discordで管理画面へログイン」に変更
- 機能紹介カードにクリックポップアップ追加（画像スロット付き、画像は後日差し替え）
- 404ページのボタンを共通 `Button` コンポーネントに統一

## Test plan
- [ ] ランディングページのヘッドライン・ボタン文言が正しく表示される
- [ ] 機能紹介カードをクリックするとポップアップが表示される
- [ ] ポップアップの閉じるボタン・背景クリックで閉じる
- [ ] 404ページのボタンが他のページと同じスタイルで表示される
- [ ] EN locale でも文言が正しく表示される