### PR TITLE
fix(bot-dashboard): guild admin authz, CSP, and landing page improvements

### DIFF
--- a/service/bot-dashboard/src/middleware.ts
+++ b/service/bot-dashboard/src/middleware.ts
@@ -43,11 +43,11 @@ const STATIC_HEADERS: ReadonlyArray<readonly [string, string]> = [
  */
 const CSP_HEADER = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline'",
+  "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",
   "style-src 'self' 'unsafe-inline'",
   "font-src 'self'",
   "img-src 'self' https://cdn.discordapp.com https://yt3.ggpht.com https://lh3.googleusercontent.com data:",
-  "connect-src 'self' https://discord.com",
+  "connect-src 'self' https://discord.com https://cloudflareinsights.com",
   "frame-ancestors 'none'",
 ].join("; ");
 


### PR DESCRIPTION
## Summary
- Add real-time RPC guild admin authorization to all mutation endpoints (addChannel, updateChannel, deleteChannel) with session-cached middleware pre-check
- Fix cross-channel initial message contamination by stripping `isInitialAdd` from non-target channels before enqueue
- Allow Cloudflare Web Analytics beacon in CSP (`script-src` and `connect-src`)
- Hide stats section on landing page when API fetch fails instead of showing error UI
- Tighten input validation: enum for `language`, min/max length for `customMemberIds`
- Update landing page feature images with actual screenshots
- Bump next to 16.2.3, next-intl to 4.9.1 (security)