### PR TITLE
fix(bot-dashboard): clear channel messages on setting change and fix session storage

### DIFF
--- a/service/bot-dashboard/src/env.d.ts
+++ b/service/bot-dashboard/src/env.d.ts
@@ -26,14 +26,6 @@ declare namespace App {
     pkce_verifier: string;
     locale: import("~/i18n/dict").Locale;
     lastActivity: number;
-    /** Cached guild summaries to avoid re-fetching on guild detail pages */
-    guildSummaries: Array<{
-      id: string;
-      name: string;
-      icon: string | null;
-      isAdmin: boolean;
-      botInstalled: boolean;
-    }>;
   }
   interface Locals {
     user: SessionData["user"] | null;

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -73,9 +73,10 @@ const toServerMemberType = (
  */
 /**
  * Adjust a channel's bot configuration and enqueue the result for D1 persistence.
- * Mirrors the two-step pattern used by Discord slash command handlers.
+ * Mirrors the three-step pattern used by Discord slash command handlers.
  * @precondition appWorker is a valid service binding with DiscordService RPC
- * @postcondition On Ok, channel config is updated in KV cache and enqueued for D1 persistence
+ * @postcondition On Ok, channel config is updated in KV cache, enqueued for D1 persistence,
+ *   and existing bot messages in the channel are enqueued for deletion
  */
 const adjustAndEnqueue = async (
   appWorker: ApplicationService,
@@ -85,6 +86,7 @@ const adjustAndEnqueue = async (
   const result = await discord.adjustBotChannel(params);
   if (result.err) return result;
   await discord.batchUpsertEnqueue([result.val]);
+  await discord.deleteMessageInChannelEnqueue(params.targetChannelId);
   return Ok(undefined);
 };
 

--- a/service/bot-dashboard/src/pages/dashboard/[guildId].astro
+++ b/service/bot-dashboard/src/pages/dashboard/[guildId].astro
@@ -19,19 +19,9 @@ if (!accessToken || !user) {
   return Astro.redirect("/");
 }
 
-// Use cached guild summaries from session (set by /dashboard) to avoid the heavy
-// ListGuildsUsecase call on every guild detail navigation.
-// Falls back to the full fetch only on direct navigation (e.g. bookmark).
-const cachedGuilds = await Astro.session?.get("guildSummaries");
-const cachedGuild = cachedGuilds?.find((g) => g.id === guildId);
-
-const currentGuild = cachedGuild
-  ? { id: cachedGuild.id, name: cachedGuild.name, icon: cachedGuild.icon, isAdmin: cachedGuild.isAdmin, botInstalled: cachedGuild.botInstalled }
-  : await (async () => {
-      const guildsResult = await ListGuildsUsecase.execute({ accessToken, userId: user.id, appWorker: env.APP_WORKER, includeChannelSummary: false });
-      const all = guildsResult.err ? [] : [...guildsResult.val.installed, ...guildsResult.val.notInstalled];
-      return all.find((g) => g.id === guildId) ?? null;
-    })();
+const guildsResult = await ListGuildsUsecase.execute({ accessToken, userId: user.id, appWorker: env.APP_WORKER, includeChannelSummary: false });
+const allGuilds = guildsResult.err ? [] : [...guildsResult.val.installed, ...guildsResult.val.notInstalled];
+const currentGuild = allGuilds.find((g) => g.id === guildId) ?? null;
 const guildName = currentGuild?.name ?? guildId;
 ---
 

--- a/service/bot-dashboard/src/pages/dashboard/index.astro
+++ b/service/bot-dashboard/src/pages/dashboard/index.astro
@@ -25,14 +25,6 @@ const installed = result.err ? [] : result.val.installed;
 const notInstalled = result.err ? [] : result.val.notInstalled;
 const botClientId = DISCORD_BOT_CLIENT_ID;
 
-// Cache guild summaries in session for fast access on guild detail pages
-if (!result.err) {
-  const allGuilds = [...result.val.installed, ...result.val.notInstalled];
-  Astro.session?.set(
-    "guildSummaries",
-    allGuilds.map((g) => ({ id: g.id, name: g.name, icon: g.icon, isAdmin: g.isAdmin, botInstalled: g.botInstalled })),
-  );
-}
 ---
 
 <Dashboard title={t(locale, "dashboard.servers")} description={t(locale, "meta.dashboard.description")} showSidebar>

--- a/service/bot-dashboard/src/pages/dashboard/index.astro
+++ b/service/bot-dashboard/src/pages/dashboard/index.astro
@@ -20,6 +20,17 @@ const result = await ListGuildsUsecase.execute({
   appWorker: env.APP_WORKER,
 });
 
+// Token expired/revoked on Discord side but middleware didn't detect it — force re-login
+if (result.err?.code === "UNAUTHORIZED") {
+  console.error("[dashboard] getUserGuilds UNAUTHORIZED — forcing re-login");
+  Astro.session?.destroy();
+  return Astro.redirect("/?error=auth_failed");
+}
+
+if (result.err) {
+  console.error("[dashboard] ListGuildsUsecase failed:", result.err.code, result.err.message);
+}
+
 const fetchError = result.err ?? null;
 const installed = result.err ? [] : result.val.installed;
 const notInstalled = result.err ? [] : result.val.notInstalled;

--- a/service/bot-dashboard/wrangler.prd.jsonc
+++ b/service/bot-dashboard/wrangler.prd.jsonc
@@ -9,6 +9,9 @@
   },
   "workers_dev": false,
   "routes": [{ "pattern": "discord.vspo-schedule.com", "custom_domain": true }],
+  "kv_namespaces": [
+    { "binding": "SESSION", "id": "4c4d9b07156542cea12392b94123e5e2" }
+  ],
   "services": [
     {
       "binding": "APP_WORKER",


### PR DESCRIPTION
## Summary

- **メンバー変更未反映の修正**: ダッシュボードからチャンネル設定を変更した際、server側のDiscordコマンドと同様に `deleteMessageInChannelEnqueue` を呼び出して既存メッセージを削除するように修正。次のsend workflowサイクルで新しい設定に基づいた配信のみが投稿される。
- **セッション早期切れの修正**: production環境の `wrangler.prd.jsonc` に `SESSION` KV namespace バインディングを追加し、cookie-based storageからKV-based storageへ移行。セッションデータの永続性を改善。
- **セッションサイズ削減**: `guildSummaries` のセッション書き込みを除去し、guild詳細ページでは毎回APIから取得するように変更。

## Test plan

- [ ] 管理画面でcustomメンバーを変更し、既存配信メッセージがDiscordから削除されることを確認
- [ ] 次のsend workflowサイクルで変更後のメンバーのみの配信が投稿されることを確認
- [ ] ログイン後、2時間以上放置してもセッションが維持されることを確認
- [ ] guild詳細ページに直接アクセスしてもギルド情報が正しく表示されることを確認