### PR TITLE
perf(web): persist layout shell across page navigations

### DIFF
--- a/service/vspo-schedule/v2/web/src/app/[locale]/layout.tsx
+++ b/service/vspo-schedule/v2/web/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { AppProviders } from "@/components/AppProviders";
 import { GoogleAnalytics } from "@/features/shared/components/Elements/Google/GoogleAnalytics";
+import { LayoutShell } from "@/features/shared/components/Layout/LayoutShell";
 import { routing } from "@/i18n/routing";
 
 export default async function LocaleLayout({
@@ -38,7 +39,9 @@ export default async function LocaleLayout({
       <body>
         <InitColorSchemeScript attribute="class" />
         <NextIntlClientProvider messages={messages}>
-          <AppProviders>{children}</AppProviders>
+          <AppProviders>
+            <LayoutShell>{children}</LayoutShell>
+          </AppProviders>
         </NextIntlClientProvider>
         <GoogleAnalytics />
         {process.env.ENV === "production" &&

--- a/service/vspo-schedule/v2/web/src/context/PageMetaContext.tsx
+++ b/service/vspo-schedule/v2/web/src/context/PageMetaContext.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useRef,
+  useState,
+} from "react";
+
+export type PageMeta = {
+  title: string;
+  lastUpdateTimestamp?: number;
+  footerMessage?: string;
+};
+
+type PageMetaContextValue = {
+  pageMeta: PageMeta;
+  setPageMeta: (meta: PageMeta) => void;
+};
+
+const defaultPageMeta: PageMeta = { title: "" };
+
+const PageMetaContext = createContext<PageMetaContextValue | null>(null);
+
+const shallowEqual = (a: PageMeta, b: PageMeta): boolean =>
+  a.title === b.title &&
+  a.lastUpdateTimestamp === b.lastUpdateTimestamp &&
+  a.footerMessage === b.footerMessage;
+
+export const PageMetaProvider = ({ children }: { children: ReactNode }) => {
+  const [pageMeta, setPageMetaState] = useState<PageMeta>(defaultPageMeta);
+  const metaRef = useRef(pageMeta);
+
+  const setPageMeta = (meta: PageMeta) => {
+    if (shallowEqual(metaRef.current, meta)) return;
+    metaRef.current = meta;
+    setPageMetaState(meta);
+  };
+
+  return (
+    <PageMetaContext.Provider value={{ pageMeta, setPageMeta }}>
+      {children}
+    </PageMetaContext.Provider>
+  );
+};
+
+export const usePageMeta = (): PageMetaContextValue => {
+  const ctx = useContext(PageMetaContext);
+  if (!ctx) {
+    throw new Error("usePageMeta must be used within PageMetaProvider");
+  }
+  return ctx;
+};

--- a/service/vspo-schedule/v2/web/src/context/PageMetaContext.tsx
+++ b/service/vspo-schedule/v2/web/src/context/PageMetaContext.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 
-export type PageMeta = {
+type PageMeta = {
   title: string;
   lastUpdateTimestamp?: number;
   footerMessage?: string;

--- a/service/vspo-schedule/v2/web/src/features/shared/components/Layout/ContentLayout.tsx
+++ b/service/vspo-schedule/v2/web/src/features/shared/components/Layout/ContentLayout.tsx
@@ -4,36 +4,12 @@ import {
   type Breakpoint,
   Container,
   type ContainerTypeMap,
-  GlobalStyles,
 } from "@mui/material";
 import type { OverridableComponent } from "@mui/material/OverridableComponent";
 import { styled } from "@mui/material/styles";
 import type React from "react";
-import { useEffect, useState } from "react";
-import { AlertSnackbar } from "../Elements";
-import { Footer } from "./Footer";
-import { Header } from "./Header";
-import { CustomBottomNavigation } from "./Navigation";
-
-/**
- * Global CSS to hide layout chrome (header, footer, bottom nav) when immersive mode is active.
- * Toggled via `document.documentElement.dataset.immersive = "true"` from page components.
- */
-const immersiveStyles = (
-  <GlobalStyles
-    styles={{
-      'html[data-immersive="true"] [data-layout-header]': {
-        display: "none !important",
-      },
-      'html[data-immersive="true"] [data-layout-footer]': {
-        display: "none !important",
-      },
-      'html[data-immersive="true"] [data-layout-bottom-nav]': {
-        display: "none !important",
-      },
-    }}
-  />
-);
+import { useEffect } from "react";
+import { usePageMeta } from "@/context/PageMetaContext";
 
 type ContentLayoutProps = {
   children: React.ReactNode;
@@ -74,45 +50,20 @@ export const ContentLayout = ({
   maxPageWidth,
   padTop,
 }: ContentLayoutProps) => {
-  const [alertOpen, setAlertOpen] = useState(false);
-
-  const handleAlertClose = () => {
-    setAlertOpen(false);
-    localStorage.setItem("alertSeen-discordBot", "true");
-  };
+  const { setPageMeta } = usePageMeta();
 
   useEffect(() => {
-    const hasSeenAlert = localStorage.getItem("alertSeen-discordBot");
-
-    if (!hasSeenAlert) {
-      setAlertOpen(true);
-    }
-  }, []);
+    setPageMeta({ title, lastUpdateTimestamp, footerMessage });
+  }, [title, lastUpdateTimestamp, footerMessage, setPageMeta]);
 
   return (
-    <>
-      {immersiveStyles}
-      <div data-layout-header>
-        <Header title={title} />
-      </div>
-      <AlertSnackbar open={alertOpen} onClose={handleAlertClose} />
-      <StyledContainer
-        component="main"
-        maxWidth={maxPageWidth}
-        padTop={padTop}
-        className={path === "/multiview" ? "multiview-container" : ""}
-      >
-        {children}
-      </StyledContainer>
-      <div data-layout-footer>
-        <Footer
-          lastUpdateTimestamp={lastUpdateTimestamp}
-          description={footerMessage}
-        />
-      </div>
-      <div data-layout-bottom-nav>
-        <CustomBottomNavigation />
-      </div>
-    </>
+    <StyledContainer
+      component="main"
+      maxWidth={maxPageWidth}
+      padTop={padTop}
+      className={path === "/multiview" ? "multiview-container" : ""}
+    >
+      {children}
+    </StyledContainer>
   );
 };

--- a/service/vspo-schedule/v2/web/src/features/shared/components/Layout/LayoutShell.tsx
+++ b/service/vspo-schedule/v2/web/src/features/shared/components/Layout/LayoutShell.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { GlobalStyles } from "@mui/material";
+import type React from "react";
+import { useEffect, useState } from "react";
+import { PageMetaProvider, usePageMeta } from "@/context/PageMetaContext";
+import { AlertSnackbar } from "../Elements";
+import { Footer } from "./Footer";
+import { Header } from "./Header";
+import { CustomBottomNavigation } from "./Navigation";
+
+const immersiveStyles = (
+  <GlobalStyles
+    styles={{
+      'html[data-immersive="true"] [data-layout-header]': {
+        display: "none !important",
+      },
+      'html[data-immersive="true"] [data-layout-footer]': {
+        display: "none !important",
+      },
+      'html[data-immersive="true"] [data-layout-bottom-nav]': {
+        display: "none !important",
+      },
+    }}
+  />
+);
+
+const Shell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { pageMeta } = usePageMeta();
+  const [alertOpen, setAlertOpen] = useState(false);
+
+  useEffect(() => {
+    if (!localStorage.getItem("alertSeen-discordBot")) {
+      setAlertOpen(true);
+    }
+  }, []);
+
+  const handleAlertClose = () => {
+    setAlertOpen(false);
+    localStorage.setItem("alertSeen-discordBot", "true");
+  };
+
+  return (
+    <>
+      {immersiveStyles}
+      <div data-layout-header>
+        <Header title={pageMeta.title} />
+      </div>
+      <AlertSnackbar open={alertOpen} onClose={handleAlertClose} />
+      {children}
+      <div data-layout-footer>
+        <Footer
+          lastUpdateTimestamp={pageMeta.lastUpdateTimestamp}
+          description={pageMeta.footerMessage}
+        />
+      </div>
+      <div data-layout-bottom-nav>
+        <CustomBottomNavigation />
+      </div>
+    </>
+  );
+};
+
+/**
+ * Wraps children with persistent Header/Footer/BottomNav.
+ * Split into Shell + Provider because Shell must read from PageMetaContext.
+ */
+export const LayoutShell: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
+  <PageMetaProvider>
+    <Shell>{children}</Shell>
+  </PageMetaProvider>
+);

--- a/service/vspo-schedule/v2/web/src/features/shared/components/Layout/Navigation.tsx
+++ b/service/vspo-schedule/v2/web/src/features/shared/components/Layout/Navigation.tsx
@@ -9,8 +9,8 @@ import {
   getNavigationRouteInfo,
   type NavigationRouteId,
 } from "@/constants/navigation";
-import { usePathname } from "@/i18n/navigation";
-import { DrawerIcon, Link } from "../Elements";
+import { Link as NextIntlLink, usePathname } from "@/i18n/navigation";
+import { DrawerIcon } from "../Elements";
 
 const bottomNavigationRoutes = [
   "list",
@@ -62,12 +62,13 @@ export const CustomBottomNavigation: React.FC = () => {
         >
           {bottomNavigationRoutes.map((id) => (
             <BottomNavigationAction
-              component={Link}
+              component={NextIntlLink}
               href={getNavigationRouteInfo(id).link}
               key={id}
               label={t(`bottomNav.pages.${id}`)}
               value={id}
               icon={<DrawerIcon id={id} />}
+              sx={{ textDecoration: "none", color: "inherit" }}
             />
           ))}
         </BottomNavigation>


### PR DESCRIPTION
## Summary

- Header/Footer/BottomNavigation を `[locale]/layout.tsx` の `LayoutShell` に移動し、ページ遷移で再マウントされないように変更
- `PageMetaContext` を追加し、各ページから title/lastUpdateTimestamp/footerMessage をシェルに伝達
- `ContentLayout` を Header/Footer/BottomNav を含まないコンテナのみに簡素化
- `BottomNavigationAction` で `NextIntlLink` を直接使用（`Link` → `MuiLink` → `NextIntlLink` の二重ラップを排除）

## Motivation

BottomNav等からの遷移時にハードリロードが発生する場合があった。原因は `ContentLayout` が各ページ内でレンダリングされていたため、`(content)` ↔ `(standalone)` ルートグループ境界を越える遷移でReactツリー全体が再構築されていたこと。

## Verification

Playwright で全ナビゲーションパスを検証済み（JSマーカーが保持されることを確認）:
- `/schedule/all` → `/clips` (content → standalone)
- `/clips` → `/multiview` (standalone → standalone)
- `/multiview` → `/schedule/all` (standalone → content)
- `/schedule/all` → `/terms` (Footer link)
- `/terms` → `/freechat` (Drawer link)