### PR TITLE
fix(bot-dashboard): prevent cross-channel initial message on channel update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ dist
 
 docs/superpowers/
 .claude/settings.local.json
+.claude/logs/
 
 # Cloudflare generated types
 **/worker-configuration.d.ts

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -84,7 +84,21 @@ const adjustAndEnqueue = async (
   const discord = appWorker.newDiscordUsecase();
   const result = await discord.adjustBotChannel(params);
   if (result.err) return result;
-  await discord.batchUpsertEnqueue([result.val]);
+
+  // Prevent cross-channel initial-message contamination:
+  // adjustBotChannel returns the FULL server with ALL channels.
+  // Only the target channel should retain isInitialAdd; clear it on others
+  // so the queue consumer does not send initial messages to unrelated channels.
+  const sanitized = {
+    ...result.val,
+    discordChannels: result.val.discordChannels.map((ch) => ({
+      ...ch,
+      isInitialAdd:
+        ch.rawId === params.targetChannelId ? ch.isInitialAdd : false,
+    })),
+  };
+
+  await discord.batchUpsertEnqueue([sanitized]);
   return Ok(undefined);
 };
 

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -87,15 +87,17 @@ const adjustAndEnqueue = async (
 
   // Prevent cross-channel initial-message contamination:
   // adjustBotChannel returns the FULL server with ALL channels.
-  // Only the target channel should retain isInitialAdd; clear it on others
+  // Only the target channel should retain isInitialAdd; strip it from others
   // so the queue consumer does not send initial messages to unrelated channels.
+  // We use undefined (field removal) rather than false so that any legitimately
+  // pending initial-add state on other channels is not overwritten in the store.
   const sanitized = {
     ...result.val,
-    discordChannels: result.val.discordChannels.map((ch) => ({
-      ...ch,
-      isInitialAdd:
-        ch.rawId === params.targetChannelId ? ch.isInitialAdd : false,
-    })),
+    discordChannels: result.val.discordChannels.map((ch) => {
+      if (ch.rawId === params.targetChannelId) return ch;
+      const { isInitialAdd: _, ...rest } = ch;
+      return rest;
+    }),
   };
 
   await discord.batchUpsertEnqueue([sanitized]);


### PR DESCRIPTION
## Summary
- チャンネル設定変更時に、同一サーバーの他チャンネルに初回メッセージが誤送信されるバグを修正
- `adjustBotChannel` がサーバー全体(全チャンネル含む)を返すため、`batchUpsertEnqueue` にそのまま渡すと `isInitialAdd: true` の他チャンネルにも初回メッセージが飛んでいた
- enqueue前にターゲットチャンネル以外の `isInitialAdd` を `false` にクリアすることで、対象チャンネルのみに初回メッセージ送信を限定

## Test plan
- [ ] チャンネルAの設定(言語・メンバータイプ)を変更し、チャンネルBに初回メッセージが送信されないことを確認
- [ ] 新規チャンネル追加時に、そのチャンネルのみに初回メッセージが送信されることを確認
- [ ] チャンネル削除時に、他チャンネルに影響がないことを確認
- [ ] 連続で設定変更した場合に、重複メッセージが送信されないことを確認