### PR TITLE
fix(bot-dashboard): patch memberType and selectedMemberIds before enqueue

### DIFF
--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -94,7 +94,20 @@ const adjustAndEnqueue = async (
   const sanitized = {
     ...result.val,
     discordChannels: result.val.discordChannels.map((ch) => {
-      if (ch.rawId === params.targetChannelId) return ch;
+      if (ch.rawId === params.targetChannelId) {
+        // adjustBotChannel RPC does not accept selectedMemberIds in its params,
+        // and may not apply memberType reliably. Patch the target channel with
+        // the intended values so that batchUpsertEnqueue persists the correct state.
+        return {
+          ...ch,
+          ...(params.memberType !== undefined && {
+            memberType: params.memberType,
+          }),
+          ...(params.selectedMemberIds !== undefined && {
+            selectedMemberIds: params.selectedMemberIds,
+          }),
+        };
+      }
       const { isInitialAdd: _, ...rest } = ch;
       return rest;
     }),


### PR DESCRIPTION
## Summary
- `adjustBotChannel` RPC does not accept `selectedMemberIds` in its params (`AdjustBotChannelParams` type), and may not apply `memberType` reliably to KV
- When switching member type (e.g. custom → all, custom → vspo_jp), stale `selectedMemberIds` and `memberType` from the RPC response were re-persisted to D1 via `batchUpsertEnqueue`
- Fix: patch the target channel with the intended `memberType` and `selectedMemberIds` from request params before enqueuing, ensuring correct state is persisted

## Root Cause
The `AdjustBotChannelParams` server RPC type only accepts `type`, `serverId`, `targetChannelId`, `serverLangaugeCode`, `channelLangaugeCode`, and `memberType`. The dashboard extended this with `selectedMemberIds` via TypeScript intersection, but the server ignores the extra field. The `adjustAndEnqueue` function passed the server's response (with stale values) directly to `batchUpsertEnqueue`.

## Test plan
- [ ] Switch a channel from "カスタム" to "全メンバー" → verify `selected_member_ids` is cleared
- [ ] Switch from "カスタム" to "VSPO JP" → verify `member_type` changes to `vspo_jp` and `selected_member_ids` is cleared
- [ ] Click "デフォルトに戻す" → verify both fields reset correctly
- [ ] Switch from "全メンバー" to "カスタム" with selected members → verify `selected_member_ids` is populated