### PR TITLE
fix(bot-dashboard): remove deleteMessageInChannelEnqueue and defer BotStats

### DIFF
--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -73,10 +73,9 @@ const toServerMemberType = (
  */
 /**
  * Adjust a channel's bot configuration and enqueue the result for D1 persistence.
- * Mirrors the three-step pattern used by Discord slash command handlers.
+ * Mirrors the two-step pattern used by Discord slash command handlers.
  * @precondition appWorker is a valid service binding with DiscordService RPC
- * @postcondition On Ok, channel config is updated in KV cache, enqueued for D1 persistence,
- *   and existing bot messages in the channel are enqueued for deletion
+ * @postcondition On Ok, channel config is updated in KV cache and enqueued for D1 persistence
  */
 const adjustAndEnqueue = async (
   appWorker: ApplicationService,
@@ -86,7 +85,6 @@ const adjustAndEnqueue = async (
   const result = await discord.adjustBotChannel(params);
   if (result.err) return result;
   await discord.batchUpsertEnqueue([result.val]);
-  await discord.deleteMessageInChannelEnqueue(params.targetChannelId);
   return Ok(undefined);
 };
 

--- a/service/bot-dashboard/src/pages/index.astro
+++ b/service/bot-dashboard/src/pages/index.astro
@@ -122,8 +122,19 @@ const errorKey = errorParam === "auth_failed" || errorParam === "no_code" || err
               </Button>
             </div>
 
-            {/* Stats — inline-rendered with 30min cache; fixed frame prevents layout shift */}
-            <BotStats locale={locale} />
+            {/* Stats — server:defer so the rest of the page renders immediately */}
+            <BotStats server:defer locale={locale}>
+              <div slot="fallback" class="hero-stats inline-grid grid-cols-2 gap-3 sm:gap-4">
+                <div class="stat-card flex h-20 min-w-[9rem] flex-col items-center justify-center rounded-2xl px-3 py-3 text-center sm:h-24 sm:min-w-[10.5rem] sm:px-4">
+                  <div class="h-8 w-16 animate-pulse rounded bg-on-surface/10 sm:h-9"></div>
+                  <div class="mt-1.5 text-xs font-medium text-on-surface-variant">{t(locale, "login.stat.servers")}</div>
+                </div>
+                <div class="stat-card flex h-20 min-w-[9rem] flex-col items-center justify-center rounded-2xl px-3 py-3 text-center sm:h-24 sm:min-w-[10.5rem] sm:px-4">
+                  <div class="h-8 w-20 animate-pulse rounded bg-on-surface/10 sm:h-9"></div>
+                  <div class="mt-1.5 text-xs font-medium text-on-surface-variant">{t(locale, "login.stat.users")}</div>
+                </div>
+              </div>
+            </BotStats>
           </div>
 
           {/* Right: Discord preview images */}


### PR DESCRIPTION
## Summary
- `adjustAndEnqueue` から `deleteMessageInChannelEnqueue` を削除。設定変更のたびにチャンネルのメッセージ削除→cron再送信が全サーバーに波及するバグを修正
- BotStats コンポーネントに `server:defer` を追加し、API呼び出しがランディングページ全体の描画をブロックしないように改善

## Related Issues
なし（運用中に発見されたバグ）