### PR TITLE
fix(bot-dashboard): polish mobile layout, remove redundant stats, add contact link

### DIFF
--- a/.github/workflows/deploy-bot-dashboard.yaml
+++ b/.github/workflows/deploy-bot-dashboard.yaml
@@ -50,6 +50,7 @@ jobs:
               DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
               DISCORD_REDIRECT_URI: process.env.DISCORD_REDIRECT_URI,
               DISCORD_BOT_CLIENT_ID: process.env.DISCORD_BOT_CLIENT_ID,
+              CONTACT_FORM_URL: process.env.CONTACT_FORM_URL,
             };
             process.stdout.write(JSON.stringify(secrets));
           " | pnpm exec wrangler secret bulk
@@ -59,3 +60,4 @@ jobs:
           DISCORD_CLIENT_ID: ${{ secrets.DISCORD_CLIENT_ID }}
           DISCORD_REDIRECT_URI: ${{ secrets.DISCORD_REDIRECT_URI }}
           DISCORD_BOT_CLIENT_ID: ${{ secrets.DISCORD_BOT_CLIENT_ID }}
+          CONTACT_FORM_URL: ${{ secrets.CONTACT_FORM_URL }}

--- a/service/bot-dashboard/astro.config.ts
+++ b/service/bot-dashboard/astro.config.ts
@@ -22,6 +22,12 @@ export default defineConfig({
         context: "server",
         access: "secret",
       }),
