### PR TITLE
fix(api): remove debug logs from API client retry logic

### DIFF
--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -162,9 +162,6 @@ export class VSPOApi {
 
         if (i < this.retry.attempts) {
           const backoff = this.retry.backoff(i);
-          console.debug(
-            `Attempt ${i + 1} of ${this.retry.attempts + 1} failed, retrying in ${backoff}ms: ${err.message}`,
-          );
           await new Promise((r) => setTimeout(r, backoff));
         }
         continue;
@@ -204,9 +201,6 @@ export class VSPOApi {
 
       if (i < this.retry.attempts) {
         const backoff = this.retry.backoff(i);
-        console.debug(
-          `Attempt ${i + 1} of ${this.retry.attempts + 1} failed, retrying in ${backoff}ms: ${errorMessage}`,
-        );
         await new Promise((r) => setTimeout(r, backoff));
       }
     }


### PR DESCRIPTION
## Summary
- Remove `console.debug` statements from API client retry logic in `packages/api/src/client.ts`
- Prevents retry attempt details from leaking to production logs
- Error information is still propagated via `Result<T, AppError>` type