### PR TITLE
fix(bot-dashboard): guild admin authz and landing page improvements

### DIFF
--- a/service/bot-dashboard/src/features/landing/components/BotStats.astro
+++ b/service/bot-dashboard/src/features/landing/components/BotStats.astro
@@ -13,36 +13,33 @@ type Props = z.infer<typeof propsSchema>;
 const { locale } = Astro.props;
 // getBotStats is cached server-side (30min TTL in vspo-server's DiscordService),
 // so calling it inline is cheap after the first request per region.
-const statsResult = await VspoGuildApiRepository.getBotStats(env.APP_WORKER);
-const stats = statsResult.err ? null : statsResult.val;
+// On error, the entire stats section is hidden — no error UI on the landing page.
+let stats: { guildCount: number; totalMemberCount: number } | null = null;
+try {
+  const statsResult = await VspoGuildApiRepository.getBotStats(env.APP_WORKER);
+  stats = statsResult.err ? null : statsResult.val;
+} catch {
+  stats = null;
+}
 ---
 
-{/* Fixed-height wrapper so skeleton/placeholder/success states share the same box */}
-<div class="hero-stats inline-grid grid-cols-2 gap-3 sm:gap-4">
-  <div class="stat-card flex h-20 min-w-[9rem] flex-col items-center justify-center rounded-2xl px-3 py-3 text-center sm:h-24 sm:min-w-[10.5rem] sm:px-4">
-    <div class="text-2xl font-extrabold leading-none text-on-surface sm:text-3xl">
-      {stats ? (
+{stats && (
+  <div class="hero-stats inline-grid grid-cols-2 gap-3 sm:gap-4">
+    <div class="stat-card flex h-20 min-w-[9rem] flex-col items-center justify-center rounded-2xl px-3 py-3 text-center sm:h-24 sm:min-w-[10.5rem] sm:px-4">
+      <div class="text-2xl font-extrabold leading-none text-on-surface sm:text-3xl">
         <DigitRoll value={stats.guildCount} />
-      ) : (
-        <span class="text-on-surface-variant/60" aria-hidden="true">—</span>
-      )}
-      {!stats && <span class="sr-only">{t(locale, "login.stat.servers")}</span>}
+      </div>
+      <div class="mt-1.5 text-xs font-medium text-on-surface-variant">
+        {t(locale, "login.stat.servers")}
+      </div>
     </div>
-    <div class="mt-1.5 text-xs font-medium text-on-surface-variant">
-      {t(locale, "login.stat.servers")}
-    </div>
-  </div>
-  <div class="stat-card flex h-20 min-w-[9rem] flex-col items-center justify-center rounded-2xl px-3 py-3 text-center sm:h-24 sm:min-w-[10.5rem] sm:px-4">
-    <div class="text-2xl font-extrabold leading-none text-on-surface sm:text-3xl">
-      {stats ? (
+    <div class="stat-card flex h-20 min-w-[9rem] flex-col items-center justify-center rounded-2xl px-3 py-3 text-center sm:h-24 sm:min-w-[10.5rem] sm:px-4">
+      <div class="text-2xl font-extrabold leading-none text-on-surface sm:text-3xl">
         <DigitRoll value={stats.totalMemberCount} />
-      ) : (
-        <span class="text-on-surface-variant/60" aria-hidden="true">—</span>
-      )}
-      {!stats && <span class="sr-only">{t(locale, "login.stat.users")}</span>}
-    </div>
-    <div class="mt-1.5 text-xs font-medium text-on-surface-variant">
-      {t(locale, "login.stat.users")}
+      </div>
+      <div class="mt-1.5 text-xs font-medium text-on-surface-variant">
+        {t(locale, "login.stat.users")}
+      </div>
     </div>
   </div>
-</div>
+)}


### PR DESCRIPTION
## Summary

- Guild admin authorization を middleware に集約し、mutation エンドポイントへの未認可アクセスを防止
- Landing page の stats セクションで取得失敗時にエラー表示せず非表示にするよう変更
- Landing page の feature 画像を実際のスクリーンショットに更新
- next-intl セキュリティアップデート (v4.9.1)