### PR TITLE
fix(bot-dashboard): align custom memberType mapping with vspo-server

### DIFF
--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -8,9 +8,7 @@ import type { MemberTypeValue } from "../domain/member-type";
 
 type AdjustBotChannelRpcParams = Parameters<
   ReturnType<ApplicationService["newDiscordUsecase"]>["adjustBotChannel"]
->[0] & {
-  selectedMemberIds?: string[];
-};
+>[0];
 
 /**
  * Maps the vspo-server memberType to the bot-dashboard's MemberType domain value.
@@ -24,6 +22,7 @@ const toFrontendMemberType = (
     | "vspo_ch"
     | "vspo_all"
     | "general"
+    | "custom"
     | undefined,
   selectedMemberIds?: string[],
 ): MemberTypeValue => {
@@ -32,6 +31,8 @@ const toFrontendMemberType = (
       return "vspo_jp";
     case "vspo_en":
       return "vspo_en";
+    case "custom":
+      return "custom";
     case "vspo_all":
       return selectedMemberIds && selectedMemberIds.length > 0
         ? "custom"
@@ -51,14 +52,14 @@ const toFrontendMemberType = (
  */
 const toServerMemberType = (
   frontendMemberType: MemberTypeValue,
-): "vspo_jp" | "vspo_en" | "vspo_all" | "general" => {
+): "vspo_jp" | "vspo_en" | "vspo_all" | "general" | "custom" => {
   switch (frontendMemberType) {
     case "vspo_jp":
       return "vspo_jp";
     case "vspo_en":
       return "vspo_en";
     case "custom":
-      return "vspo_all";
+      return "custom";
     case "all":
       return "vspo_all";
     default:

--- a/service/vspo-schedule/v2/web/src/features/shared/types/api.d.ts
+++ b/service/vspo-schedule/v2/web/src/features/shared/types/api.d.ts
@@ -1774,7 +1774,8 @@ type AdjustBotChannelParams = {
   targetChannelId: string;
   serverLangaugeCode?: string;
   channelLangaugeCode?: string;
-  memberType?: "vspo_jp" | "vspo_en" | "vspo_ch" | "vspo_all" | "general";
+  memberType?: "vspo_jp" | "vspo_en" | "vspo_ch" | "vspo_all" | "general" | "custom";
+  selectedMemberIds?: string[];
 };
 type ListDiscordServerParam = {
   limit: number;


### PR DESCRIPTION
## Summary
- Fix bidirectional memberType mismatch between Discord bot `/setting` command and bot-dashboard
- The `/setting` command saves `memberType: "custom"` but the dashboard mapped it to/from `"vspo_all"`, causing member selections to appear blank in both directions
- Add `"custom"` to `toFrontendMemberType` and `toServerMemberType` mapping functions
- Update shared `api.d.ts` `AdjustBotChannelParams` type to include `"custom"` memberType and `selectedMemberIds`

## Test plan
- [ ] Set custom members via Discord `/setting` command → verify they appear on dashboard
- [ ] Set custom members via dashboard → verify they appear in Discord bot `/setting` display
- [ ] Verify non-custom memberTypes (vspo_jp, vspo_en, all) still work correctly in both directions
- [ ] Verify dashboard TypeScript compilation passes