### PR TITLE
fix(bot-dashboard): prevent text wrapping on mobile layout

### DIFF
--- a/service/bot-dashboard/src/features/channel/components/ChannelTable.astro
+++ b/service/bot-dashboard/src/features/channel/components/ChannelTable.astro
@@ -74,7 +74,7 @@ const resolveCustomCreators = (customMembers?: string[]): CreatorType[] => {
                   </div>
                 </div>
               </td>
-              <td class="hidden px-6 py-4 sm:table-cell sm:px-8">
+              <td class="hidden whitespace-nowrap px-6 py-4 sm:table-cell sm:px-8">
                 <span class="rounded bg-surface-container-highest px-2.5 py-1 text-xs font-bold text-on-surface">
                   {langChipLabel(ch.language)}
                 </span>

--- a/service/bot-dashboard/src/features/shared/components/Header.astro
+++ b/service/bot-dashboard/src/features/shared/components/Header.astro
@@ -26,7 +26,7 @@ const localeLabels = {
 <header class="sticky top-0 z-50 flex h-14 items-center justify-between border-b border-border/50 bg-surface/80 px-4 backdrop-blur-lg sm:px-6">
   <div class="flex items-center gap-4">
     <slot name="left" />
-    <a href={user ? "/dashboard" : "/"} class="font-heading text-base font-bold tracking-tight text-vspo-purple sm:text-lg">
+    <a href={user ? "/dashboard" : "/"} class="whitespace-nowrap font-heading text-base font-bold tracking-tight text-vspo-purple sm:text-lg">
       {t(locale, "app.name")}
     </a>
   </div>

--- a/service/bot-dashboard/src/i18n/locales/en.ts
+++ b/service/bot-dashboard/src/i18n/locales/en.ts
@@ -79,7 +79,7 @@ export const en: Record<keyof typeof ja, string> = {
   "dashboard.noServers": "No servers with admin permissions found.",
   "dashboard.allServers": "All Servers",
   "dashboard.channelsCount": "{total} channels configured",
-  "dashboard.stat.channels": "Channels",
+  "dashboard.stat.channels": "Active Channels",
   "dashboard.error": "Error: {message}",
 
   // Guild

--- a/service/bot-dashboard/src/i18n/locales/ja.ts
+++ b/service/bot-dashboard/src/i18n/locales/ja.ts
@@ -70,7 +70,7 @@ export const ja = {
   "dashboard.noServers": "管理者権限を持つサーバーがありません。",
   "dashboard.allServers": "すべてのサーバー",
   "dashboard.channelsCount": "{total} チャンネル設定済み",
-  "dashboard.stat.channels": "チャンネル数",
+  "dashboard.stat.channels": "導入チャンネル数",
   "dashboard.error": "エラー: {message}",
 
   // Guild

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -99,7 +99,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
               rel="noopener"
               variant="outline"
               size="lg"
-              class="w-full sm:w-auto"
+              class="w-full whitespace-nowrap sm:w-auto"
               data-astro-prefetch="false"
             >
               {t(locale, "login.button")}
@@ -275,7 +275,7 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
               rel="noopener"
               variant="outline"
               size="lg"
-              class="w-full sm:w-auto"
+              class="w-full whitespace-nowrap sm:w-auto"
               data-astro-prefetch="false"
             >
               {t(locale, "login.button")}


### PR DESCRIPTION
## Summary
- 言語バッジ列（「デフォルト」等）が狭い画面幅で縦に崩れる問題を `whitespace-nowrap` で修正
- ヘッダーの「すぽじゅーる Bot」がモバイルで2行になる問題を修正
- ランディングページの「Discordで管理画面へログイン」ボタンが2行になる問題を修正
- スタッツラベルを「チャンネル数」→「導入チャンネル数」に変更

## Test plan
- [ ] モバイル(375px): ヘッダー、言語バッジ、CTAボタンが1行表示
- [ ] タブレット(768px): テーブルの言語列が正常表示
- [ ] デスクトップ(1440px): 全列が正常表示