+      CONTACT_FORM_URL: envField.string({
+        context: "server",
+        access: "public",
+        optional: true,
+        default: "",
+      }),
       DEV_MOCK_AUTH: envField.boolean({
         context: "server",
         access: "public",

--- a/service/bot-dashboard/astro.config.ts
+++ b/service/bot-dashboard/astro.config.ts
@@ -24,9 +24,8 @@ export default defineConfig({
       }),
       CONTACT_FORM_URL: envField.string({
         context: "server",
-        access: "public",
+        access: "secret",
         optional: true,
-        default: "",
       }),
       DEV_MOCK_AUTH: envField.boolean({
         context: "server",

--- a/service/bot-dashboard/src/features/channel/components/ChannelConfigModal.tsx
+++ b/service/bot-dashboard/src/features/channel/components/ChannelConfigModal.tsx
@@ -316,7 +316,7 @@ function ChannelConfigModalInner({
 
               {/* Chips */}
               {customIds.size > 0 && (
-                <div className="flex flex-wrap gap-1.5">
+                <div className="flex max-h-24 flex-wrap gap-1.5 overflow-y-auto">
                   {creators
                     .filter((c) => customIds.has(c.id))
                     .map((c) => (
@@ -430,20 +430,24 @@ function ChannelConfigModalInner({
               {diffs.map((d) => (
                 <div
                   key={d.label}
-                  className="flex items-center justify-between text-sm"
+                  className="flex flex-col gap-0.5 text-sm sm:flex-row sm:items-center sm:justify-between"
                 >
-                  <span className="text-on-surface-variant">{d.label}</span>
-                  <span className="flex items-center gap-2">
-                    <span className="text-destructive line-through">
+                  <span className="shrink-0 text-on-surface-variant">
+                    {d.label}
+                  </span>
+                  <span className="flex items-center gap-2 truncate">
+                    <span className="shrink-0 text-destructive line-through">
                       {d.from}
                     </span>
                     <span
-                      className="text-on-surface-variant"
+                      className="shrink-0 text-on-surface-variant"
                       aria-hidden="true"
                     >
                       &rarr;
                     </span>
-                    <span className="font-medium text-success">{d.to}</span>
+                    <span className="truncate font-medium text-success">
+                      {d.to}
+                    </span>
                   </span>
                 </div>
               ))}

--- a/service/bot-dashboard/src/features/channel/components/GuildChannelContent.astro
+++ b/service/bot-dashboard/src/features/channel/components/GuildChannelContent.astro
@@ -109,30 +109,10 @@ const memberTypeLabelsMap = Object.fromEntries(
 );
 ---
 
-{/* Stats Bento Grid */}
-<div class="grid grid-cols-2 gap-4 sm:grid-cols-4 sm:gap-6">
-  <div class="rounded-2xl bg-surface-container-low p-4 sm:p-6">
-    <p class="mb-2 text-sm font-medium text-on-surface-variant">{t(locale, "dashboard.stat.channels")}</p>
-    <span class="font-heading text-3xl font-bold text-on-surface">{channels.length}</span>
-  </div>
-  <div class="rounded-2xl bg-surface-container-low p-4 sm:p-6">
-    <p class="mb-2 text-sm font-medium text-on-surface-variant">{t(locale, "channel.language")}</p>
-    <div class="flex gap-2">
-      {[...new Set(channels.map(c => c.language))].map(lang => (
-        <span class="rounded bg-surface-container-highest px-2.5 py-1 text-xs font-bold text-vspo-purple">{t(locale, languageDisplayKey(lang))}</span>
-      ))}
-      {channels.length === 0 && <span class="text-sm text-on-surface-variant">—</span>}
-    </div>
-  </div>
-  <div class="col-span-2 rounded-2xl bg-surface-container-low p-4 sm:p-6">
-    <p class="mb-2 text-sm font-medium text-on-surface-variant">{t(locale, "channel.members")}</p>
-    <div class="flex flex-wrap gap-2">
-      {[...new Set(channels.map(c => c.memberType))].map(mt => (
-        <span class="text-sm font-medium text-on-surface">{t(locale, memberTypeKey(mt))}</span>
-      ))}
-      {channels.length === 0 && <span class="text-sm text-on-surface-variant">—</span>}
-    </div>
-  </div>
+{/* Stats */}
+<div class="inline-block rounded-2xl bg-surface-container-low p-4 sm:p-6">
+  <p class="mb-2 text-sm font-medium text-on-surface-variant">{t(locale, "dashboard.stat.channels")}</p>
+  <span class="font-heading text-3xl font-bold text-on-surface">{channels.length}</span>
 </div>
 
 {fetchError && (

--- a/service/bot-dashboard/src/features/channel/components/GuildDashboardIsland.tsx
+++ b/service/bot-dashboard/src/features/channel/components/GuildDashboardIsland.tsx
@@ -124,7 +124,7 @@ export function GuildDashboardIsland({
       <ClientFlashMessage dismissLabel={translations.flash.dismiss} />
 
       {/* Channel Table */}
-      <div className="overflow-hidden rounded-2xl bg-surface-container-low">
+      <div className="overflow-hidden rounded-2xl bg-surface-container-low mt-10">
         <div className="flex items-center justify-between bg-surface-container-low px-6 py-5 sm:px-8">
           <h3 className="font-heading text-lg font-bold text-on-surface">
             {translations.table.title}

--- a/service/bot-dashboard/src/features/guild/components/GuildCard.astro
+++ b/service/bot-dashboard/src/features/guild/components/GuildCard.astro
@@ -20,7 +20,7 @@ const iconUrl = GuildSummary.iconUrl(guild);
   "flex flex-col rounded-2xl p-6 transition-all duration-200",
   guild.botInstalled
     ? "bg-surface-container hover:bg-surface-container-high"
-    : "bg-surface-container-low opacity-70",
+    : "bg-surface-container-low opacity-80 dark:opacity-70",
 ]}>
   <div class="mb-4 flex items-center gap-3">
     <AvatarFallback src={iconUrl} name={guild.name} size="md" />

--- a/service/bot-dashboard/src/features/shared/components/DesktopSidebarIsland.tsx
+++ b/service/bot-dashboard/src/features/shared/components/DesktopSidebarIsland.tsx
@@ -16,7 +16,9 @@ type DesktopSidebarIslandProps = {
     sidebarLabel: string;
     firstLabel: string;
     notifications: string;
+    contact: string;
   };
+  contactFormUrl?: string;
   channelsHref: string;
   announcementsHref: string;
   isChannelsActive: boolean;
@@ -125,6 +127,26 @@ function BellIcon({ className }: { className: string }) {
   );
 }
 
+/** Question-mark circle icon for contact */
+function ContactIcon({ className }: { className: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
 /** Hamburger icon */
 function MenuIcon() {
   return (
@@ -150,6 +172,7 @@ export function DesktopSidebarIsland({
   translations,
   channelsHref,
   announcementsHref,
+  contactFormUrl,
   isChannelsActive,
   isAnnouncementsActive,
 }: DesktopSidebarIslandProps) {
@@ -247,6 +270,20 @@ export function DesktopSidebarIsland({
           <BellIcon className="h-5 w-5 shrink-0" />
           {expanded && <span>{translations.notifications}</span>}
         </a>
+        {contactFormUrl && (
+          <a
+            href={contactFormUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${navInactive} ${
+              expanded ? "" : "justify-center px-0 gap-0"
+            }`}
+            title={translations.contact}
+          >
+            <ContactIcon className="h-5 w-5 shrink-0" />
+            {expanded && <span>{translations.contact}</span>}
+          </a>
+        )}
       </nav>
     </aside>
   );

--- a/service/bot-dashboard/src/features/shared/components/Header.astro
+++ b/service/bot-dashboard/src/features/shared/components/Header.astro
@@ -26,7 +26,7 @@ const localeLabels = {
 <header class="sticky top-0 z-50 flex h-14 items-center justify-between border-b border-border/50 bg-surface/80 px-4 backdrop-blur-lg sm:px-6">
   <div class="flex items-center gap-4">
     <slot name="left" />
-    <a href={user ? "/dashboard" : "/"} class="font-heading text-lg font-bold tracking-tight text-vspo-purple">
+    <a href={user ? "/dashboard" : "/"} class="font-heading text-base font-bold tracking-tight text-vspo-purple sm:text-lg">
       {t(locale, "app.name")}
     </a>
   </div>

--- a/service/bot-dashboard/src/i18n/locales/en.ts
+++ b/service/bot-dashboard/src/i18n/locales/en.ts
@@ -154,6 +154,7 @@ export const en: Record<keyof typeof ja, string> = {
   "nav.comingSoon": "Coming Soon",
   "nav.breadcrumb": "Breadcrumb",
   "nav.sidebarCollapse": "Toggle sidebar",
+  "nav.contact": "Contact Us",
   "announcements.title": "Announcements",
   "announcements.empty": "No announcements",
   "announcements.type.info": "Info",

--- a/service/bot-dashboard/src/i18n/locales/ja.ts
+++ b/service/bot-dashboard/src/i18n/locales/ja.ts
@@ -145,6 +145,7 @@ export const ja = {
   "nav.comingSoon": "準備中",
   "nav.breadcrumb": "パンくずリスト",
   "nav.sidebarCollapse": "サイドバーを折りたたむ",
+  "nav.contact": "お問い合わせ",
   "announcements.title": "お知らせ",
   "announcements.empty": "お知らせはありません",
   "announcements.type.info": "お知らせ",

--- a/service/bot-dashboard/src/layouts/Dashboard.astro
+++ b/service/bot-dashboard/src/layouts/Dashboard.astro
@@ -4,6 +4,7 @@ import Header from "~/features/shared/components/Header.astro";
 import AvatarFallback from "~/features/shared/components/AvatarFallback.astro";
 import { DesktopSidebarIsland } from "~/features/shared/components/DesktopSidebarIsland";
 import { DiscordUser } from "~/features/auth/domain/discord-user";
+import { CONTACT_FORM_URL } from "astro:env/server";
 import { t } from "~/i18n/dict";
 import { z } from "zod";
 
@@ -50,9 +51,11 @@ const isAnnouncementsActive = currentPath === sidebarAnnouncementsHref;
             sidebarLabel: t(locale, "nav.sidebar"),
             firstLabel: sidebarFirstLabel,
             notifications: t(locale, "nav.notifications"),
+            contact: t(locale, "nav.contact"),
           }}
           channelsHref={sidebarChannelsHref}
           announcementsHref={sidebarAnnouncementsHref}
+          contactFormUrl={CONTACT_FORM_URL}
           isChannelsActive={isChannelsActive}
           isAnnouncementsActive={isAnnouncementsActive}
         />
@@ -96,6 +99,17 @@ const isAnnouncementsActive = currentPath === sidebarAnnouncementsHref;
                     <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" /></svg>
                     <span>{t(locale, "nav.notifications")}</span>
                   </a>
+                  {CONTACT_FORM_URL && (
+                    <a
+                      href={CONTACT_FORM_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-on-surface-variant hover:bg-surface-container-highest hover:text-on-surface"
+                    >
+                      <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                      <span>{t(locale, "nav.contact")}</span>
+                    </a>
+                  )}
                   {activeGuild && (
                     <>
                       <hr class="my-2 border-outline-variant/30" />
@@ -113,7 +127,7 @@ const isAnnouncementsActive = currentPath === sidebarAnnouncementsHref;
             </details>
           </Header>
 
-          <main id="main-content" class="flex-1 bg-surface p-6 sm:p-10">
+          <main id="main-content" class="flex-1 overflow-x-hidden bg-surface p-6 sm:p-10">
             <slot />
           </main>
         </div>

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -61,20 +61,10 @@ const guildName = currentGuild?.name ?? guildId;
     {/* Deferred: stats + channel table (heavy API calls) */}
     <GuildChannelContent server:defer guildId={guildId} locale={locale}>
       <div slot="fallback" class="space-y-10">
-        {/* Skeleton Stats Grid */}
-        <div class="grid grid-cols-2 gap-4 sm:grid-cols-4 sm:gap-6">
-          <div class="rounded-2xl bg-surface-container-low p-4 sm:p-6">
-            <Skeleton variant="text" class="mb-2 w-20" />
-            <Skeleton variant="stat" />
-          </div>
-          <div class="rounded-2xl bg-surface-container-low p-4 sm:p-6">
-            <Skeleton variant="text" class="mb-2 w-16" />
-            <Skeleton variant="text" class="w-24" />
-          </div>
-          <div class="col-span-2 rounded-2xl bg-surface-container-low p-4 sm:p-6">
-            <Skeleton variant="text" class="mb-2 w-20" />
-            <Skeleton variant="text" class="w-32" />
-          </div>
+        {/* Skeleton Stats */}
+        <div class="inline-block rounded-2xl bg-surface-container-low p-4 sm:p-6">
+          <Skeleton variant="text" class="mb-2 w-20" />
+          <Skeleton variant="stat" />
         </div>
 
         {/* Skeleton Table */}

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -251,7 +251,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
 
       {/* CTA Section */}
       <section class="px-6 py-16 sm:py-24">
-        <ScrollReveal animation="fade-in-up" class="mx-auto max-w-3xl rounded-2xl border border-border bg-surface-container-low p-8 text-center sm:p-16">
+        <ScrollReveal animation="fade-in-up" class="mx-auto max-w-3xl rounded-2xl border border-border bg-surface-container-low px-4 py-8 text-center sm:p-16">
           <h2 class="mb-4 font-heading text-3xl font-extrabold text-on-surface sm:text-4xl">{t(locale, "login.cta.headline")}</h2>
           <p class="mx-auto mb-8 max-w-lg text-on-surface-variant">{t(locale, "login.cta.description")}</p>
           <div class="flex flex-col justify-center gap-3 sm:flex-row">


### PR DESCRIPTION
## Summary
- **Mobile layout fixes**: horizontal scroll prevention (`overflow-x-hidden`), smaller header text, CTA button text wrap fix
- **Remove redundant stats**: language/member summary cards removed (data varies per channel, not useful as guild-level summary)
- **UI polish**: toast-to-table spacing, light mode contrast for uninstalled servers, custom member chips overflow, responsive diff preview
- **Contact form link**: configurable via `CONTACT_FORM_URL` env var, shown in sidebar (desktop + mobile) when set, CI/CD updated

## Changed files
| Area | Files | Change |
|------|-------|--------|
| Layout | `Dashboard.astro`, `Header.astro` | overflow-x-hidden, header text size |
| Stats | `GuildChannelContent.astro`, `[guildId].astro` | Remove language/member cards + skeleton sync |
| Table | `GuildDashboardIsland.tsx` | Toast spacing (mt-10) |
| Modal | `ChannelConfigModal.tsx` | Chips max-h + responsive diff |
| Cards | `GuildCard.astro` | Light mode opacity |
| Landing | `index.astro` | CTA mobile padding |
| Sidebar | `DesktopSidebarIsland.tsx`, `Dashboard.astro` | Contact link |
| Config | `astro.config.ts`, `deploy-bot-dashboard.yaml` | CONTACT_FORM_URL env |
| i18n | `ja.ts`, `en.ts` | nav.contact translation |

## CI/CD
- Add `CONTACT_FORM_URL` to GitHub environment secrets to enable the contact link
- Link is hidden when env var is empty or not set